### PR TITLE
Stable key order for map vectorizers

### DIFF
--- a/core/src/main/scala/com/salesforce/op/stages/impl/feature/SmartTextMapVectorizer.scala
+++ b/core/src/main/scala/com/salesforce/op/stages/impl/feature/SmartTextMapVectorizer.scala
@@ -121,7 +121,7 @@ class SmartTextMapVectorizer[T <: OPMap[String]]
 
   def makeSmartTextMapVectorizerModelArgs(aggregatedStats: Array[TextMapStats]): SmartTextMapVectorizerModelArgs = {
     val maxCard = $(maxCardinality)
-    val minSup = ${minSupport}
+    val minSup = $(minSupport)
     val shouldCleanKeys = $(cleanKeys)
     val shouldCleanValues = $(cleanText)
     val shouldTrackNulls = $(trackNulls)

--- a/core/src/test/scala/com/salesforce/op/stages/impl/feature/BinaryMapVectorizerTest.scala
+++ b/core/src/test/scala/com/salesforce/op/stages/impl/feature/BinaryMapVectorizerTest.scala
@@ -55,9 +55,9 @@ class BinaryMapVectorizerTest
 
   val estimator = new BinaryMapVectorizer().setTrackNulls(false).setCleanKeys(true).setInput(m1, m2)
 
-  val expectedResult: Seq[OPVector] = Seq(
+  val expectedResult = Seq(
     Vectors.sparse(6, Array(1), Array(1.0)),
-    Vectors.sparse(6, Array(4, 5), Array(1.0, 1.0)),
+    Vectors.sparse(6, Array(3, 4), Array(1.0, 1.0)),
     Vectors.sparse(6, Array(), Array())
   ).map(_.toOPVector)
 
@@ -68,7 +68,7 @@ class BinaryMapVectorizerTest
     val expectedMeta = TestOpVectorMetadataBuilder(
       estimator,
       m1 -> List(IndColWithGroup(None, "A"), IndColWithGroup(None, "B"), IndColWithGroup(None, "C")),
-      m2 -> List(IndColWithGroup(None, "Z"), IndColWithGroup(None, "Y"), IndColWithGroup(None, "X"))
+      m2 -> List(IndColWithGroup(None, "X"), IndColWithGroup(None, "Y"), IndColWithGroup(None, "Z"))
     )
 
     transformed.collect(vector) shouldBe expectedResult
@@ -82,8 +82,8 @@ class BinaryMapVectorizerTest
     val transformed = estimator.setTrackNulls(true).fit(inputData).transform(inputData)
     val vector = estimator.getOutput()
     val expected = Array(
-      Vectors.sparse(12, Array(2, 5, 9, 11), Array(1.0, 1.0, 1.0, 1.0)),
-      Vectors.sparse(12, Array(1, 3, 7, 8, 10), Array(1.0, 1.0, 1.0, 1.0, 1.0)),
+      Vectors.sparse(12, Array(2, 5, 7, 9), Array(1.0, 1.0, 1.0, 1.0)),
+      Vectors.sparse(12, Array(1, 3, 6, 8, 11), Array(1.0, 1.0, 1.0, 1.0, 1.0)),
       Vectors.sparse(12, Array(1, 3, 5, 7, 9, 11), Array(1.0, 1.0, 1.0, 1.0, 1.0, 1.0))
     ).map(_.toOPVector)
 
@@ -93,9 +93,9 @@ class BinaryMapVectorizerTest
       m1 -> List(IndColWithGroup(None, "A"), IndColWithGroup(nullIndicatorValue, "A"),
         IndColWithGroup(None, "B"), IndColWithGroup(nullIndicatorValue, "B"),
         IndColWithGroup(None, "C"), IndColWithGroup(nullIndicatorValue, "C")),
-      m2 -> List(IndColWithGroup(None, "Z"), IndColWithGroup(nullIndicatorValue, "Z"),
+      m2 -> List(IndColWithGroup(None, "X"), IndColWithGroup(nullIndicatorValue, "X"),
         IndColWithGroup(None, "Y"), IndColWithGroup(nullIndicatorValue, "Y"),
-        IndColWithGroup(None, "X"), IndColWithGroup(nullIndicatorValue, "X"))
+        IndColWithGroup(None, "Z"), IndColWithGroup(nullIndicatorValue, "Z"))
     )
 
     transformed.collect(vector) shouldBe expected

--- a/core/src/test/scala/com/salesforce/op/stages/impl/feature/IntegralMapVectorizerTest.scala
+++ b/core/src/test/scala/com/salesforce/op/stages/impl/feature/IntegralMapVectorizerTest.scala
@@ -31,21 +31,22 @@
 package com.salesforce.op.stages.impl.feature
 
 import com.salesforce.op.features.types._
-import com.salesforce.op.test.TestOpVectorColumnType.{IndCol, IndColWithGroup}
-import com.salesforce.op.test.{TestFeatureBuilder, TestOpVectorMetadataBuilder, TestSparkContext}
-import com.salesforce.op.utils.spark.{OpVectorColumnMetadata, OpVectorMetadata}
+import com.salesforce.op.stages.base.sequence.SequenceModel
+import com.salesforce.op.test.TestOpVectorColumnType.IndColWithGroup
+import com.salesforce.op.test.{OpEstimatorSpec, TestFeatureBuilder, TestOpVectorMetadataBuilder}
 import com.salesforce.op.utils.spark.RichDataset._
 import com.salesforce.op.utils.spark.RichStructType._
+import com.salesforce.op.utils.spark.{OpVectorColumnMetadata, OpVectorMetadata}
 import org.apache.spark.ml.linalg.Vectors
 import org.junit.runner.RunWith
-import org.scalatest.FlatSpec
 import org.scalatest.junit.JUnitRunner
 
 
 @RunWith(classOf[JUnitRunner])
-class IntegralMapVectorizerTest extends FlatSpec with TestSparkContext {
+class IntegralMapVectorizerTest
+  extends OpEstimatorSpec[OPVector, SequenceModel[IntegralMap, OPVector], IntegralMapVectorizer[IntegralMap]] {
 
-  lazy val (data, m1, m2) = TestFeatureBuilder("m1", "m2",
+  val (inputData, m1, m2) = TestFeatureBuilder("m1", "m2",
     Seq(
       (Map("a" -> 1L, "b" -> 5L), Map("z" -> 10L)),
       (Map("c" -> 11L), Map("y" -> 3L, "x" -> 0L)),
@@ -53,68 +54,52 @@ class IntegralMapVectorizerTest extends FlatSpec with TestSparkContext {
     ).map(v => v._1.toIntegralMap -> v._2.toIntegralMap)
   )
 
-  val nullIndicatorValue = Some(OpVectorColumnMetadata.NullString)
+  val estimator = new IntegralMapVectorizer().setTrackNulls(false).setCleanKeys(true).setInput(m1, m2)
 
-  val baseVectorizer = new IntegralMapVectorizer().setInput(m1, m2).setCleanKeys(true)
+  val expectedResult = Seq(
+    Vectors.dense(Array(1.0, 5.0, 0.0, 0.0, 0.0, 10.0)),
+    Vectors.sparse(6, Array(2, 4), Array(11.0, 3.0)),
+    Vectors.sparse(6, Array(), Array())
+  ).map(_.toOPVector)
 
   val expectedMeta = TestOpVectorMetadataBuilder(
-    baseVectorizer,
-    m1 -> List(IndColWithGroup(None, "A"), IndColWithGroup(None, "B"),
-      IndColWithGroup(None, "C")),
-    m2 -> List(IndColWithGroup(None, "Z"), IndColWithGroup(None, "Y"), IndColWithGroup(None, "X"))
+    estimator,
+    m1 -> List(IndColWithGroup(None, "A"), IndColWithGroup(None, "B"), IndColWithGroup(None, "C")),
+    m2 -> List(IndColWithGroup(None, "X"), IndColWithGroup(None, "Y"), IndColWithGroup(None, "Z"))
   )
 
+  val nullIndicatorValue = Some(OpVectorColumnMetadata.NullString)
 
   val expectedMetaTrackNulls = TestOpVectorMetadataBuilder(
-    baseVectorizer,
+    estimator,
     m1 -> List(IndColWithGroup(None, "A"), IndColWithGroup(nullIndicatorValue, "A"),
       IndColWithGroup(None, "B"), IndColWithGroup(nullIndicatorValue, "B"),
       IndColWithGroup(None, "C"), IndColWithGroup(nullIndicatorValue, "C")),
-    m2 -> List(IndColWithGroup(None, "Z"), IndColWithGroup(nullIndicatorValue, "Z"),
+    m2 -> List(IndColWithGroup(None, "X"), IndColWithGroup(nullIndicatorValue, "X"),
       IndColWithGroup(None, "Y"), IndColWithGroup(nullIndicatorValue, "Y"),
-      IndColWithGroup(None, "X"), IndColWithGroup(nullIndicatorValue, "X"))
+      IndColWithGroup(None, "Z"), IndColWithGroup(nullIndicatorValue, "Z"))
   )
 
-  Spec[IntegralMapVectorizer[_]] should "take an array of features as input and return a single vector feature" in {
-    val vector = baseVectorizer.getOutput()
+  it should "return a model that correctly transforms the data and produces metadata" in {
+    val vector = estimator.getOutput()
+    val transformed = model.transform(inputData)
 
-    vector.name shouldBe baseVectorizer.getOutputFeatureName
-    vector.parents should contain theSameElementsAs Array(m1, m2)
-    vector.originStage shouldBe baseVectorizer
-    vector.typeName shouldBe FeatureType.typeName[OPVector]
-    vector.isResponse shouldBe false
-  }
-
-  it should "return a model that correctly transforms the data" in {
-    val vectorizer = baseVectorizer.setTrackNulls(false).fit(data)
-
-    val vector = vectorizer.getOutput()
-    val transformed = vectorizer.transform(data)
-
-    val expected = Array(
-      Vectors.dense(Array(1.0, 5.0, 0.0, 10.0, 0.0, 0.0)),
-      Vectors.sparse(6, Array(2, 4), Array(11.0, 3.0)),
-      Vectors.sparse(6, Array(), Array())
-    ).map(_.toOPVector)
-
-
-    transformed.collect(vector) shouldBe expected
-    transformed.schema.toOpVectorMetadata(vectorizer.getOutputFeatureName) shouldEqual expectedMeta
-    val vectorMetadata = vectorizer.getMetadata()
-    OpVectorMetadata(vectorizer.getOutputFeatureName, vectorMetadata) shouldEqual expectedMeta
+    transformed.collect(vector) shouldBe expectedResult
+    transformed.schema.toOpVectorMetadata(estimator.getOutputFeatureName) shouldEqual expectedMeta
+    val vectorMetadata = estimator.getMetadata()
+    OpVectorMetadata(estimator.getOutputFeatureName, vectorMetadata) shouldEqual expectedMeta
   }
 
   it should "track nulls" in {
-    val vectorizer = baseVectorizer.setTrackNulls(true).fit(data)
+    val vectorizer = estimator.setTrackNulls(true).fit(inputData)
     val vector = vectorizer.getOutput()
-    val transformed = vectorizer.transform(data)
+    val transformed = vectorizer.transform(inputData)
 
     val expected = Array(
-      Vectors.sparse(12, Array(0, 2, 5, 6, 9, 11), Array(1.0, 5.0, 1.0, 10.0, 1.0, 1.0)),
-      Vectors.sparse(12, Array(1, 3, 4, 7, 8), Array(1.0, 1.0, 11.0, 1.0, 3.0)),
+      Vectors.sparse(12, Array(0, 2, 5, 7, 9, 10), Array(1.0, 5.0, 1.0, 1.0, 1.0, 10.0)),
+      Vectors.sparse(12, Array(1, 3, 4, 8, 11), Array(1.0, 1.0, 11.0, 3.0, 1.0)),
       Vectors.sparse(12, Array(1, 3, 5, 7, 9, 11), Array(1.0, 1.0, 1.0, 1.0, 1.0, 1.0))
     ).map(_.toOPVector)
-
 
     transformed.collect(vector) shouldBe expected
     transformed.schema.toOpVectorMetadata(vectorizer.getOutputFeatureName) shouldEqual expectedMetaTrackNulls
@@ -123,13 +108,13 @@ class IntegralMapVectorizerTest extends FlatSpec with TestSparkContext {
   }
 
   it should "use the correct fill value for missing keys" in {
-    val vectorizer = baseVectorizer.setDefaultValue(100).setTrackNulls(false).fit(data)
+    val vectorizer = estimator.setDefaultValue(100).setTrackNulls(false).fit(inputData)
     val vector = vectorizer.getOutput()
-    val transformed = vectorizer.transform(data)
+    val transformed = vectorizer.transform(inputData)
 
     val expected = Array(
-      Vectors.dense(Array(1.0, 5.0, 100.0, 10.0, 100.0, 100.0)),
-      Vectors.dense(Array(100.0, 100.0, 11.0, 100.0, 3.0, 0.0)),
+      Vectors.dense(Array(1.0, 5.0, 100.0, 100.0, 100.0, 10.0)),
+      Vectors.dense(Array(100.0, 100.0, 11.0, 0.0, 3.0, 100.0)),
       Vectors.dense(Array(100.0, 100.0, 100.0, 100.0, 100.0, 100.0))
     ).map(_.toOPVector)
 
@@ -140,16 +125,15 @@ class IntegralMapVectorizerTest extends FlatSpec with TestSparkContext {
   }
 
   it should "track nulls with the correct fill value for missing keys" in {
-    val vectorizer = baseVectorizer.setDefaultValue(100).setTrackNulls(true).fit(data)
+    val vectorizer = estimator.setDefaultValue(100).setTrackNulls(true).fit(inputData)
     val vector = vectorizer.getOutput()
-    val transformed = vectorizer.transform(data)
+    val transformed = vectorizer.transform(inputData)
 
     val expected = Array(
-      Vectors.sparse(12, Array(0, 2, 4, 5, 6, 8, 9, 10, 11), Array(1.0, 5.0, 100.0, 1.0, 10.0, 100.0, 1.0, 100.0, 1.0)),
-      Vectors.sparse(12, Array(0, 1, 2, 3, 4, 6, 7, 8), Array(100.0, 1.0, 100.0, 1.0, 11.0, 100.0, 1.0, 3.0)),
+      Vectors.dense(Array(1.0, 0.0, 5.0, 0.0, 100.0, 1.0, 100.0, 1.0, 100.0, 1.0, 10.0, 0.0)),
+      Vectors.dense(Array(100.0, 1.0, 100.0, 1.0, 11.0, 0.0, 0.0, 0.0, 3.0, 0.0, 100.0, 1.0)),
       Vectors.dense(Array(100.0, 1.0, 100.0, 1.0, 100.0, 1.0, 100.0, 1.0, 100.0, 1.0, 100.0, 1.0))
     ).map(_.toOPVector)
-
 
     transformed.collect(vector) shouldBe expected
     transformed.schema.toOpVectorMetadata(vectorizer.getOutputFeatureName) shouldEqual expectedMetaTrackNulls
@@ -160,9 +144,9 @@ class IntegralMapVectorizerTest extends FlatSpec with TestSparkContext {
   it should "correctly whitelist keys" in {
     val vectorizer =
       new IntegralMapVectorizer[IntegralMap]().setInput(m1, m2).setCleanKeys(true).setTrackNulls(false)
-        .setWhiteListKeys(Array("a", "b", "z")).fit(data)
+        .setWhiteListKeys(Array("a", "b", "z")).fit(inputData)
     val vector = vectorizer.getOutput()
-    val transformed = vectorizer.transform(data)
+    val transformed = vectorizer.transform(inputData)
 
     val expected = Array(
       Vectors.dense(Array(1.0, 5.0, 10.0)),
@@ -184,9 +168,9 @@ class IntegralMapVectorizerTest extends FlatSpec with TestSparkContext {
   it should "correctly track nulls with whitelist keys" in {
     val vectorizer =
       new IntegralMapVectorizer[IntegralMap]().setInput(m1, m2).setCleanKeys(true).setTrackNulls(true)
-        .setWhiteListKeys(Array("a", "b", "z")).fit(data)
+        .setWhiteListKeys(Array("a", "b", "z")).fit(inputData)
     val vector = vectorizer.getOutput()
-    val transformed = vectorizer.transform(data)
+    val transformed = vectorizer.transform(inputData)
 
     val expected = Array(
       Vectors.sparse(6, Array(0, 2, 4), Array(1.0, 5.0, 10.0)),
@@ -208,19 +192,19 @@ class IntegralMapVectorizerTest extends FlatSpec with TestSparkContext {
 
   it should "correctly backlist keys" in {
     val vectorizer = new IntegralMapVectorizer[IntegralMap]()
-      .setInput(m1, m2).setCleanKeys(true).setTrackNulls(false).setBlackListKeys(Array("a", "z")).fit(data)
+      .setInput(m1, m2).setCleanKeys(true).setTrackNulls(false).setBlackListKeys(Array("a", "z")).fit(inputData)
     val vector = vectorizer.getOutput()
-    val transformed = vectorizer.transform(data)
+    val transformed = vectorizer.transform(inputData)
 
     val expected = Array(
       Vectors.sparse(4, Array(0), Array(5.0)),
-      Vectors.dense(Array(0.0, 11.0, 3.0, 0.0)),
+      Vectors.dense(Array(0.0, 11.0, 0.0, 3.0)),
       Vectors.sparse(4, Array(), Array())
     ).map(_.toOPVector)
     val expectedMeta = TestOpVectorMetadataBuilder(
       vectorizer,
       m1 -> List(IndColWithGroup(None, "B"), IndColWithGroup(None, "C")),
-      m2 -> List(IndColWithGroup(None, "Y"), IndColWithGroup(None, "X"))
+      m2 -> List(IndColWithGroup(None, "X"), IndColWithGroup(None, "Y"))
     )
 
     transformed.collect(vector) shouldBe expected
@@ -231,21 +215,21 @@ class IntegralMapVectorizerTest extends FlatSpec with TestSparkContext {
 
   it should "track nulls with backlist keys" in {
     val vectorizer = new IntegralMapVectorizer[IntegralMap]()
-      .setInput(m1, m2).setCleanKeys(true).setTrackNulls(true).setBlackListKeys(Array("a", "z")).fit(data)
+      .setInput(m1, m2).setCleanKeys(true).setTrackNulls(true).setBlackListKeys(Array("a", "z")).fit(inputData)
     val vector = vectorizer.getOutput()
-    val transformed = vectorizer.transform(data)
+    val transformed = vectorizer.transform(inputData)
 
     val expected = Array(
       Vectors.sparse(8, Array(0, 3, 5, 7), Array(5.0, 1.0, 1.0, 1.0)),
-      Vectors.sparse(8, Array(1, 2, 4, 6), Array(1.0, 11.0, 3.0, 0.0)),
+      Vectors.sparse(8, Array(1, 2, 6), Array(1.0, 11.0, 3.0)),
       Vectors.sparse(8, Array(1, 3, 5, 7), Array(1.0, 1.0, 1.0, 1.0))
     ).map(_.toOPVector)
     val expectedMeta = TestOpVectorMetadataBuilder(
       vectorizer,
       m1 -> List(IndColWithGroup(None, "B"), IndColWithGroup(nullIndicatorValue, "B"),
         IndColWithGroup(None, "C"), IndColWithGroup(nullIndicatorValue, "C")),
-      m2 -> List(IndColWithGroup(None, "Y"), IndColWithGroup(nullIndicatorValue, "Y"),
-        IndColWithGroup(None, "X"), IndColWithGroup(nullIndicatorValue, "X"))
+      m2 -> List(IndColWithGroup(None, "X"), IndColWithGroup(nullIndicatorValue, "X"),
+        IndColWithGroup(None, "Y"), IndColWithGroup(nullIndicatorValue, "Y"))
     )
 
     transformed.collect(vector) shouldBe expected

--- a/core/src/test/scala/com/salesforce/op/stages/impl/feature/RealMapVectorizerTest.scala
+++ b/core/src/test/scala/com/salesforce/op/stages/impl/feature/RealMapVectorizerTest.scala
@@ -31,21 +31,22 @@
 package com.salesforce.op.stages.impl.feature
 
 import com.salesforce.op.features.types._
-import com.salesforce.op.test.TestOpVectorColumnType.{IndCol, IndColWithGroup}
-import com.salesforce.op.test.{TestFeatureBuilder, TestOpVectorMetadataBuilder, TestSparkContext}
-import com.salesforce.op.utils.spark.{OpVectorColumnMetadata, OpVectorMetadata}
+import com.salesforce.op.stages.base.sequence.SequenceModel
+import com.salesforce.op.test.TestOpVectorColumnType.IndColWithGroup
+import com.salesforce.op.test.{OpEstimatorSpec, TestFeatureBuilder, TestOpVectorMetadataBuilder}
 import com.salesforce.op.utils.spark.RichDataset._
 import com.salesforce.op.utils.spark.RichStructType._
+import com.salesforce.op.utils.spark.{OpVectorColumnMetadata, OpVectorMetadata}
 import org.apache.spark.ml.linalg.Vectors
 import org.junit.runner.RunWith
-import org.scalatest.FlatSpec
 import org.scalatest.junit.JUnitRunner
 
 
 @RunWith(classOf[JUnitRunner])
-class RealMapVectorizerTest extends FlatSpec with TestSparkContext {
+class RealMapVectorizerTest
+  extends OpEstimatorSpec[OPVector, SequenceModel[RealMap, OPVector], RealMapVectorizer[RealMap]] {
 
-  lazy val (data, m1, m2) = TestFeatureBuilder("m1", "m2",
+  val (inputData, m1, m2) = TestFeatureBuilder("m1", "m2",
     Seq(
       (Map("a" -> 1.0, "b" -> 5.0), Map("z" -> 10.0)),
       (Map("c" -> 11.0), Map("y" -> 3.0, "x" -> 0.0)),
@@ -53,7 +54,7 @@ class RealMapVectorizerTest extends FlatSpec with TestSparkContext {
     ).map(v => v._1.toRealMap -> v._2.toRealMap)
   )
 
-  lazy val (meanData, f1, f2) = TestFeatureBuilder("f1", "f2",
+  val (meanData, f1, f2) = TestFeatureBuilder("f1", "f2",
     Seq(
       (Map("a" -> 1.0, "b" -> 5.0), Map("y" -> 4.0, "x" -> 0.0, "z" -> 10.0)),
       (Map("a" -> -3.0, "b" -> 3.0, "c" -> 11.0), Map("y" -> 3.0, "x" -> 0.0)),
@@ -62,60 +63,49 @@ class RealMapVectorizerTest extends FlatSpec with TestSparkContext {
     ).map(v => v._1.toRealMap -> v._2.toRealMap)
   )
 
-  val baseVectorizer = new RealMapVectorizer[RealMap]().setInput(m1, m2).setCleanKeys(true)
+  val estimator = new RealMapVectorizer[RealMap]().setInput(m1, m2).setTrackNulls(false).setCleanKeys(true)
+
+  val expectedResult = Seq(
+    Vectors.dense(Array(1.0, 5.0, 0.0, 0.0, 0.0, 10.0)),
+    Vectors.sparse(6, Array(2, 4), Array(11.0, 3.0)),
+    Vectors.sparse(6, Array(), Array())
+  ).map(_.toOPVector)
 
   val expectedMeta = TestOpVectorMetadataBuilder(
-    baseVectorizer,
+    estimator,
     m1 -> List(IndColWithGroup(None, "A"), IndColWithGroup(None, "B"), IndColWithGroup(None, "C")),
-    m2 -> List(IndColWithGroup(None, "Z"), IndColWithGroup(None, "Y"), IndColWithGroup(None, "X"))
+    m2 -> List(IndColWithGroup(None, "X"), IndColWithGroup(None, "Y"), IndColWithGroup(None, "Z"))
   )
 
   val nullIndicatorValue = Some(OpVectorColumnMetadata.NullString)
-
   val expectedMetaTrackNulls = TestOpVectorMetadataBuilder(
-    baseVectorizer,
+    estimator,
     m1 -> List(IndColWithGroup(None, "A"), IndColWithGroup(nullIndicatorValue, "A"),
       IndColWithGroup(None, "B"), IndColWithGroup(nullIndicatorValue, "B"),
       IndColWithGroup(None, "C"), IndColWithGroup(nullIndicatorValue, "C")),
-    m2 -> List(IndColWithGroup(None, "Z"), IndColWithGroup(nullIndicatorValue, "Z"),
+    m2 -> List(IndColWithGroup(None, "X"), IndColWithGroup(nullIndicatorValue, "X"),
       IndColWithGroup(None, "Y"), IndColWithGroup(nullIndicatorValue, "Y"),
-      IndColWithGroup(None, "X"), IndColWithGroup(nullIndicatorValue, "X"))
+      IndColWithGroup(None, "Z"), IndColWithGroup(nullIndicatorValue, "Z"))
   )
 
-  Spec[RealMapVectorizer[_]] should "take an array of features as input and return a single vector feature" in {
-    val vectorizer = new RealMapVectorizer[RealMap]().setCleanKeys(true).setInput(m1, m2)
+  it should "return a model that correctly transforms the data and produces metadata" in {
+    val vectorizer = estimator.setDefaultValue(0.0).setTrackNulls(false).fit(inputData)
+    val transformed = vectorizer.transform(inputData)
     val vector = vectorizer.getOutput()
 
-    vector.name shouldBe vectorizer.getOutputFeatureName
-    vector.parents should contain theSameElementsAs Array(m1, m2)
-    vector.originStage shouldBe vectorizer
-    vector.typeName shouldBe FeatureType.typeName[OPVector]
-    vector.isResponse shouldBe false
-  }
-
-  it should "return a model that correctly transforms the data" in {
-    val vectorizer = baseVectorizer.setDefaultValue(0.0).setTrackNulls(false).fit(data)
-    val transformed = vectorizer.transform(data)
-    val vector = vectorizer.getOutput()
-    val expected = Array(
-      Vectors.dense(Array(1.0, 5.0, 0.0, 10.0, 0.0, 0.0)),
-      Vectors.sparse(6, Array(2, 4), Array(11.0, 3.0)),
-      Vectors.sparse(6, Array(), Array())
-    ).map(_.toOPVector)
-
-    transformed.collect(vector) shouldBe expected
+    transformed.collect(vector) shouldBe expectedResult
     transformed.schema.toOpVectorMetadata(vectorizer.getOutputFeatureName) shouldEqual expectedMeta
     val vectorMetadata = vectorizer.getMetadata()
     OpVectorMetadata(vectorizer.getOutputFeatureName, vectorMetadata) shouldEqual expectedMeta
   }
 
   it should "track nulls" in {
-    val vectorizer = baseVectorizer.setDefaultValue(0.0).setTrackNulls(true).fit(data)
-    val transformed = vectorizer.transform(data)
+    val vectorizer = estimator.setDefaultValue(0.0).setTrackNulls(true).fit(inputData)
+    val transformed = vectorizer.transform(inputData)
     val vector = vectorizer.getOutput()
     val expected = Array(
-      Vectors.sparse(12, Array(0, 2, 5, 6, 9, 11), Array(1.0, 5.0, 1.0, 10.0, 1.0, 1.0)),
-      Vectors.sparse(12, Array(1, 3, 4, 7, 8), Array(1.0, 1.0, 11.0, 1.0, 3.0)),
+      Vectors.sparse(12, Array(0, 2, 5, 7, 9, 10), Array(1.0, 5.0, 1.0, 1.0, 1.0, 10.0)),
+      Vectors.sparse(12, Array(1, 3, 4, 8, 11), Array(1.0, 1.0, 11.0, 3.0, 1.0)),
       Vectors.sparse(12, Array(1, 3, 5, 7, 9, 11), Array(1.0, 1.0, 1.0, 1.0, 1.0, 1.0))
     ).map(_.toOPVector)
 
@@ -126,12 +116,12 @@ class RealMapVectorizerTest extends FlatSpec with TestSparkContext {
   }
 
   it should "use the correct fill value for missing keys" in {
-    val vectorizer = baseVectorizer.setDefaultValue(100).setTrackNulls(false).fit(data)
-    val transformed = vectorizer.transform(data)
+    val vectorizer = estimator.setDefaultValue(100).setTrackNulls(false).fit(inputData)
+    val transformed = vectorizer.transform(inputData)
     val vector = vectorizer.getOutput()
     val expected = Array(
-      Vectors.dense(Array(1.0, 5.0, 100.0, 10.0, 100.0, 100.0)),
-      Vectors.dense(Array(100.0, 100.0, 11.0, 100.0, 3.0, 0.0)),
+      Vectors.dense(Array(1.0, 5.0, 100.0, 100.0, 100.0, 10.0)),
+      Vectors.dense(Array(100.0, 100.0, 11.0, 0.0, 3.0, 100.0)),
       Vectors.dense(Array(100.0, 100.0, 100.0, 100.0, 100.0, 100.0))
     ).map(_.toOPVector)
 
@@ -142,16 +132,15 @@ class RealMapVectorizerTest extends FlatSpec with TestSparkContext {
   }
 
   it should "track nulls with fill value for missing keys" in {
-    val vectorizer = baseVectorizer.setDefaultValue(100).setTrackNulls(true).fit(data)
+    val vectorizer = estimator.setDefaultValue(100).setTrackNulls(true).fit(inputData)
     val vector = vectorizer.getOutput()
-    val transformed = vectorizer.transform(data)
+    val transformed = vectorizer.transform(inputData)
 
     val expected = Array(
-      Vectors.sparse(12, Array(0, 2, 4, 5, 6, 8, 9, 10, 11), Array(1.0, 5.0, 100.0, 1.0, 10.0, 100.0, 1.0, 100.0, 1.0)),
-      Vectors.sparse(12, Array(0, 1, 2, 3, 4, 6, 7, 8), Array(100.0, 1.0, 100.0, 1.0, 11.0, 100.0, 1.0, 3.0)),
+      Vectors.dense(Array(1.0, 0.0, 5.0, 0.0, 100.0, 1.0, 100.0, 1.0, 100.0, 1.0, 10.0, 0.0)),
+      Vectors.dense(Array(100.0, 1.0, 100.0, 1.0, 11.0, 0.0, 0.0, 0.0, 3.0, 0.0, 100.0, 1.0)),
       Vectors.dense(Array(100.0, 1.0, 100.0, 1.0, 100.0, 1.0, 100.0, 1.0, 100.0, 1.0, 100.0, 1.0))
     ).map(_.toOPVector)
-
 
     transformed.collect(vector) shouldBe expected
     transformed.schema.toOpVectorMetadata(vectorizer.getOutputFeatureName) shouldEqual expectedMetaTrackNulls
@@ -161,8 +150,8 @@ class RealMapVectorizerTest extends FlatSpec with TestSparkContext {
 
   it should "correctly whitelist keys" in {
     val vectorizer = new RealMapVectorizer[RealMap]().setInput(m1, m2).setDefaultValue(0.0)
-      .setCleanKeys(true).setWhiteListKeys(Array("a", "b", "z")).setTrackNulls(false).fit(data)
-    val transformed = vectorizer.transform(data)
+      .setCleanKeys(true).setWhiteListKeys(Array("a", "b", "z")).setTrackNulls(false).fit(inputData)
+    val transformed = vectorizer.transform(inputData)
     val vector = vectorizer.getOutput()
     val expected = Array(
       Vectors.dense(Array(1.0, 5.0, 10.0)),
@@ -182,9 +171,9 @@ class RealMapVectorizerTest extends FlatSpec with TestSparkContext {
 
   it should "track nulls with whitelist keys" in {
     val vectorizer = new RealMapVectorizer[RealMap]().setInput(m1, m2).setDefaultValue(0.0)
-      .setCleanKeys(true).setWhiteListKeys(Array("a", "b", "z")).setTrackNulls(true).fit(data)
+      .setCleanKeys(true).setWhiteListKeys(Array("a", "b", "z")).setTrackNulls(true).fit(inputData)
     val vector = vectorizer.getOutput()
-    val transformed = vectorizer.transform(data)
+    val transformed = vectorizer.transform(inputData)
 
     val expected = Array(
       Vectors.sparse(6, Array(0, 2, 4), Array(1.0, 5.0, 10.0)),
@@ -206,18 +195,18 @@ class RealMapVectorizerTest extends FlatSpec with TestSparkContext {
 
   it should "correctly backlist keys" in {
     val vectorizer = new RealMapVectorizer[RealMap]().setInput(m1, m2).setDefaultValue(0.0)
-      .setCleanKeys(true).setBlackListKeys(Array("a", "z")).setTrackNulls(false).fit(data)
-    val transformed = vectorizer.transform(data)
+      .setCleanKeys(true).setBlackListKeys(Array("a", "z")).setTrackNulls(false).fit(inputData)
+    val transformed = vectorizer.transform(inputData)
     val vector = vectorizer.getOutput()
     val expected = Array(
       Vectors.sparse(4, Array(0), Array(5.0)),
-      Vectors.dense(Array(0.0, 11.0, 3.0, 0.0)),
+      Vectors.dense(Array(0.0, 11.0, 0.0, 3.0)),
       Vectors.sparse(4, Array(), Array())
     ).map(_.toOPVector)
     val expectedMeta = TestOpVectorMetadataBuilder(
       vectorizer,
       m1 -> List(IndColWithGroup(None, "B"), IndColWithGroup(None, "C")),
-      m2 -> List(IndColWithGroup(None, "Y"), IndColWithGroup(None, "X"))
+      m2 -> List(IndColWithGroup(None, "X"), IndColWithGroup(None, "Y"))
     )
 
     transformed.collect(vector) shouldBe expected
@@ -226,24 +215,23 @@ class RealMapVectorizerTest extends FlatSpec with TestSparkContext {
     OpVectorMetadata(vectorizer.getOutputFeatureName, vectorMetadata) shouldEqual expectedMeta
   }
 
-
   it should "track nulls with backlist keys" in {
     val vectorizer = new RealMapVectorizer[RealMap]().setInput(m1, m2).setDefaultValue(0.0)
-      .setCleanKeys(true).setBlackListKeys(Array("a", "z")).setTrackNulls(true).fit(data)
+      .setCleanKeys(true).setBlackListKeys(Array("a", "z")).setTrackNulls(true).fit(inputData)
     val vector = vectorizer.getOutput()
-    val transformed = vectorizer.transform(data)
+    val transformed = vectorizer.transform(inputData)
 
     val expected = Array(
       Vectors.sparse(8, Array(0, 3, 5, 7), Array(5.0, 1.0, 1.0, 1.0)),
-      Vectors.sparse(8, Array(1, 2, 4, 6), Array(1.0, 11.0, 3.0, 0.0)),
+      Vectors.sparse(8, Array(1, 2, 6), Array(1.0, 11.0, 3.0)),
       Vectors.sparse(8, Array(1, 3, 5, 7), Array(1.0, 1.0, 1.0, 1.0))
     ).map(_.toOPVector)
     val expectedMeta = TestOpVectorMetadataBuilder(
       vectorizer,
       m1 -> List(IndColWithGroup(None, "B"), IndColWithGroup(nullIndicatorValue, "B"),
         IndColWithGroup(None, "C"), IndColWithGroup(nullIndicatorValue, "C")),
-      m2 -> List(IndColWithGroup(None, "Y"), IndColWithGroup(nullIndicatorValue, "Y"),
-        IndColWithGroup(None, "X"), IndColWithGroup(nullIndicatorValue, "X"))
+      m2 -> List(IndColWithGroup(None, "X"), IndColWithGroup(nullIndicatorValue, "X"),
+        IndColWithGroup(None, "Y"), IndColWithGroup(nullIndicatorValue, "Y"))
     )
 
     transformed.collect(vector) shouldBe expected
@@ -258,19 +246,18 @@ class RealMapVectorizerTest extends FlatSpec with TestSparkContext {
     val transformed = vectorizer.transform(meanData)
     val vector = vectorizer.getOutput()
     val expected = Array(
-      Vectors.dense(1.0, 5.0, 11.0, 4.0, 0.0, 10.0),
-      Vectors.dense(-3.0, 3.0, 11.0, 3.0, 0.0, 15.0 / 2),
-      Vectors.dense(-1.0, 4.0, 11.0, 1.0, 0.0, 5.0),
-      Vectors.dense(-1.0, 4.0, 11.0, 8.0 / 3, 0.0, 15.0 / 2)
+      Vectors.dense(1.0, 5.0, 11.0, 0.0, 4.0, 10.0),
+      Vectors.dense(-3.0, 3.0, 11.0, 0.0, 3.0, 15.0 / 2),
+      Vectors.dense(-1.0, 4.0, 11.0, 0.0, 1.0, 5.0),
+      Vectors.dense(-1.0, 4.0, 11.0, 0.0, 8.0 / 3, 15.0 / 2)
     ).map(_.toOPVector)
 
     transformed.collect(vector) shouldBe expected
 
-    // TODO: Order of columns needed to be changed here compared to earlier tests - why does this happen?
     val expectedMeta = TestOpVectorMetadataBuilder(
       vectorizer,
       f1 -> List(IndColWithGroup(None, "A"), IndColWithGroup(None, "B"), IndColWithGroup(None, "C")),
-      f2 -> List(IndColWithGroup(None, "Y"), IndColWithGroup(None, "X"), IndColWithGroup(None, "Z"))
+      f2 -> List(IndColWithGroup(None, "X"), IndColWithGroup(None, "Y"), IndColWithGroup(None, "Z"))
     )
     transformed.schema.toOpVectorMetadata(vectorizer.getOutputFeatureName) shouldEqual expectedMeta
     val vectorMetadata = vectorizer.getMetadata()
@@ -283,22 +270,21 @@ class RealMapVectorizerTest extends FlatSpec with TestSparkContext {
     val transformed = vectorizer.transform(meanData)
     val vector = vectorizer.getOutput()
     val expected = Array(
-      Vectors.sparse(12, Array(0, 2, 4, 5, 6, 10), Array(1.0, 5.0, 11.0, 1.0, 4.0, 10.0)),
-      Vectors.sparse(12, Array(0, 2, 4, 6, 10, 11), Array(-3.0, 3.0, 11.0, 3.0, 15.0 / 2, 1.0)),
-      Vectors.dense(-1.0, 1.0, 4.0, 1.0, 11.0, 1.0, 1.0, 0.0, 0.0, 0.0, 5.0, 0.0),
-      Vectors.dense(-1.0, 1.0, 4.0, 1.0, 11.0, 1.0, 8.0 / 3, 1.0, 0.0, 1.0, 15.0 / 2, 1.0)
+      Vectors.sparse(12, Array(0, 2, 4, 5, 8, 10), Array(1.0, 5.0, 11.0, 1.0, 4.0, 10.0)),
+      Vectors.sparse(12, Array(0, 2, 4, 8, 10, 11), Array(-3.0, 3.0, 11.0, 3.0, 15.0 / 2, 1.0)),
+      Vectors.dense(-1.0, 1.0, 4.0, 1.0, 11.0, 1.0, 0.0, 0.0, 1.0, 0.0, 5.0, 0.0),
+      Vectors.dense(-1.0, 1.0, 4.0, 1.0, 11.0, 1.0, 0.0, 1.0, 8.0 / 3, 1.0, 15.0 / 2, 1.0)
     ).map(_.toOPVector)
 
     transformed.collect(vector) shouldBe expected
 
-    // TODO: Order of columns needed to be changed here compared to earlier tests - why does this happen?
     val expectedMetaTrackNulls = TestOpVectorMetadataBuilder(
       vectorizer,
       f1 -> List(IndColWithGroup(None, "A"), IndColWithGroup(nullIndicatorValue, "A"),
         IndColWithGroup(None, "B"), IndColWithGroup(nullIndicatorValue, "B"),
         IndColWithGroup(None, "C"), IndColWithGroup(nullIndicatorValue, "C")),
-      f2 -> List(IndColWithGroup(None, "Y"), IndColWithGroup(nullIndicatorValue, "Y"),
-        IndColWithGroup(None, "X"), IndColWithGroup(nullIndicatorValue, "X"),
+      f2 -> List(IndColWithGroup(None, "X"), IndColWithGroup(nullIndicatorValue, "X"),
+        IndColWithGroup(None, "Y"), IndColWithGroup(nullIndicatorValue, "Y"),
         IndColWithGroup(None, "Z"), IndColWithGroup(nullIndicatorValue, "Z"))
     )
     transformed.schema.toOpVectorMetadata(vectorizer.getOutputFeatureName) shouldEqual expectedMetaTrackNulls

--- a/core/src/test/scala/com/salesforce/op/stages/impl/preparators/SanityCheckerTest.scala
+++ b/core/src/test/scala/com/salesforce/op/stages/impl/preparators/SanityCheckerTest.scala
@@ -535,7 +535,7 @@ class SanityCheckerTest extends OpEstimatorSpec[OPVector, BinaryModel[RealNN, OP
   }
 
   // TODO: Not sure if we should do this test since it may not fail if spark settings are changed
-  it should "fail (due to a Kyro buffer overflow) when calculating a large (5k x 5k) correlation matrix " in {
+  it should "fail (due to a Kryo buffer overflow) when calculating a large (5k x 5k) correlation matrix " in {
     val numHashes = 5000
 
     val vectorized = textMap.vectorize(

--- a/core/src/test/scala/com/salesforce/op/stages/impl/preparators/SanityCheckerTest.scala
+++ b/core/src/test/scala/com/salesforce/op/stages/impl/preparators/SanityCheckerTest.scala
@@ -487,12 +487,12 @@ class SanityCheckerTest extends OpEstimatorSpec[OPVector, BinaryModel[RealNN, OP
 
     val transformed = new OpWorkflow().setResultFeatures(vectorized, checkedFeatures).transform(textData)
 
-    val featuresToDrop = Seq("textMap_color_NullIndicatorValue_512")
+    val featuresToDrop = Seq("textMap_color_NullIndicatorValue_513")
     val expectedFeatNames = (0 until 512).map(i => "textMap_" + i.toString) ++
-      Seq("textMap_color_NullIndicatorValue_512", "textMap_fruit_NullIndicatorValue_513",
-        "textMap_beverage_NullIndicatorValue_514")
-    val featuresWithCorr = Seq("textMap_color_NullIndicatorValue_512", "textMap_fruit_NullIndicatorValue_513",
-      "textMap_beverage_NullIndicatorValue_514"
+      Seq("textMap_beverage_NullIndicatorValue_512", "textMap_color_NullIndicatorValue_513",
+        "textMap_fruit_NullIndicatorValue_514")
+    val featuresWithCorr = Seq("textMap_beverage_NullIndicatorValue_512", "textMap_color_NullIndicatorValue_513",
+      "textMap_fruit_NullIndicatorValue_514"
     )
     val featuresWithNaNCorr = Seq.empty[String]
 
@@ -595,14 +595,14 @@ class SanityCheckerTest extends OpEstimatorSpec[OPVector, BinaryModel[RealNN, OP
 
     val featuresToDrop = Seq.empty[String]
     val totalFeatures = (0 until numHashes).map(i => "textMap_" + i.toString) ++
-      Seq("textMap_color_NullIndicatorValue_" + numHashes.toString,
-        "textMap_fruit_NullIndicatorValue_" + (numHashes + 1).toString,
-        "textMap_beverage_NullIndicatorValue_" + (numHashes + 2).toString)
+      Seq("textMap_beverage_NullIndicatorValue_" + numHashes.toString,
+        "textMap_color_NullIndicatorValue_" + (numHashes + 1).toString,
+        "textMap_fruit_NullIndicatorValue_" + (numHashes + 2).toString)
     val featuresWithCorr = Seq("textMap_8", "textMap_89", "textMap_294", "textMap_706", "textMap_971",
       "textMap_1364", "textMap_1633", "textMap_2382", "textMap_2527", "textMap_3159", "textMap_3491",
-      "textMap_3804", "textMap_color_NullIndicatorValue_" + numHashes.toString,
-      "textMap_fruit_NullIndicatorValue_" + (numHashes + 1).toString,
-      "textMap_beverage_NullIndicatorValue_" + (numHashes + 2).toString)
+      "textMap_3804", "textMap_beverage_NullIndicatorValue_" + numHashes.toString,
+      "textMap_color_NullIndicatorValue_" + (numHashes + 1).toString,
+      "textMap_fruit_NullIndicatorValue_" + (numHashes + 2).toString)
     val featuresWithNaNCorr = totalFeatures.filterNot(featuresWithCorr.contains)
 
 


### PR DESCRIPTION
**Related issues**
Map vectorizers do not order the keys properly.

**Describe the proposed solution**
- Sorted map keys in `MapVectorizerFuns.getKeyValues` function.
- bonus: use op specs base classes for the vectorizers

**Describe alternatives you've considered**
N/A
