### PR TITLE
Using MapReduce Api for Avro Read Write

### DIFF
--- a/core/src/test/scala/com/salesforce/op/ModelInsightsTest.scala
+++ b/core/src/test/scala/com/salesforce/op/ModelInsightsTest.scala
@@ -161,7 +161,7 @@ class ModelInsightsTest extends FlatSpec with PassengerSparkFixtureTest {
     insights.label.rawFeatureName shouldBe Seq(survived.name)
     insights.label.rawFeatureType shouldBe Seq(survived.typeName)
     insights.label.stagesApplied.size shouldBe 1
-    insights.label.sampleSize shouldBe Some(4.0)
+    insights.label.sampleSize shouldBe Some(5.0)
     insights.features.size shouldBe 5
     insights.features.map(_.featureName).toSet shouldEqual rawNames
     ageInsights.derivedFeatures.size shouldBe 2
@@ -213,12 +213,13 @@ class ModelInsightsTest extends FlatSpec with PassengerSparkFixtureTest {
     insights.label.rawFeatureName shouldBe Seq(survived.name)
     insights.label.rawFeatureType shouldBe Seq(survived.typeName)
     insights.label.stagesApplied.size shouldBe 1
-    insights.label.sampleSize shouldBe Some(4.0)
+    insights.label.sampleSize shouldBe Some(5.0)
     insights.features.size shouldBe 5
     insights.features.map(_.featureName).toSet shouldEqual rawNames
     ageInsights.derivedFeatures.size shouldBe 2
+    ageInsights.derivedFeatures(0).contribution.size shouldBe 1
+    ageInsights.derivedFeatures(1).contribution.size shouldBe 0
     ageInsights.derivedFeatures.foreach { f =>
-      f.contribution.size shouldBe 1
       f.corr.nonEmpty shouldBe true
       f.variance.nonEmpty shouldBe true
       f.cramersV.isEmpty shouldBe true
@@ -304,11 +305,10 @@ class ModelInsightsTest extends FlatSpec with PassengerSparkFixtureTest {
         pretty should not include(m.modelName)
       }
     }
-    pretty should include("area under precision-recall | 0.0")
+    pretty should include("area under precision-recall | 1.0")
     pretty should include("Model Evaluation Metrics")
     pretty should include("Top Model Insights")
     pretty should include("Top Positive Correlations")
-    pretty should include("Top Negative Correlations")
     pretty should include("Top Contributions")
   }
 

--- a/core/src/test/scala/com/salesforce/op/stages/OpMinMaxEstimatorReaderWriterTest.scala
+++ b/core/src/test/scala/com/salesforce/op/stages/OpMinMaxEstimatorReaderWriterTest.scala
@@ -45,7 +45,7 @@ class OpMinMaxEstimatorReaderWriterTest extends OpPipelineStageReaderWriterTest 
   val stage: OpPipelineStageBase = minMax.fit(passengersDataSet)
 
   val expected =
-    Array(1.0.toReal, Real.empty, 0.10476190476190476.toReal, 0.0.toReal, 0.2761904761904762.toReal, 0.0.toReal)
+    Array(1.0.toReal, 0.0.toReal, Real.empty, 0.10476190476190476.toReal, 0.2761904761904762.toReal, 0.0.toReal)
 }
 
 

--- a/core/src/test/scala/com/salesforce/op/stages/OpTransformerReaderWriterTest.scala
+++ b/core/src/test/scala/com/salesforce/op/stages/OpTransformerReaderWriterTest.scala
@@ -49,5 +49,5 @@ class OpTransformerReaderWriterTest extends OpPipelineStageReaderWriterTest {
       uid = UID[UnaryLambdaTransformer[_, _]]
     ).setInput(weight).setMetadata(meta)
 
-  val expected = Array(21.2248.toReal, Real.empty, 9.6252.toReal, 8.2678.toReal, 11.8464.toReal, 8.2678.toReal)
+  val expected = Array(21.2248.toReal, 8.2678.toReal, Real.empty, 9.6252.toReal, 11.8464.toReal, 8.2678.toReal)
 }

--- a/readers/src/test/scala/com/salesforce/op/readers/DataGenerationTest.scala
+++ b/readers/src/test/scala/com/salesforce/op/readers/DataGenerationTest.scala
@@ -142,7 +142,7 @@ class DataGenerationTest extends FlatSpec with PassengerSparkFixtureTest {
       Row("5", null, 2, List("Female"), 0.0, 67, "", List(1471046100),
         Map("Female" -> "string"), Map("Female" -> 1.0), Map("Female" -> false)),
       Row("6", true, null, null, 0.0, null, null, null, null, null, null),
-      Row("4", null, 50, List("Male"), 0.0, 248, "this is a description stuff stuff",
+      Row("4", null, 50, List("Male"), 0.0, 248, "stuff this is a description stuff",
         List(1471046400, 1471046400, 1471046300), Map("Male" -> "string string string"),
         Map("Male" -> 3.0), Map("Male" -> false))
     )

--- a/utils/src/main/scala/com/salesforce/op/utils/io/avro/AvroInOut.scala
+++ b/utils/src/main/scala/com/salesforce/op/utils/io/avro/AvroInOut.scala
@@ -35,11 +35,12 @@ import java.net.URI
 import com.salesforce.op.utils.spark.RichRDD._
 import org.apache.avro.Schema
 import org.apache.avro.generic.GenericRecord
-import org.apache.avro.mapred._
+import org.apache.avro.mapred.AvroKey
+import org.apache.avro.mapreduce.{AvroJob, AvroKeyInputFormat, AvroKeyOutputFormat}
 import org.apache.avro.specific.SpecificData
 import org.apache.hadoop.fs.{FileSystem, Path}
 import org.apache.hadoop.io.NullWritable
-import org.apache.hadoop.mapred.JobConf
+import org.apache.hadoop.mapreduce.Job
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.SparkSession
 
@@ -133,9 +134,9 @@ object AvroInOut {
     (implicit sc: SparkSession, ct: ClassTag[T]): RDD[T] = {
     def maybeCopy(r: T): T = if (deepCopy) SpecificData.get().deepCopy(r.getSchema, r) else r
 
-    val records = sc.sparkContext.hadoopFile(path,
-      classOf[AvroInputFormat[T]],
-      classOf[AvroWrapper[T]],
+    val records = sc.sparkContext.newAPIHadoopFile(path,
+      classOf[AvroKeyInputFormat[T]],
+      classOf[AvroKey[T]],
       classOf[NullWritable]
     )
 
@@ -153,41 +154,35 @@ object AvroInOut {
 
   implicit class AvroWriter[T <: GenericRecord](rdd: RDD[T]) {
 
-    private def createJobConfFromContext(schema: String)(implicit sc: SparkSession) = {
-      val jobConf = new JobConf(sc.sparkContext.hadoopConfiguration)
-      AvroJob.setOutputSchema(jobConf, new Schema.Parser().parse(schema))
-      jobConf
-    }
-
     /**
-     * This method writes out RDDs of generic records as avro files to path.
-     *
-     * @param path Input directory where avro records should be written.
-     * @param jobConf job config
-     * @return
-     */
-    def writeAvro(path: String)(implicit jobConf: JobConf): Unit = {
+      * This method writes out RDDs of generic records as avro files to path.
+      *
+      * @param path Input directory where avro records should be written.
+      * @param job  Job instance
+      * @return
+      */
+    def writeAvro(path: String)(implicit job: Job): Unit = {
       val avroData = rdd.map(ar => (new AvroKey(ar), NullWritable.get))
-      avroData.saveAsHadoopFile(
+      avroData.saveAsNewAPIHadoopFile(
         path,
-        classOf[AvroWrapper[GenericRecord]],
+        classOf[AvroKey[T]],
         classOf[NullWritable],
-        classOf[AvroOutputFormat[GenericRecord]],
-        jobConf
+        classOf[AvroKeyOutputFormat[T]],
+        job.getConfiguration
       )
     }
 
     /**
-     * This method writes out RDDs of generic records as avro files to path.
-     *
-     * @param path   Input directory where avro records should be written.
-     * @param schema Avro schema string for records being written out.
-     * @param sc     Spark Session
-     * @return
-     */
-    def writeAvro(path: String, schema: String)(implicit sc: SparkSession): Unit = {
-      val jobConf = createJobConfFromContext(schema)
-      writeAvro(path)(jobConf)
+      * This method writes out RDDs of generic records as avro files to path.
+      *
+      * @param path   Input directory where avro records should be written.
+      * @param schema Avro schema string for records being written out.
+      * @return
+      */
+    def writeAvro(path: String, schema: String): Unit = {
+      val job: Job = Job.getInstance()
+      AvroJob.setOutputKeySchema(job, new Schema.Parser().parse(schema))
+      writeAvro(path)(job)
     }
 
   }

--- a/utils/src/main/scala/com/salesforce/op/utils/io/avro/AvroInOut.scala
+++ b/utils/src/main/scala/com/salesforce/op/utils/io/avro/AvroInOut.scala
@@ -155,12 +155,12 @@ object AvroInOut {
   implicit class AvroWriter[T <: GenericRecord](rdd: RDD[T]) {
 
     /**
-      * This method writes out RDDs of generic records as avro files to path.
-      *
-      * @param path Input directory where avro records should be written.
-      * @param job  Job instance
-      * @return
-      */
+     * This method writes out RDDs of generic records as avro files to path.
+     *
+     * @param path Input directory where avro records should be written.
+     * @param job  Job instance
+     * @return
+     */
     def writeAvro(path: String)(implicit job: Job): Unit = {
       val avroData = rdd.map(ar => (new AvroKey(ar), NullWritable.get))
       avroData.saveAsNewAPIHadoopFile(
@@ -173,12 +173,12 @@ object AvroInOut {
     }
 
     /**
-      * This method writes out RDDs of generic records as avro files to path.
-      *
-      * @param path   Input directory where avro records should be written.
-      * @param schema Avro schema string for records being written out.
-      * @return
-      */
+     * This method writes out RDDs of generic records as avro files to path.
+     *
+     * @param path   Input directory where avro records should be written.
+     * @param schema Avro schema string for records being written out.
+     * @return
+     */
     def writeAvro(path: String, schema: String): Unit = {
       val job: Job = Job.getInstance()
       AvroJob.setOutputKeySchema(job, new Schema.Parser().parse(schema))


### PR DESCRIPTION
**Related issues**
Refer to issue(s) addressed in this pull request from [Issues]https://github.com/salesforce/TransmogrifAI/issues/134

**Describe the proposed solution**
Using Mapreduce API to read/write Avro.

**Describe alternatives you've considered**
Considered using Spark Avro, Spark Avro returns and writes DataFrames, but current implementation deals with RDD.

**Additional context**
Add any other context about the changes here.
