### PR TITLE
Added OpParams.copy

### DIFF
--- a/features/src/main/scala/com/salesforce/op/OpParams.scala
+++ b/features/src/main/scala/com/salesforce/op/OpParams.scala
@@ -158,6 +158,40 @@ final class OpParams
     )
   }
 
+  def copy(
+    stageParams: Map[String, Map[String, Any]] = this.stageParams,
+    readerParams: Map[String, ReaderParams] = this.readerParams,
+    modelLocation: Option[String] = this.modelLocation,
+    writeLocation: Option[String] = this.writeLocation,
+    metricsLocation: Option[String] = this.metricsLocation,
+    metricsCompress: Option[Boolean] = this.metricsCompress,
+    metricsCodec: Option[String] = this.metricsCodec,
+    batchDurationSecs: Option[Int] = this.batchDurationSecs,
+    awaitTerminationTimeoutSecs: Option[Int] = this.awaitTerminationTimeoutSecs,
+    customTagName: Option[String] = this.customTagName,
+    customTagValue: Option[String] = this.customTagValue,
+    logStageMetrics: Option[Boolean] = this.logStageMetrics,
+    collectStageMetrics: Option[Boolean] = this.collectStageMetrics,
+    customParams: Map[String, Any] = this.customParams,
+    alternateReaderParams: Map[String, ReaderParams] = this.alternateReaderParams
+  ): OpParams = new OpParams(
+    stageParams = stageParams,
+    readerParams = readerParams,
+    modelLocation = modelLocation,
+    writeLocation = writeLocation,
+    metricsLocation = metricsLocation,
+    metricsCompress = metricsCompress,
+    metricsCodec = metricsCodec,
+    batchDurationSecs = batchDurationSecs,
+    awaitTerminationTimeoutSecs = awaitTerminationTimeoutSecs,
+    customTagName = customTagName,
+    customTagValue = customTagValue,
+    logStageMetrics = logStageMetrics,
+    collectStageMetrics = collectStageMetrics,
+    customParams = customParams,
+    alternateReaderParams = alternateReaderParams
+  )
+
   /**
    * Switch the reader params with the alternate reader params and return a new params instance
    * this is necessary because the readers will always try to use readerParams so if you want to

--- a/features/src/main/scala/com/salesforce/op/OpParams.scala
+++ b/features/src/main/scala/com/salesforce/op/OpParams.scala
@@ -158,6 +158,7 @@ final class OpParams
     )
   }
 
+  // scalastyle:off parameter.number
   def copy(
     stageParams: Map[String, Map[String, Any]] = this.stageParams,
     readerParams: Map[String, ReaderParams] = this.readerParams,
@@ -191,6 +192,7 @@ final class OpParams
     customParams = customParams,
     alternateReaderParams = alternateReaderParams
   )
+  // scalastyle:on
 
   /**
    * Switch the reader params with the alternate reader params and return a new params instance

--- a/features/src/test/scala/com/salesforce/op/OpParamsTest.scala
+++ b/features/src/test/scala/com/salesforce/op/OpParamsTest.scala
@@ -59,6 +59,19 @@ class OpParamsTest extends FlatSpec with TestCommon {
     assertParams(workflowParams.get)
   }
 
+  it should "correctly copy parameters" in {
+    val workflowParams = expectedParamsSimple.copy(
+      customTagName = None,
+      metricsLocation = Some("xyz"),
+      metricsCompress = Some(true),
+      customParams = expectedParamsSimple.customParams + ("abc" -> Seq(1, 2, 3))
+    )
+    workflowParams.customTagName shouldBe None
+    workflowParams.metricsLocation shouldBe Some("xyz")
+    workflowParams.metricsCompress shouldBe Some(true)
+    workflowParams.customParams shouldBe Map("custom1" -> 1, "custom2" -> "2", "abc" -> Seq(1, 2, 3))
+  }
+
   it should "correctly swap reader params" in {
     val switched = expectedParamsSimple.switchReaderParams()
     readerParamsCompare(expectedParamsSimple.readerParams, switched.alternateReaderParams)


### PR DESCRIPTION
**Related issues**
It's cumbersome to copy OpParams as you have to go through a ctor to modify a single field. 

**Describe the proposed solution**
Added OpParams.copy method

**Describe alternatives you've considered**
Make `OpParams` a case class, but serialization breaks (so we would have to fix that next).

