### PR TITLE
updated string indexer enum to match spark

### DIFF
--- a/core/src/main/scala/com/salesforce/op/dsl/RichTextFeature.scala
+++ b/core/src/main/scala/com/salesforce/op/dsl/RichTextFeature.scala
@@ -256,10 +256,10 @@ trait RichTextFeature {
      */
     def indexed(
       unseenName: String = OpStringIndexerNoFilter.UnseenNameDefault,
-      handleInvalid: StringIndexerHandleInvalid = StringIndexerHandleInvalid.NoFilter
+      handleInvalid: StringIndexerHandleInvalid = StringIndexerHandleInvalid.Keep
     ): FeatureLike[RealNN] = {
       handleInvalid match {
-        case StringIndexerHandleInvalid.NoFilter => f.transformWith(
+        case StringIndexerHandleInvalid.Keep => f.transformWith(
           new OpStringIndexerNoFilter[T]().setUnseenName(unseenName)
         )
         case _ => f.transformWith(new OpStringIndexer[T]().setHandleInvalid(handleInvalid))

--- a/core/src/main/scala/com/salesforce/op/dsl/RichTextFeature.scala
+++ b/core/src/main/scala/com/salesforce/op/dsl/RichTextFeature.scala
@@ -256,7 +256,7 @@ trait RichTextFeature {
      */
     def indexed(
       unseenName: String = OpStringIndexerNoFilter.UnseenNameDefault,
-      handleInvalid: StringIndexerHandleInvalid = StringIndexerHandleInvalid.Keep
+      handleInvalid: StringIndexerHandleInvalid = StringIndexerHandleInvalid.NoFilter
     ): FeatureLike[RealNN] = {
       handleInvalid match {
         case StringIndexerHandleInvalid.NoFilter => f.transformWith(

--- a/core/src/main/scala/com/salesforce/op/dsl/RichTextFeature.scala
+++ b/core/src/main/scala/com/salesforce/op/dsl/RichTextFeature.scala
@@ -259,7 +259,7 @@ trait RichTextFeature {
       handleInvalid: StringIndexerHandleInvalid = StringIndexerHandleInvalid.Keep
     ): FeatureLike[RealNN] = {
       handleInvalid match {
-        case StringIndexerHandleInvalid.Keep => f.transformWith(
+        case StringIndexerHandleInvalid.NoFilter => f.transformWith(
           new OpStringIndexerNoFilter[T]().setUnseenName(unseenName)
         )
         case _ => f.transformWith(new OpStringIndexer[T]().setHandleInvalid(handleInvalid))

--- a/core/src/main/scala/com/salesforce/op/stages/impl/feature/OpStringIndexer.scala
+++ b/core/src/main/scala/com/salesforce/op/stages/impl/feature/OpStringIndexer.scala
@@ -32,7 +32,7 @@ package com.salesforce.op.stages.impl.feature
 
 import com.salesforce.op.UID
 import com.salesforce.op.features.types._
-import com.salesforce.op.stages.impl.feature.StringIndexerHandleInvalid._
+import com.salesforce.op.stages.impl.feature.{StringIndexerHandleInvalid => Inv}
 import com.salesforce.op.stages.sparkwrappers.specific.OpEstimatorWrapper
 import enumeratum._
 import org.apache.spark.ml.feature.{StringIndexer, StringIndexerModel}
@@ -63,7 +63,8 @@ class OpStringIndexer[T <: Text]
    * @return this stage
    */
   def setHandleInvalid(value: StringIndexerHandleInvalid): this.type = {
-    assert(Seq(Skip, Error, Keep).contains(value), "OpStringIndexer only supports Skip, Error, and Keep for handle invalid")
+    assert(Seq(Inv.Skip, Inv.Error, Inv.Keep).contains(value),
+      "OpStringIndexer only supports Skip, Error, and Keep for handle invalid")
     getSparkMlStage().get.setHandleInvalid(value.entryName.toLowerCase)
     this
   }

--- a/core/src/main/scala/com/salesforce/op/stages/impl/feature/OpStringIndexer.scala
+++ b/core/src/main/scala/com/salesforce/op/stages/impl/feature/OpStringIndexer.scala
@@ -32,6 +32,7 @@ package com.salesforce.op.stages.impl.feature
 
 import com.salesforce.op.UID
 import com.salesforce.op.features.types._
+import com.salesforce.op.stages.impl.feature.StringIndexerHandleInvalid.{Keep, Skip}
 import com.salesforce.op.stages.sparkwrappers.specific.OpEstimatorWrapper
 import enumeratum._
 import org.apache.spark.ml.feature.{StringIndexer, StringIndexerModel}
@@ -62,6 +63,8 @@ class OpStringIndexer[T <: Text]
    * @return this stage
    */
   def setHandleInvalid(value: StringIndexerHandleInvalid): this.type = {
+    assert(Seq(StringIndexerHandleInvalid.Skip, StringIndexerHandleInvalid.Error, StringIndexerHandleInvalid.Keep)
+      .contains(value), "OpStringIndexer only supports Skip, Error, and Keep for handle invalid")
     getSparkMlStage().get.setHandleInvalid(value.entryName.toLowerCase)
     this
   }
@@ -74,4 +77,5 @@ object StringIndexerHandleInvalid extends Enum[StringIndexerHandleInvalid] {
   case object Skip extends StringIndexerHandleInvalid
   case object Error extends StringIndexerHandleInvalid
   case object Keep extends StringIndexerHandleInvalid
+  case object NoFilter extends StringIndexerHandleInvalid
 }

--- a/core/src/main/scala/com/salesforce/op/stages/impl/feature/OpStringIndexer.scala
+++ b/core/src/main/scala/com/salesforce/op/stages/impl/feature/OpStringIndexer.scala
@@ -32,7 +32,7 @@ package com.salesforce.op.stages.impl.feature
 
 import com.salesforce.op.UID
 import com.salesforce.op.features.types._
-import com.salesforce.op.stages.impl.feature.StringIndexerHandleInvalid.{Keep, Skip}
+import com.salesforce.op.stages.impl.feature.StringIndexerHandleInvalid._
 import com.salesforce.op.stages.sparkwrappers.specific.OpEstimatorWrapper
 import enumeratum._
 import org.apache.spark.ml.feature.{StringIndexer, StringIndexerModel}
@@ -63,8 +63,7 @@ class OpStringIndexer[T <: Text]
    * @return this stage
    */
   def setHandleInvalid(value: StringIndexerHandleInvalid): this.type = {
-    assert(Seq(StringIndexerHandleInvalid.Skip, StringIndexerHandleInvalid.Error, StringIndexerHandleInvalid.Keep)
-      .contains(value), "OpStringIndexer only supports Skip, Error, and Keep for handle invalid")
+    assert(Seq(Skip, Error, Keep).contains(value), "OpStringIndexer only supports Skip, Error, and Keep for handle invalid")
     getSparkMlStage().get.setHandleInvalid(value.entryName.toLowerCase)
     this
   }

--- a/core/src/test/scala/com/salesforce/op/stages/impl/feature/OpStringIndexerNoFilterTest.scala
+++ b/core/src/test/scala/com/salesforce/op/stages/impl/feature/OpStringIndexerNoFilterTest.scala
@@ -38,8 +38,8 @@ import com.salesforce.op.test.{TestFeatureBuilder, TestSparkContext}
 import com.salesforce.op.utils.spark.RichDataset._
 import org.apache.spark.ml.feature.StringIndexerModel
 import org.junit.runner.RunWith
+import org.scalatest.FlatSpec
 import org.scalatest.junit.JUnitRunner
-import org.scalatest.{Assertions, FlatSpec, Matchers}
 
 
 @RunWith(classOf[JUnitRunner])
@@ -90,22 +90,4 @@ class OpStringIndexerNoFilterTest extends FlatSpec with TestSparkContext {
 
     indices shouldBe expectedNew
   }
-
-  Spec[OpStringIndexer[_]] should "correctly index a text column" in {
-    val stringIndexer = new OpStringIndexer[Text]().setInput(txtF)
-    val indices = stringIndexer.fit(ds).transform(ds).collect(stringIndexer.getOutput())
-
-    indices shouldBe expected
-  }
-
-  it should "correctly deinxed a numeric column" in {
-    val indexedStage = new OpStringIndexer[Text]().setInput(txtF)
-    val indexed = indexedStage.getOutput()
-    val indices = indexedStage.fit(ds).transform(ds)
-    val deindexedStage = new OpIndexToString().setInput(indexed)
-    val deindexed = deindexedStage.getOutput()
-    val deindexedData = deindexedStage.transform(indices).collect(deindexed)
-    deindexedData shouldBe txtData
-  }
-
 }

--- a/core/src/test/scala/com/salesforce/op/stages/impl/feature/OpStringIndexerTest.scala
+++ b/core/src/test/scala/com/salesforce/op/stages/impl/feature/OpStringIndexerTest.scala
@@ -46,7 +46,12 @@ class OpStringIndexerTest extends FlatSpec with TestSparkContext{
     indexer.setHandleInvalid(StringIndexerHandleInvalid.Error)
     indexer.getSparkMlStage().get.getHandleInvalid shouldBe StringIndexerHandleInvalid.Error.entryName.toLowerCase
     indexer.setHandleInvalid(StringIndexerHandleInvalid.Keep)
-    indexer.getSparkMlStage().get.getHandleInvalid shouldBe StringIndexerHandleInvalid.Skip.entryName.toLowerCase
+    indexer.getSparkMlStage().get.getHandleInvalid shouldBe StringIndexerHandleInvalid.Keep.entryName.toLowerCase
+  }
+
+  it should "throw an error if you try to set noFilter as the indexer" in {
+    val indexer = new OpStringIndexer[Text]()
+    intercept[AssertionError](indexer.setHandleInvalid(StringIndexerHandleInvalid.NoFilter))
   }
 
 }


### PR DESCRIPTION
**Related issues**
OpStringIndexer fails when NoFilter is set for handle invalid because this value doesnt exist in spark

**Describe the proposed solution**
Update enum to match spark supported valuese

