### PR TITLE
allow numbers and underscores in names

### DIFF
--- a/features/src/main/scala/com/salesforce/op/stages/package.scala
+++ b/features/src/main/scala/com/salesforce/op/stages/package.scala
@@ -54,7 +54,7 @@ package object stages {
   private[stages] def makeOutputName(
     featureUid: String, inputs: Seq[TransientFeature], numberOperations: Int = 1
   ): String = {
-    val origins = inputs.flatMap(_.originFeatures).distinct.sorted.mkString("-").replaceAll("[^A-Za-z-]+", "")
+    val origins = inputs.flatMap(_.originFeatures).distinct.sorted.mkString("-").replaceAll("[^A-Za-z-_0-9]+", "")
     val stages = inputs.flatMap(_.stages).distinct.length + numberOperations
     s"${origins}_$stages-stagesApplied_$featureUid"
   }
@@ -74,23 +74,4 @@ package object stages {
     makeOutputName(featureUid, inputs, numberOperations)
   }
 
-  /**
-   * Replace feature names for multistage spark wrappers (gross-ness) that have had the output name overridden
-   *
-   * @param newName          override name
-   * @param oldName          default name
-   * @param numberOperations number of stages applied to add to stages from features (used in multistage operations)
-   * @return name of the output ex: "f1-f2_4-stagesApplied_Real_0183nsdk"
-   */
-  private[stages] def updateOutputName(
-    newName: String, oldName: String, numberOperations: Int
-  ): String = {
-    val name = raw"([A-Za-z-]+)_([0-9]+)-stagesApplied_([A-Za-z0-9_-]+)".r
-    (newName, oldName) match {
-      // old uid because stages are different
-      case (nn, on) if nn == on => nn
-      case (name(orig, sz, _), name(_, _, uid)) => s"${orig}_${sz.toInt + numberOperations}-stagesApplied_$uid"
-      case (_, _) => throw new IllegalArgumentException(s"Cannot override output name $oldName with $newName")
-    }
-  }
 }


### PR DESCRIPTION
**Related issues**
requirement was only so updating names on old model selector would work

**Describe the proposed solution**
allow numbers and underscores. removed unused method for name update
