### PR TITLE
Fix typos and misspellings detected by github.com/client9/misspell

### DIFF
--- a/core/src/main/scala/com/salesforce/op/dsl/RichMapFeature.scala
+++ b/core/src/main/scala/com/salesforce/op/dsl/RichMapFeature.scala
@@ -244,7 +244,7 @@ trait RichMapFeature {
      * @param cleanText                 indicates whether to ignore capitalization and punctuation
      * @param trackNulls                indicates whether or not to track null values in a separate column.
      * @param topK                      number of most common elements to be used as categorical pivots
-     * @param minSupport                minimum number of occurences an element must have to appear in pivot
+     * @param minSupport                minimum number of occurrences an element must have to appear in pivot
      * @param unseenName                name to give indexes which do not have a label name associated with them
      * @param hashWithIndex             include indices when hashing a feature that has them (OPLists or OPVectors)
      * @param binaryFreq                if true, term frequency vector will be binary such that non-zero term
@@ -373,7 +373,7 @@ trait RichMapFeature {
      * @param cleanText                 indicates whether to ignore capitalization and punctuation
      * @param trackNulls                indicates whether or not to track null values in a separate column.
      * @param topK                      number of most common elements to be used as categorical pivots
-     * @param minSupport                minimum number of occurences an element must have to appear in pivot
+     * @param minSupport                minimum number of occurrences an element must have to appear in pivot
      * @param unseenName                name to give indexes which do not have a label name associated with them
      * @param hashWithIndex             include indices when hashing a feature that has them (OPLists or OPVectors)
      * @param binaryFreq                if true, term frequency vector will be binary such that non-zero term

--- a/core/src/main/scala/com/salesforce/op/dsl/RichNumericFeature.scala
+++ b/core/src/main/scala/com/salesforce/op/dsl/RichNumericFeature.scala
@@ -445,7 +445,7 @@ trait RichNumericFeature {
      *                                the entire correlation matrix which includes all feature-feature correlations
      * @param correlationExclusion    Setting for what categories of feature vector columns to exclude from the
      *                                correlation calculation (eg. hashed text features)
-     * @param categoricalLabel  If true, treat label as categorical. If not set, check number of disticnt labels to
+     * @param categoricalLabel  If true, treat label as categorical. If not set, check number of distinct labels to
      *                          decide whether a label should be treated categorical.
      * @return sanity checked feature vector
      */

--- a/core/src/main/scala/com/salesforce/op/dsl/RichSetFeature.scala
+++ b/core/src/main/scala/com/salesforce/op/dsl/RichSetFeature.scala
@@ -55,7 +55,7 @@ trait RichSetFeature {
      *
      * @param others     other features to include in the pivot
      * @param topK       keep topK values
-     * @param minSupport min occurances to keep a value
+     * @param minSupport min occurrences to keep a value
      * @param cleanText  if true ignores capitalization and punctuations when grouping categories
      * @param trackNulls keep a count of nulls
      * @return
@@ -84,7 +84,7 @@ trait RichSetFeature {
      *
      * @param others    other features to include in the pivot
      * @param topK      keep topK values
-     * @param minSupport min occurances to keep a value
+     * @param minSupport min occurrences to keep a value
      * @param cleanText  if true ignores capitalization and punctuations when grouping categories
      * @param trackNulls keep a count of nulls
      * @return

--- a/core/src/main/scala/com/salesforce/op/dsl/RichTextFeature.scala
+++ b/core/src/main/scala/com/salesforce/op/dsl/RichTextFeature.scala
@@ -181,7 +181,7 @@ trait RichTextFeature {
      * @param cleanText                 indicates whether to ignore capitalization and punctuation
      * @param trackNulls                indicates whether or not to track null values in a separate column.
      * @param topK                      number of most common elements to be used as categorical pivots
-     * @param minSupport                minimum number of occurences an element must have to appear in pivot
+     * @param minSupport                minimum number of occurrences an element must have to appear in pivot
      * @param unseenName                name to give indexes which do not have a label name associated with them
      * @param hashWithIndex             include indices when hashing a feature that has them (OPLists or OPVectors)
      * @param binaryFreq                if true, term frequency vector will be binary such that non-zero term

--- a/core/src/main/scala/com/salesforce/op/evaluators/OpEvaluatorBase.scala
+++ b/core/src/main/scala/com/salesforce/op/evaluators/OpEvaluatorBase.scala
@@ -171,7 +171,7 @@ abstract class OpEvaluatorBase[T <: EvaluationMetrics] extends Evaluator
   override def evaluate(dataset: Dataset[_]): Double = getDefaultMetric(evaluateAll(dataset))
 
   /**
-   * Prepare data with differnt input types so that it can be consumed by the evaluator
+   * Prepare data with different input types so that it can be consumed by the evaluator
    * @param data input data
    * @param labelColName name of the label column
    * @return data formatted for use with the evaluator
@@ -188,7 +188,7 @@ private[op] abstract class OpClassificationEvaluatorBase[T <: EvaluationMetrics]
     with OpHasProbabilityCol[OPVector] {
 
   /**
-   * Prepare data with differnt input types so that it can be consumed by the evaluator
+   * Prepare data with different input types so that it can be consumed by the evaluator
    * @param data input data
    * @param labelColName name of the label column
    * @return data formatted for use with the evaluator
@@ -247,7 +247,7 @@ abstract class OpRegressionEvaluatorBase[T <: EvaluationMetrics]
 ) extends OpEvaluatorBase[T] {
 
   /**
-   * Prepare data with differnt input types so that it can be consumed by the evaluator
+   * Prepare data with different input types so that it can be consumed by the evaluator
    * @param data input data
    * @param labelColName name of the label column
    * @return data formatted for use with the evaluator

--- a/core/src/main/scala/com/salesforce/op/stages/impl/classification/OpMultilayerPerceptronClassifier.scala
+++ b/core/src/main/scala/com/salesforce/op/stages/impl/classification/OpMultilayerPerceptronClassifier.scala
@@ -128,7 +128,7 @@ class OpMultilayerPerceptronClassifier(uid: String = UID[OpMultilayerPerceptronC
  * @param uid           uid to give stage
  * @param operationName unique name of the operation this stage performs
  */
-// TODO in next release of spark this will be probablistic classifier
+// TODO in next release of spark this will be a probabilistic classifier
 class OpMultilayerPerceptronClassificationModel
 (
   sparkModel: MultilayerPerceptronClassificationModel,

--- a/core/src/main/scala/com/salesforce/op/stages/impl/feature/SmartTextMapVectorizer.scala
+++ b/core/src/main/scala/com/salesforce/op/stages/impl/feature/SmartTextMapVectorizer.scala
@@ -49,7 +49,7 @@ import scala.reflect.runtime.universe.TypeTag
 /**
  * Convert a sequence of text map features into a vector by detecting categoricals that are disguised as text.
  * A categorical will be represented as a vector consisting of occurrences of top K most common values of that feature
- * plus occurences of non top k values and a null indicator (if enabled).
+ * plus occurrences of non top k values and a null indicator (if enabled).
  * Non-categoricals will be converted into a vector using the hashing trick. In addition, a null indicator is created
  * for each non-categorical (if enabled).
  *

--- a/core/src/main/scala/com/salesforce/op/stages/impl/feature/SmartTextVectorizer.scala
+++ b/core/src/main/scala/com/salesforce/op/stages/impl/feature/SmartTextVectorizer.scala
@@ -51,7 +51,7 @@ import scala.reflect.runtime.universe.TypeTag
 /**
  * Convert a sequence of text features into a vector by detecting categoricals that are disguised as text.
  * A categorical will be represented as a vector consisting of occurrences of top K most common values of that feature
- * plus occurences of non top k values and a null indicator (if enabled).
+ * plus occurrences of non top k values and a null indicator (if enabled).
  * Non-categoricals will be converted into a vector using the hashing trick. In addition, a null indicator is created
  * for each non-categorical (if enabled).
  *

--- a/core/src/main/scala/com/salesforce/op/stages/impl/feature/Transmogrifier.scala
+++ b/core/src/main/scala/com/salesforce/op/stages/impl/feature/Transmogrifier.scala
@@ -522,7 +522,7 @@ trait PivotParams extends TextParams {
 
 trait MinSupportParam extends Params {
   final val minSupport = new IntParam(
-    parent = this, name = "minSupport", doc = "minimum number of occurences an element must have to appear in pivot",
+    parent = this, name = "minSupport", doc = "minimum number of occurrences an element must have to appear in pivot",
     isValid = ParamValidators.gtEq(0L)
   )
   setDefault(minSupport, TransmogrifierDefaults.MinSupport)

--- a/core/src/main/scala/com/salesforce/op/stages/impl/preparators/SanityCheckerMetadata.scala
+++ b/core/src/main/scala/com/salesforce/op/stages/impl/preparators/SanityCheckerMetadata.scala
@@ -230,7 +230,7 @@ case class CategoricalGroupStats
  * @param mutualInfos          Values of MI for each feature (should be the same for everything coming from the same
  *                             contingency matrix)
  * @param counts               Counts of occurrence for categoricals (n x m array of arrays where n = number of labels
- *                             and m = number of features + 1 with last element being occurance count of labels
+ *                             and m = number of features + 1 with last element being occurrence count of labels
  */
 @deprecated("Functionality replaced by Array[CategoricalGroupStats]", "3.3.0")
 case class CategoricalStats

--- a/core/src/test/scala/com/salesforce/op/evaluators/OpMultiClassificationEvaluatorTest.scala
+++ b/core/src/test/scala/com/salesforce/op/evaluators/OpMultiClassificationEvaluatorTest.scala
@@ -96,7 +96,7 @@ class OpMultiClassificationEvaluatorTest extends FlatSpec with TestSparkContext 
     )
   }
 
-  it should "determine incorrect/correct counts from the thresholds with one prediciton input" in {
+  it should "determine incorrect/correct counts from the thresholds with one prediction input" in {
     val evaluatorMulti = new OpMultiClassificationEvaluator()
       .setLabelCol(labelMulti2)
       .setFullPredictionCol(predictionMulti2)

--- a/core/src/test/scala/com/salesforce/op/features/TransientFeatureTest.scala
+++ b/core/src/test/scala/com/salesforce/op/features/TransientFeatureTest.scala
@@ -50,7 +50,7 @@ class TransientFeatureTest extends FlatSpec with PassengerFeaturesTest with Test
   implicit val formats = DefaultFormats
   val tf = TransientFeature(height)
 
-  Spec[TransientFeature] should "return feature after contruction with a feature" in {
+  Spec[TransientFeature] should "return feature after construction with a feature" in {
     compare(tf, height)
     tf.getFeature() shouldBe height
   }

--- a/core/src/test/scala/com/salesforce/op/stages/impl/insights/RecordInsightsCorrTest.scala
+++ b/core/src/test/scala/com/salesforce/op/stages/impl/insights/RecordInsightsCorrTest.scala
@@ -59,8 +59,8 @@ class RecordInsightsCorrTest extends FlatSpec with TestSparkContext {
 
   it  should "work with randomly generated features and one prediction" in {
     val features = RandomVector.sparse(RandomReal.normal(), 40).limit(1000)
-    val predicitons = RandomVector.dense(RandomReal.normal(), 1).limit(1000)
-    val (df, f1, p1) = TestFeatureBuilder("features", "predictions", features.zip(predicitons))
+    val predictions = RandomVector.dense(RandomReal.normal(), 1).limit(1000)
+    val (df, f1, p1) = TestFeatureBuilder("features", "predictions", features.zip(predictions))
     val dfWithMeta = addMetaData(df, "features", 40)
     val p1r = p1.copy(isResponse = true)
 
@@ -77,8 +77,8 @@ class RecordInsightsCorrTest extends FlatSpec with TestSparkContext {
 
   it should "work with randomly generated features and multiple predictions" in {
     val features = RandomVector.dense(RandomReal.poisson(1), 10).limit(1000)
-    val predicitons = RandomVector.dense(RandomReal.normal(), 5).limit(1000)
-    val (df, f1, p1) = TestFeatureBuilder("features", "predictions", features.zip(predicitons))
+    val predictions = RandomVector.dense(RandomReal.normal(), 5).limit(1000)
+    val (df, f1, p1) = TestFeatureBuilder("features", "predictions", features.zip(predictions))
     val dfWithMeta = addMetaData(df, "features", 10)
     val p1r = p1.copy(isResponse = true)
 

--- a/docs/sources/templates/docs-index.gsp
+++ b/docs/sources/templates/docs-index.gsp
@@ -3,7 +3,7 @@
     <%include "menu.gsp"%>
 
     <div class="page-header">
-        <h1>Documenation</h1>
+        <h1>Documentation</h1>
     </div>
     <ul>
         <% docs.each {doc ->%>

--- a/features/src/main/scala/com/salesforce/op/stages/package.scala
+++ b/features/src/main/scala/com/salesforce/op/stages/package.scala
@@ -75,7 +75,7 @@ package object stages {
   }
 
   /**
-   * Replace feature names for multistage spark wrappers (gross-ness) that have had the output name overriden
+   * Replace feature names for multistage spark wrappers (gross-ness) that have had the output name overridden
    *
    * @param newName          override name
    * @param oldName          default name

--- a/features/src/main/scala/com/salesforce/op/utils/spark/OpVectorMetadata.scala
+++ b/features/src/main/scala/com/salesforce/op/utils/spark/OpVectorMetadata.scala
@@ -151,7 +151,7 @@ class OpVectorMetadata private
       case _ => false
     }
 
-  // have to override to support overriden .equals
+  // have to override to support overridden .equals
   override def hashCode(): Int = 37 * columns.toSeq.hashCode()
 
   override def toString: String =

--- a/features/src/main/scala/org/apache/spark/ml/SparkMLSharedParamConstants.scala
+++ b/features/src/main/scala/org/apache/spark/ml/SparkMLSharedParamConstants.scala
@@ -52,7 +52,7 @@ case object SparkMLSharedParamConstants
   // response variable
   val PredictionColName = predictionCol.name
 
-  // these are the names for input/ouput for estimators/transformers that transform a single column to another
+  // these are the names for input/output for estimators/transformers that transform a single column to another
   // single columns
   val InputColName = inputCol.name
   val OutputColName = outputCol.name

--- a/templates/simple/spark.gradle
+++ b/templates/simple/spark.gradle
@@ -43,7 +43,7 @@
  *
  * By default (unless you add any new arguments,) spark-submit task will work exactly the same
  * as before, uploading your local spark libs / project libs every time. This is just a precaution
- * to maintain backwards compatability.
+ * to maintain backwards compatibility.
  */
 
 task copyLog4jToSparkNoInstall(type: Copy) {

--- a/testkit/src/main/scala/com/salesforce/op/testkit/RandomStream.scala
+++ b/testkit/src/main/scala/com/salesforce/op/testkit/RandomStream.scala
@@ -256,7 +256,7 @@ object RandomStream {
   /**
    * a generator of random integers between two given numbers (in
    *
-   * @param from minimium number to produce (inclusive)
+   * @param from minimum number to produce (inclusive)
    * @param to   max number to produce (exclusive)
    * @return
    */


### PR DESCRIPTION
**Related issues**
None.

**Describe the proposed solution**
This pull request fixes several typos and misspellings detected by https://github.com/client9/misspell .  I've reviewed all the detections and skipped a portion of them because they are false positives.

### before

```
$ misspell .
core/src/main/scala/com/salesforce/op/dsl/RichMapFeature.scala:247:58: "occurences" is a misspelling of "occurrences"
core/src/main/scala/com/salesforce/op/dsl/RichMapFeature.scala:376:58: "occurences" is a misspelling of "occurrences"
core/src/main/scala/com/salesforce/op/dsl/RichNumericFeature.scala:448:97: "disticnt" is a misspelling of "distinct"
core/src/main/scala/com/salesforce/op/dsl/RichSetFeature.scala:58:29: "occurances" is a misspelling of "occurrences"
core/src/main/scala/com/salesforce/op/dsl/RichSetFeature.scala:87:29: "occurances" is a misspelling of "occurrences"
core/src/main/scala/com/salesforce/op/dsl/RichTextFeature.scala:184:58: "occurences" is a misspelling of "occurrences"
core/src/main/scala/com/salesforce/op/evaluators/OpEvaluatorBase.scala:174:23: "differnt" is a misspelling of "different"
core/src/main/scala/com/salesforce/op/evaluators/OpEvaluatorBase.scala:191:23: "differnt" is a misspelling of "different"
core/src/main/scala/com/salesforce/op/evaluators/OpEvaluatorBase.scala:250:23: "differnt" is a misspelling of "different"
core/src/main/scala/com/salesforce/op/stages/impl/classification/OpMultilayerPerceptronClassifier.scala:131:46: "probablistic" is a misspelling of "probabilistic"
core/src/main/scala/com/salesforce/op/stages/impl/feature/SmartTextMapVectorizer.scala:52:8: "occurences" is a misspelling of "occurrences"
core/src/main/scala/com/salesforce/op/stages/impl/feature/SmartTextVectorizer.scala:54:8: "occurences" is a misspelling of "occurrences"
core/src/main/scala/com/salesforce/op/stages/impl/feature/Transmogrifier.scala:525:65: "occurences" is a misspelling of "occurrences"
core/src/main/scala/com/salesforce/op/stages/impl/preparators/SanityCheckerMetadata.scala:233:86: "occurance" is a misspelling of "occurrence"
core/src/test/scala/com/salesforce/op/evaluators/OpMultiClassificationEvaluatorTest.scala:99:77: "prediciton" is a misspelling of "prediction"
core/src/test/scala/com/salesforce/op/features/TransientFeatureTest.scala:53:54: "contruction" is a misspelling of "construction"
core/src/test/scala/com/salesforce/op/stages/impl/feature/TextTokenizerTest.scala:114:19: "comision" is a misspelling of "commission"
core/src/test/scala/com/salesforce/op/stages/impl/feature/TextTokenizerTest.scala:116:18: "clas" is a misspelling of "class"
core/src/test/scala/com/salesforce/op/stages/impl/insights/RecordInsightsCorrTest.scala:62:8: "predicitons" is a misspelling of "predictions"
core/src/test/scala/com/salesforce/op/stages/impl/insights/RecordInsightsCorrTest.scala:63:82: "predicitons" is a misspelling of "predictions"
core/src/test/scala/com/salesforce/op/stages/impl/insights/RecordInsightsCorrTest.scala:80:8: "predicitons" is a misspelling of "predictions"
core/src/test/scala/com/salesforce/op/stages/impl/insights/RecordInsightsCorrTest.scala:81:82: "predicitons" is a misspelling of "predictions"
docs/sources/templates/docs-index.gsp:6:12: "Documenation" is a misspelling of "Documentation"
features/src/main/scala/com/salesforce/op/stages/package.scala:78:100: "overriden" is a misspelling of "overridden"
features/src/main/scala/com/salesforce/op/utils/spark/OpVectorMetadata.scala:154:33: "overriden" is a misspelling of "overridden"
features/src/main/scala/org/apache/spark/ml/SparkMLSharedParamConstants.scala:55:35: "ouput" is a misspelling of "output"
helloworld/src/main/resources/TitanicDataset/TitanicPassengersTrainData.csv:11:8: "Sandstrom" is a misspelling of "Sandstorm"
helloworld/src/main/resources/TitanicDataset/TitanicPassengersTrainData.csv:204:9: "Youseff" is a misspelling of "Yousef"
helloworld/src/main/resources/TitanicDataset/TitanicPassengersTrainData.csv:257:31: "Maybelle" is a misspelling of "Maybelline"
helloworld/src/main/resources/TitanicDataset/TitanicPassengersTrainData.csv:395:9: "Sandstrom" is a misspelling of "Sandstorm"
templates/simple/spark.gradle:46:25: "compatability" is a misspelling of "compatibility"
test-data/PassengerDataAll.csv:11:8: "Sandstrom" is a misspelling of "Sandstorm"
test-data/PassengerDataAll.csv:204:9: "Youseff" is a misspelling of "Yousef"
test-data/PassengerDataAll.csv:257:31: "Maybelle" is a misspelling of "Maybelline"
test-data/PassengerDataAll.csv:395:9: "Sandstrom" is a misspelling of "Sandstorm"
test-data/PassengerDataAllWithHeader.csv:12:8: "Sandstrom" is a misspelling of "Sandstorm"
test-data/PassengerDataAllWithHeader.csv:205:9: "Youseff" is a misspelling of "Yousef"
test-data/PassengerDataAllWithHeader.csv:258:31: "Maybelle" is a misspelling of "Maybelline"
test-data/PassengerDataAllWithHeader.csv:396:9: "Sandstrom" is a misspelling of "Sandstorm"
testkit/build/resources/main/cities.txt:63:0: "Capitola" is a misspelling of "Capital"
testkit/build/resources/main/lastnames.txt:4480:0: "VILLEGAS" is a misspelling of "VILLAGES"
testkit/src/main/resources/cities.txt:63:0: "Capitola" is a misspelling of "Capital"
testkit/src/main/resources/lastnames.txt:4480:0: "VILLEGAS" is a misspelling of "VILLAGES"
testkit/src/main/scala/com/salesforce/op/testkit/RandomStream.scala:259:17: "minimium" is a misspelling of "minimum"
```

### after

```
$ misspell .
core/src/test/scala/com/salesforce/op/stages/impl/feature/TextTokenizerTest.scala:114:19: "comision" is a misspelling of "commission"
core/src/test/scala/com/salesforce/op/stages/impl/feature/TextTokenizerTest.scala:116:18: "clas" is a misspelling of "class"
helloworld/src/main/resources/TitanicDataset/TitanicPassengersTrainData.csv:11:8: "Sandstrom" is a misspelling of "Sandstorm"
helloworld/src/main/resources/TitanicDataset/TitanicPassengersTrainData.csv:204:9: "Youseff" is a misspelling of "Yousef"
helloworld/src/main/resources/TitanicDataset/TitanicPassengersTrainData.csv:257:31: "Maybelle" is a misspelling of "Maybelline"
helloworld/src/main/resources/TitanicDataset/TitanicPassengersTrainData.csv:395:9: "Sandstrom" is a misspelling of "Sandstorm"
test-data/PassengerDataAll.csv:11:8: "Sandstrom" is a misspelling of "Sandstorm"
test-data/PassengerDataAll.csv:204:9: "Youseff" is a misspelling of "Yousef"
test-data/PassengerDataAll.csv:257:31: "Maybelle" is a misspelling of "Maybelline"
test-data/PassengerDataAll.csv:395:9: "Sandstrom" is a misspelling of "Sandstorm"
test-data/PassengerDataAllWithHeader.csv:12:8: "Sandstrom" is a misspelling of "Sandstorm"
test-data/PassengerDataAllWithHeader.csv:205:9: "Youseff" is a misspelling of "Yousef"
test-data/PassengerDataAllWithHeader.csv:258:31: "Maybelle" is a misspelling of "Maybelline"
test-data/PassengerDataAllWithHeader.csv:396:9: "Sandstrom" is a misspelling of "Sandstorm"
testkit/build/resources/main/cities.txt:63:0: "Capitola" is a misspelling of "Capital"
testkit/build/resources/main/lastnames.txt:4480:0: "VILLEGAS" is a misspelling of "VILLAGES"
testkit/src/main/resources/cities.txt:63:0: "Capitola" is a misspelling of "Capital"
testkit/src/main/resources/lastnames.txt:4480:0: "VILLEGAS" is a misspelling of "VILLAGES"
```

**Describe alternatives you've considered**
None.

**Additional context**
None.
