### PR TITLE
Faster Travis build 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,4 @@
 language: java
-sudo: false
-os: linux
 jdk: openjdk8
 script: ./gradlew build
 before_cache:


### PR DESCRIPTION
- Use cache
- Specify the build command
- Use Open JDK8