### PR TITLE
ModelSelector UID Fix

### DIFF
--- a/core/src/main/scala/com/salesforce/op/stages/impl/classification/BinaryClassificationModelSelector.scala
+++ b/core/src/main/scala/com/salesforce/op/stages/impl/classification/BinaryClassificationModelSelector.scala
@@ -50,7 +50,7 @@ case object BinaryClassificationModelSelector {
     MTT.OpRandomForestClassifier, MTT.OpGBTClassifier, MTT.OpLinearSVC)
   // OpNaiveBayes and OpDecisionTreeClassifier off by default
 
-  private val defaultModelsAndParams: Seq[(EstimatorType, Array[ParamMap])] = {
+  private def defaultModelsAndParams: Seq[(EstimatorType, Array[ParamMap])] = {
     val lr = new OpLogisticRegression()
     val lrParams = new ParamGridBuilder()
       .addGrid(lr.fitIntercept, DefaultSelectorParams.FitIntercept)
@@ -146,7 +146,7 @@ case object BinaryClassificationModelSelector {
     stratify: Boolean = ValidatorParamDefaults.Stratify,
     parallelism: Int = ValidatorParamDefaults.Parallelism,
     modelTypesToUse: Seq[BinaryClassificationModelsToTry] = modelNames,
-    modelsAndParameters: Seq[(EstimatorType, Array[ParamMap])] = defaultModelsAndParams
+    modelsAndParameters: Seq[(EstimatorType, Array[ParamMap])] = Seq.empty
   ): ModelSelector[ModelType, EstimatorType] = {
     val cv = new OpCrossValidation[ModelType, EstimatorType](
       numFolds = numFolds, seed = seed, validationMetric, stratify = stratify, parallelism = parallelism
@@ -187,7 +187,7 @@ case object BinaryClassificationModelSelector {
     stratify: Boolean = ValidatorParamDefaults.Stratify,
     parallelism: Int = ValidatorParamDefaults.Parallelism,
     modelTypesToUse: Seq[BinaryClassificationModelsToTry] = modelNames,
-    modelsAndParameters: Seq[(EstimatorType, Array[ParamMap])] = defaultModelsAndParams
+    modelsAndParameters: Seq[(EstimatorType, Array[ParamMap])] = Seq.empty
   ): ModelSelector[ModelType, EstimatorType] = {
     val ts = new OpTrainValidationSplit[ModelType, EstimatorType](
       trainRatio = trainRatio, seed = seed, validationMetric, stratify = stratify, parallelism = parallelism
@@ -206,7 +206,9 @@ case object BinaryClassificationModelSelector {
   ): ModelSelector[ModelType, EstimatorType] = {
     val modelStrings = modelTypesToUse.map(_.entryName)
     val modelsToUse =
-      if (modelsAndParameters == defaultModelsAndParams || modelTypesToUse != modelNames) modelsAndParameters
+      if (modelsAndParameters.isEmpty) defaultModelsAndParams
+        .filter{ case (e, p) => modelStrings.contains(e.getClass.getSimpleName) }
+      else if (modelTypesToUse != modelNames) modelsAndParameters
         .filter{ case (e, p) => modelStrings.contains(e.getClass.getSimpleName) }
       else modelsAndParameters
     new ModelSelector(

--- a/core/src/main/scala/com/salesforce/op/stages/impl/classification/BinaryClassificationModelSelector.scala
+++ b/core/src/main/scala/com/salesforce/op/stages/impl/classification/BinaryClassificationModelSelector.scala
@@ -206,10 +206,13 @@ case object BinaryClassificationModelSelector {
   ): ModelSelector[ModelType, EstimatorType] = {
     val modelStrings = modelTypesToUse.map(_.entryName)
     val modelsToUse =
+      // if no models are specified use the defaults and filter then by the named models to use
       if (modelsAndParameters.isEmpty) defaultModelsAndParams
         .filter{ case (e, p) => modelStrings.contains(e.getClass.getSimpleName) }
+      // if models to use has been specified and the models have been specified filter the models by the names
       else if (modelTypesToUse != modelNames) modelsAndParameters
         .filter{ case (e, p) => modelStrings.contains(e.getClass.getSimpleName) }
+      // else just use the specified models
       else modelsAndParameters
     new ModelSelector(
       validator = validator,

--- a/core/src/main/scala/com/salesforce/op/stages/impl/classification/BinaryClassificationModelSelector.scala
+++ b/core/src/main/scala/com/salesforce/op/stages/impl/classification/BinaryClassificationModelSelector.scala
@@ -206,7 +206,7 @@ case object BinaryClassificationModelSelector {
   ): ModelSelector[ModelType, EstimatorType] = {
     val modelStrings = modelTypesToUse.map(_.entryName)
     val modelsToUse =
-      // if no models are specified use the defaults and filter then by the named models to use
+      // if no models are specified use the defaults and filter by the named models to use
       if (modelsAndParameters.isEmpty) defaultModelsAndParams
         .filter{ case (e, p) => modelStrings.contains(e.getClass.getSimpleName) }
       // if models to use has been specified and the models have been specified filter the models by the names

--- a/core/src/main/scala/com/salesforce/op/stages/impl/classification/BinaryClassificationModelSelector.scala
+++ b/core/src/main/scala/com/salesforce/op/stages/impl/classification/BinaryClassificationModelSelector.scala
@@ -34,7 +34,7 @@ import com.salesforce.op.evaluators._
 import com.salesforce.op.stages.impl.ModelsToTry
 import com.salesforce.op.stages.impl.classification.{BinaryClassificationModelsToTry => MTT}
 import com.salesforce.op.stages.impl.selector.ModelSelectorNames.{EstimatorType, ModelType}
-import com.salesforce.op.stages.impl.selector.{DefaultSelectorParams, MakeSelector, ModelSelector}
+import com.salesforce.op.stages.impl.selector.{DefaultSelectorParams, ModelSelectorFactory, ModelSelector}
 import com.salesforce.op.stages.impl.tuning.{DataSplitter, Splitter, _}
 import enumeratum.Enum
 import org.apache.spark.ml.param.ParamMap
@@ -44,7 +44,7 @@ import org.apache.spark.ml.tuning.ParamGridBuilder
 /**
  * A factory for Binary Classification Model Selector
  */
-case object BinaryClassificationModelSelector extends MakeSelector {
+case object BinaryClassificationModelSelector extends ModelSelectorFactory {
 
   private[op] val modelNames: Seq[BinaryClassificationModelsToTry] = Seq(MTT.OpLogisticRegression,
     MTT.OpRandomForestClassifier, MTT.OpGBTClassifier, MTT.OpLinearSVC)

--- a/core/src/main/scala/com/salesforce/op/stages/impl/classification/MultiClassificationModelSelector.scala
+++ b/core/src/main/scala/com/salesforce/op/stages/impl/classification/MultiClassificationModelSelector.scala
@@ -49,7 +49,7 @@ case object MultiClassificationModelSelector {
   private[op] val modelNames: Seq[MultiClassClassificationModelsToTry] = Seq(MTT.OpLogisticRegression,
     MTT.OpRandomForestClassifier) // OpDecisionTreeClassifier and OpNaiveBayes off by default
 
-  private val defaultModelsAndParams: Seq[(EstimatorType, Array[ParamMap])] = {
+  private def defaultModelsAndParams: Seq[(EstimatorType, Array[ParamMap])] = {
     val lr = new OpLogisticRegression()
     val lrParams = new ParamGridBuilder()
       .addGrid(lr.fitIntercept, DefaultSelectorParams.FitIntercept)
@@ -124,7 +124,7 @@ case object MultiClassificationModelSelector {
     stratify: Boolean = ValidatorParamDefaults.Stratify,
     parallelism: Int = ValidatorParamDefaults.Parallelism,
     modelTypesToUse: Seq[MultiClassClassificationModelsToTry] = modelNames,
-    modelsAndParameters: Seq[(EstimatorType, Array[ParamMap])] = defaultModelsAndParams
+    modelsAndParameters: Seq[(EstimatorType, Array[ParamMap])] = Seq.empty
   ): ModelSelector[ModelType, EstimatorType] = {
     val cv = new OpCrossValidation[ModelType, EstimatorType](
       numFolds = numFolds, seed = seed, validationMetric, stratify = stratify, parallelism = parallelism
@@ -165,7 +165,7 @@ case object MultiClassificationModelSelector {
     stratify: Boolean = ValidatorParamDefaults.Stratify,
     parallelism: Int = ValidatorParamDefaults.Parallelism,
     modelTypesToUse: Seq[MultiClassClassificationModelsToTry] = modelNames,
-    modelsAndParameters: Seq[(EstimatorType, Array[ParamMap])] = defaultModelsAndParams
+    modelsAndParameters: Seq[(EstimatorType, Array[ParamMap])] = Seq.empty
   ): ModelSelector[ModelType, EstimatorType] = {
     val ts = new OpTrainValidationSplit[ModelType, EstimatorType](
       trainRatio = trainRatio, seed = seed, validationMetric, stratify = stratify, parallelism = parallelism
@@ -184,7 +184,9 @@ case object MultiClassificationModelSelector {
   ): ModelSelector[ModelType, EstimatorType] = {
     val modelStrings = modelTypesToUse.map(_.entryName)
     val modelsToUse =
-      if (modelsAndParameters == defaultModelsAndParams || modelTypesToUse != modelNames) modelsAndParameters
+      if (modelsAndParameters.isEmpty) defaultModelsAndParams
+        .filter{ case (e, p) => modelStrings.contains(e.getClass.getSimpleName) }
+      else if (modelTypesToUse != modelNames) modelsAndParameters
         .filter{ case (e, p) => modelStrings.contains(e.getClass.getSimpleName) }
       else modelsAndParameters
     new ModelSelector(

--- a/core/src/main/scala/com/salesforce/op/stages/impl/classification/MultiClassificationModelSelector.scala
+++ b/core/src/main/scala/com/salesforce/op/stages/impl/classification/MultiClassificationModelSelector.scala
@@ -33,7 +33,7 @@ package com.salesforce.op.stages.impl.classification
 import com.salesforce.op.evaluators._
 import com.salesforce.op.stages.impl.ModelsToTry
 import com.salesforce.op.stages.impl.classification.{MultiClassClassificationModelsToTry => MTT}
-import com.salesforce.op.stages.impl.selector.{DefaultSelectorParams, MakeSelector, ModelSelector}
+import com.salesforce.op.stages.impl.selector.{DefaultSelectorParams, ModelSelectorFactory, ModelSelector}
 import com.salesforce.op.stages.impl.tuning._
 import enumeratum.Enum
 import com.salesforce.op.stages.impl.selector.ModelSelectorNames.{EstimatorType, ModelType}
@@ -44,7 +44,7 @@ import org.apache.spark.ml.tuning.ParamGridBuilder
 /**
  * A factory for Multi Classification Model Selector
  */
-case object MultiClassificationModelSelector extends MakeSelector {
+case object MultiClassificationModelSelector extends ModelSelectorFactory {
 
   private[op] val modelNames: Seq[MultiClassClassificationModelsToTry] = Seq(MTT.OpLogisticRegression,
     MTT.OpRandomForestClassifier) // OpDecisionTreeClassifier and OpNaiveBayes off by default

--- a/core/src/main/scala/com/salesforce/op/stages/impl/classification/MultiClassificationModelSelector.scala
+++ b/core/src/main/scala/com/salesforce/op/stages/impl/classification/MultiClassificationModelSelector.scala
@@ -184,10 +184,13 @@ case object MultiClassificationModelSelector {
   ): ModelSelector[ModelType, EstimatorType] = {
     val modelStrings = modelTypesToUse.map(_.entryName)
     val modelsToUse =
+      // if no models are specified use the defaults and filter then by the named models to use
       if (modelsAndParameters.isEmpty) defaultModelsAndParams
         .filter{ case (e, p) => modelStrings.contains(e.getClass.getSimpleName) }
+      // if models to use has been specified and the models have been specified filter the models by the names
       else if (modelTypesToUse != modelNames) modelsAndParameters
         .filter{ case (e, p) => modelStrings.contains(e.getClass.getSimpleName) }
+      // else just use the specified models
       else modelsAndParameters
     new ModelSelector(
       validator = validator,

--- a/core/src/main/scala/com/salesforce/op/stages/impl/classification/MultiClassificationModelSelector.scala
+++ b/core/src/main/scala/com/salesforce/op/stages/impl/classification/MultiClassificationModelSelector.scala
@@ -184,7 +184,7 @@ case object MultiClassificationModelSelector {
   ): ModelSelector[ModelType, EstimatorType] = {
     val modelStrings = modelTypesToUse.map(_.entryName)
     val modelsToUse =
-      // if no models are specified use the defaults and filter then by the named models to use
+      // if no models are specified use the defaults and filter by the named models to use
       if (modelsAndParameters.isEmpty) defaultModelsAndParams
         .filter{ case (e, p) => modelStrings.contains(e.getClass.getSimpleName) }
       // if models to use has been specified and the models have been specified filter the models by the names

--- a/core/src/main/scala/com/salesforce/op/stages/impl/regression/RegressionModelSelector.scala
+++ b/core/src/main/scala/com/salesforce/op/stages/impl/regression/RegressionModelSelector.scala
@@ -196,10 +196,13 @@ case object RegressionModelSelector {
   ): ModelSelector[ModelType, EstimatorType] = {
     val modelStrings = modelTypesToUse.map(_.entryName)
     val modelsToUse =
+    // if no models are specified use the defaults and filter then by the named models to use
       if (modelsAndParameters.isEmpty) defaultModelsAndParams
         .filter{ case (e, p) => modelStrings.contains(e.getClass.getSimpleName) }
+      // if models to use has been specified and the models have been specified filter the models by the names
       else if (modelTypesToUse != modelNames) modelsAndParameters
         .filter{ case (e, p) => modelStrings.contains(e.getClass.getSimpleName) }
+      // else just use the specified models
       else modelsAndParameters
     new ModelSelector(
       validator = validator,

--- a/core/src/main/scala/com/salesforce/op/stages/impl/regression/RegressionModelSelector.scala
+++ b/core/src/main/scala/com/salesforce/op/stages/impl/regression/RegressionModelSelector.scala
@@ -34,7 +34,7 @@ import com.salesforce.op.evaluators._
 import com.salesforce.op.stages.impl.ModelsToTry
 import com.salesforce.op.stages.impl.regression.{RegressionModelsToTry => MTT}
 import com.salesforce.op.stages.impl.selector.ModelSelectorNames.{EstimatorType, ModelType}
-import com.salesforce.op.stages.impl.selector.{DefaultSelectorParams, MakeSelector, ModelSelector}
+import com.salesforce.op.stages.impl.selector.{DefaultSelectorParams, ModelSelectorFactory, ModelSelector}
 import com.salesforce.op.stages.impl.tuning._
 import enumeratum.Enum
 import org.apache.spark.ml.param.ParamMap
@@ -44,7 +44,7 @@ import org.apache.spark.ml.tuning.ParamGridBuilder
 /**
  * A factory for Regression Model Selector
  */
-case object RegressionModelSelector extends MakeSelector {
+case object RegressionModelSelector extends ModelSelectorFactory {
 
   private[op] val modelNames: Seq[RegressionModelsToTry] = Seq(MTT.OpLinearRegression, MTT.OpRandomForestRegressor,
     MTT.OpGBTRegressor, MTT.OpGeneralizedLinearRegression) // OpDecisionTreeRegressor off by default

--- a/core/src/main/scala/com/salesforce/op/stages/impl/regression/RegressionModelSelector.scala
+++ b/core/src/main/scala/com/salesforce/op/stages/impl/regression/RegressionModelSelector.scala
@@ -196,7 +196,7 @@ case object RegressionModelSelector {
   ): ModelSelector[ModelType, EstimatorType] = {
     val modelStrings = modelTypesToUse.map(_.entryName)
     val modelsToUse =
-    // if no models are specified use the defaults and filter then by the named models to use
+    // if no models are specified use the defaults and filter by the named models to use
       if (modelsAndParameters.isEmpty) defaultModelsAndParams
         .filter{ case (e, p) => modelStrings.contains(e.getClass.getSimpleName) }
       // if models to use has been specified and the models have been specified filter the models by the names

--- a/core/src/main/scala/com/salesforce/op/stages/impl/selector/MakeSelector.scala
+++ b/core/src/main/scala/com/salesforce/op/stages/impl/selector/MakeSelector.scala
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2017, Salesforce.com, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.salesforce.op.stages.impl.selector
+
+import com.salesforce.op.evaluators.{EvaluationMetrics, OpEvaluatorBase}
+import com.salesforce.op.stages.impl.ModelsToTry
+import com.salesforce.op.stages.impl.selector.ModelSelectorNames.{EstimatorType, ModelType}
+import com.salesforce.op.stages.impl.tuning.{OpValidator, Splitter}
+import org.apache.spark.ml.param.ParamMap
+
+/**
+ * Creates the model selector class
+ */
+private[op] trait MakeSelector {
+
+  /**
+   * Subset of models to use
+   */
+  private[op] val modelNames: Seq[ModelsToTry]
+
+  /**
+   * Default models and parameters
+   * @return defaults for problem type
+   */
+  protected def defaultModelsAndParams: Seq[(EstimatorType, Array[ParamMap])]
+
+  /**
+   * Create the model selector for specified interface
+   * @param validator training split of cross validator
+   * @param splitter data prep class
+   * @param trainTestEvaluators evaluation to do on data
+   * @param modelTypesToUse list of models to use
+   * @param modelsAndParameters sequence of models and parameters to explore
+   * @return model selector with these settings
+   */
+  protected def selector(
+    validator: OpValidator[ModelType, EstimatorType],
+    splitter: Option[Splitter],
+    trainTestEvaluators: Seq[OpEvaluatorBase[_ <: EvaluationMetrics]],
+    modelTypesToUse: Seq[ModelsToTry],
+    modelsAndParameters: Seq[(EstimatorType, Array[ParamMap])]
+  ): ModelSelector[ModelType, EstimatorType] = {
+    val modelStrings = modelTypesToUse.map(_.entryName)
+    val modelsToUse =
+    // if no models are specified use the defaults and filter by the named models to use
+      if (modelsAndParameters.isEmpty) defaultModelsAndParams
+        .filter{ case (e, p) => modelStrings.contains(e.getClass.getSimpleName) }
+      // if models to use has been specified and the models have been specified filter the models by the names
+      else if (modelTypesToUse != modelNames) modelsAndParameters
+        .filter{ case (e, p) => modelStrings.contains(e.getClass.getSimpleName) }
+      // else just use the specified models
+      else modelsAndParameters
+    new ModelSelector(
+      validator = validator,
+      splitter = splitter,
+      models = modelsToUse,
+      evaluators = trainTestEvaluators
+    )
+  }
+
+}

--- a/core/src/main/scala/com/salesforce/op/stages/impl/selector/ModelSelectorFactory.scala
+++ b/core/src/main/scala/com/salesforce/op/stages/impl/selector/ModelSelectorFactory.scala
@@ -38,7 +38,7 @@ import org.apache.spark.ml.param.ParamMap
 /**
  * Creates the model selector class
  */
-private[op] trait MakeSelector {
+private[op] trait ModelSelectorFactory {
 
   /**
    * Subset of models to use


### PR DESCRIPTION
**Related issues**
Because objects are initialized on first use having the models to try defined as values in the Selector interfaces means that a different number of stages are initialized if the Selectors are used twice in the same JVM. This means that the selectors cannot be used in unit tests that save and then load the model by creating a new workflow.

**Describe the proposed solution**
Changed the values to defs for default models so the same number of stages are created every time the model selector is called
