### PR TITLE
Introduced FeatureBuilder.fromDataFrame function allowing materializing features from a DataFrame

### DIFF
--- a/features/src/main/scala/com/salesforce/op/features/FeatureBuilder.scala
+++ b/features/src/main/scala/com/salesforce/op/features/FeatureBuilder.scala
@@ -31,16 +31,16 @@
 
 package com.salesforce.op.features
 
-import com.salesforce.op.utils.spark.RichRow._
 import com.salesforce.op.aggregators._
 import com.salesforce.op.features.types._
 import com.salesforce.op.stages.{FeatureGeneratorStage, OpPipelineStage}
+import com.salesforce.op.utils.spark.RichRow._
 import com.twitter.algebird.MonoidAggregator
-import org.apache.spark.sql.Row
+import org.apache.spark.sql.{DataFrame, Row}
 import org.joda.time.Duration
 
 import scala.language.experimental.macros
-import scala.reflect.runtime.universe.WeakTypeTag
+import scala.reflect.runtime.universe._
 
 /**
  * Factory for creating features
@@ -178,10 +178,48 @@ object FeatureBuilder {
 
   def apply[I: WeakTypeTag, O <: FeatureType : WeakTypeTag](name: String): FeatureBuilder[I, O] = new FeatureBuilder[I, O](name)
 
-  def fromRow[O <: FeatureType: WeakTypeTag](implicit name: sourcecode.Name): FeatureBuilderWithExtract[Row, O] = fromRow[O](name.value, None)
-  def fromRow[O <: FeatureType: WeakTypeTag](name: String): FeatureBuilderWithExtract[Row, O] = fromRow[O](name, None)
-  def fromRow[O <: FeatureType: WeakTypeTag](index: Int)(implicit name: sourcecode.Name): FeatureBuilderWithExtract[Row, O] = fromRow[O](name.value, Some(index))
-  def fromRow[O <: FeatureType: WeakTypeTag](name: String, index: Option[Int]): FeatureBuilderWithExtract[Row, O] = {
+  /**
+   * Builds features from a [[DataFrame]]
+   *
+   * @param data        input [[DataFrame]]
+   * @param response    response feature name
+   * @param nonNullable optional non nullable feature names
+   * @throws IllegalArgumentException if fails to map dataframe field type into a feature type
+   * @throws RuntimeException if fails to construct a response feature
+   * @return label and other features
+   */
+  def fromDataFrame[ResponseType <: FeatureType : WeakTypeTag](
+    data: DataFrame,
+    response: String,
+    nonNullable: Set[String] = Set.empty
+  ): (Feature[ResponseType], Array[Feature[_ <: FeatureType]]) = {
+    val allFeatures: Array[Feature[_ <: FeatureType]] =
+      data.schema.fields.zipWithIndex.map { case (field, index) =>
+        val isResponse = field.name == response
+        val isNullable = !isResponse && !nonNullable.contains(field.name)
+        val wtt: WeakTypeTag[_ <: FeatureType] = FeatureSparkTypes.featureTypeTagOf(field.dataType, isNullable)
+        val feature = fromRow(name = field.name, index = Some(index))(wtt)
+        if (isResponse) feature.asResponse else feature.asPredictor
+      }
+    val (responses, features) = allFeatures.partition(_.name == response)
+    val responseFeature = responses.toList match {
+      case feature :: Nil if feature.isSubtypeOf[ResponseType] =>
+        feature.asInstanceOf[Feature[ResponseType]]
+      case feature :: Nil =>
+        throw new RuntimeException(
+          s"Response feature '$response' is of type ${feature.typeName}, but expected ${FeatureType.typeName[ResponseType]}")
+      case Nil =>
+        throw new RuntimeException(s"Response feature '$response' was not found in dataframe schema")
+      case _ =>
+        throw new RuntimeException(s"Multiple features with name '$response' were found (should not happen): "
+          + responses.map(_.name).mkString(","))
+    }
+    responseFeature -> features
+  }
+  def fromRow[O <: FeatureType : WeakTypeTag](implicit name: sourcecode.Name): FeatureBuilderWithExtract[Row, O] = fromRow[O](name.value, None)
+  def fromRow[O <: FeatureType : WeakTypeTag](name: String): FeatureBuilderWithExtract[Row, O] = fromRow[O](name, None)
+  def fromRow[O <: FeatureType : WeakTypeTag](index: Int)(implicit name: sourcecode.Name): FeatureBuilderWithExtract[Row, O] = fromRow[O](name.value, Some(index))
+  def fromRow[O <: FeatureType : WeakTypeTag](name: String, index: Option[Int]): FeatureBuilderWithExtract[Row, O] = {
     val c = FeatureTypeSparkConverter[O]()
     new FeatureBuilderWithExtract[Row, O](
       name = name,
@@ -189,9 +227,7 @@ object FeatureBuilder {
       extractSource = "(r: Row) => c.fromSpark(index.map(r.get).getOrElse(r.getAny(name)))"
     )
   }
-
   // scalastyle:on
-
 }
 
 /**

--- a/features/src/test/scala/com/salesforce/op/features/TestFeatureBuilderTest.scala
+++ b/features/src/test/scala/com/salesforce/op/features/TestFeatureBuilderTest.scala
@@ -47,24 +47,7 @@ case class FeatureBuilderContainerTest(s: String, l: Long, d: Double)
 @RunWith(classOf[JUnitRunner])
 class TestFeatureBuilderTest extends FlatSpec with TestSparkContext {
 
-  Spec(TestFeatureBuilder.getClass) should "infer features from a dataset" in {
-    import spark.implicits._
-    val ds = Seq(
-      FeatureBuilderContainerTest("blah1", 10, 2.0),
-      FeatureBuilderContainerTest("blah2", 11, 3.0)
-    ).toDS.toDF()
-
-    val features@Array(f1, f2, f3) = TestFeatureBuilder(ds, Set.empty[String])
-
-    f1.name shouldBe "s"
-    f1.typeName shouldBe FeatureType.typeName[Text]
-    f2.name shouldBe "l"
-    f2.typeName shouldBe FeatureType.typeName[Integral]
-    f3.name shouldBe "d"
-    f3.typeName shouldBe FeatureType.typeName[Real]
-  }
-
-  it should "create a dataset with one feature" in {
+  Spec(TestFeatureBuilder.getClass)  should "create a dataset with one feature" in {
     val res@(ds, f1) = TestFeatureBuilder[Real](Seq(Real(1), Real(2L), Real(3.1f), Real(4.5)))
 
     assertFeature(f1)(name = "f1", in = ds.head(), out = Real(1.0))


### PR DESCRIPTION
I moved this functionality from TestFeatureBuilder to a top level FeatureBuilder as it can be quite powerful for very simple applications, in which there is a dataset/dataframe available and once would like to automatically create features from it.

Example usage:
```scala
case class MyClass(s: String, l: Long, label: Double)
val data: DataFrame = Seq(MyClass("blah1", 10, label = 2.0)).toDS.toDF()
val (label, Array(fs, fl)) = FeatureBuilder.fromDataFrame[RealNN](data, response = "label")
```