### PR TITLE
Adding Array of metadataSeq in RichMap

### DIFF
--- a/utils/src/main/scala/com/salesforce/op/utils/spark/RichMetadata.scala
+++ b/utils/src/main/scala/com/salesforce/op/utils/spark/RichMetadata.scala
@@ -186,6 +186,7 @@ object RichMetadata {
   private val intSeq = TypeCase[Seq[Int]]
   private val doubleSeq = TypeCase[Seq[Double]]
   private val stringSeq = TypeCase[Seq[String]]
+  private val metadataSeq = TypeCase[Seq[Metadata]]
 
   /**
    * Enrichment functions for Maps
@@ -203,6 +204,7 @@ object RichMetadata {
         case longSeq(v) => builder.putLongArray(key, v.toArray)
         case doubleSeq(v) => builder.putDoubleArray(key, v.toArray)
         case stringSeq(v) => builder.putStringArray(key, v.toArray)
+        case metadataSeq(v) => builder.putMetadataArray(key, v.toArray)
         case _ => unsupported(key, seq)
       }
       theMap.foldLeft(builder) {

--- a/utils/src/test/scala/com/salesforce/op/utils/spark/RichMetadataTest.scala
+++ b/utils/src/test/scala/com/salesforce/op/utils/spark/RichMetadataTest.scala
@@ -85,6 +85,11 @@ class RichMetadataTest extends FlatSpec with TestCommon {
     val mergedMetadata = meta1.deepMerge(map2.toMetadata)
     mergedMetadata.json shouldBe Serialization.write(mergedMap)
 
+    val m1 = Map("1" -> Array(Map("val" -> "a").toMetadata)).toMetadata
+    val m2 = Map("1" -> Array(Map("val" -> "b").toMetadata)).toMetadata
+    val mergedValue = Map("1" -> Array(Map("val" -> "a").toMetadata, Map("val" -> "b").toMetadata)).toMetadata
+
+    m1.deepMerge(m2) shouldBe mergedValue
   }
 
   it should "throw an error on incompatible value types in deep merge" in {
@@ -100,6 +105,17 @@ class RichMetadataTest extends FlatSpec with TestCommon {
     summaryMeta.containsSummaryMetadata shouldBe true
   }
 
+  it should "create summary for a given metadata" in {
+    val richMetaData = RichMetadata(meta1)
+    richMetaData.containsSummaryMetadata() shouldBe false
+
+    // create a summary for the metadata.
+    val expectedSummaryMetadata = Map("s" -> "summaryTest").toMetadata
+    val richMetaDataWithSummary = richMetaData.withSummaryMetadata(expectedSummaryMetadata)
+
+    richMetaDataWithSummary.getSummaryMetadata() shouldBe expectedSummaryMetadata
+    richMetaDataWithSummary.containsSummaryMetadata() shouldBe true
+  }
 }
 
 case class TestClass(name: String)

--- a/utils/src/test/scala/com/salesforce/op/utils/spark/RichMetadataTest.scala
+++ b/utils/src/test/scala/com/salesforce/op/utils/spark/RichMetadataTest.scala
@@ -84,7 +84,9 @@ class RichMetadataTest extends FlatSpec with TestCommon {
 
     val mergedMetadata = meta1.deepMerge(map2.toMetadata)
     mergedMetadata.json shouldBe Serialization.write(mergedMap)
+  }
 
+  it should "deep merge the Array of metadata" in {
     val m1 = Map("1" -> Array(Map("val" -> "a").toMetadata)).toMetadata
     val m2 = Map("1" -> Array(Map("val" -> "b").toMetadata)).toMetadata
     val mergedValue = Map("1" -> Array(Map("val" -> "a").toMetadata, Map("val" -> "b").toMetadata)).toMetadata
@@ -106,12 +108,11 @@ class RichMetadataTest extends FlatSpec with TestCommon {
   }
 
   it should "create summary for a given metadata" in {
-    val richMetaData = RichMetadata(meta1)
-    richMetaData.containsSummaryMetadata() shouldBe false
+    meta1.containsSummaryMetadata() shouldBe false
 
     // create a summary for the metadata.
     val expectedSummaryMetadata = Map("s" -> "summaryTest").toMetadata
-    val richMetaDataWithSummary = richMetaData.withSummaryMetadata(expectedSummaryMetadata)
+    val richMetaDataWithSummary = meta1.withSummaryMetadata(expectedSummaryMetadata)
 
     richMetaDataWithSummary.getSummaryMetadata() shouldBe expectedSummaryMetadata
     richMetaDataWithSummary.containsSummaryMetadata() shouldBe true


### PR DESCRIPTION
In RichMap, for Array values, we are currently accepting booleanSeq, intSeq, longSeq, doubleSeq and stringSeq. 
- Adding one more datatype to the list - MetadataSeq.
- Adding test case for the new type added.
- Adding test case for withSummary() as well for improved coverage