### PR TITLE
Bump scala-graph dependency version to avoid scalacheck

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -63,7 +63,7 @@ configure(allProjs) {
         sparkVersion = '2.2.1'
         sparkAvroVersion = '4.0.0'
         scalaGraphVersion = '1.12.5'
-        scalafmtVersion = '1.0.0-RC1'
+        scalafmtVersion = '1.5.1'
         hadoopVersion = 'hadoop2'
         scalajCollVersion = '0.1.2'
         json4sVersion = '3.2.11' // matches Spark dependency version

--- a/build.gradle
+++ b/build.gradle
@@ -62,7 +62,7 @@ configure(allProjs) {
         avroVersion = '1.7.7'
         sparkVersion = '2.2.1'
         sparkAvroVersion = '4.0.0'
-        scalaGraphVersion = '1.11.2'
+        scalaGraphVersion = '1.12.5'
         scalafmtVersion = '1.0.0-RC1'
         hadoopVersion = 'hadoop2'
         scalajCollVersion = '0.1.2'


### PR DESCRIPTION
**Related issues**
#105

**Describe the proposed solution**
Bumped `scala-graph` version to `1.12.5` + bonus: update `scalafmt` version to `1.5.1`