### PR TITLE
Set seed for binary data randomizer to make mimetype detector test non flaky

### DIFF
--- a/core/src/test/scala/com/salesforce/op/stages/impl/feature/MimeTypeDetectorTest.scala
+++ b/core/src/test/scala/com/salesforce/op/stages/impl/feature/MimeTypeDetectorTest.scala
@@ -80,9 +80,13 @@ class MimeTypeDetectorTest extends OpTransformerSpec[Text, MimeTypeDetector] wit
 trait Base64TestData {
   self: TestSparkContext =>
 
-  lazy val (randomData, randomBase64) = TestFeatureBuilder(
-    Base64.empty +: Base64("") +: RandomText.base64(0, 10000).take(10).toSeq
-  )
+  val seed = 42L
+
+  lazy val (randomData, randomBase64) = {
+    val rnd = RandomText.base64(0, 10000)
+    rnd.reset(seed)
+    TestFeatureBuilder(Base64.empty +: Base64("") +: rnd.take(10).toSeq)
+  }
   lazy val (realData, realBase64) = TestFeatureBuilder(
     Seq(
       "811harmo24to36.mp3", "820orig36to48.wav", "face.png",


### PR DESCRIPTION
**Related issues**
Mimetype detector tests are flaky.

**Describe the proposed solution**
Set random seed.

**Describe alternatives you've considered**
Retry test on failure.
