### PR TITLE
Ignore null values in meta + support floats

### DIFF
--- a/utils/src/main/scala/com/salesforce/op/utils/spark/RichMetadata.scala
+++ b/utils/src/main/scala/com/salesforce/op/utils/spark/RichMetadata.scala
@@ -185,6 +185,7 @@ object RichMetadata {
   private val longSeq = TypeCase[Seq[Long]]
   private val intSeq = TypeCase[Seq[Int]]
   private val doubleSeq = TypeCase[Seq[Double]]
+  private val floatSeq = TypeCase[Seq[Float]]
   private val stringSeq = TypeCase[Seq[String]]
   private val metadataSeq = TypeCase[Seq[Metadata]]
 
@@ -194,37 +195,46 @@ object RichMetadata {
    */
   implicit class RichMap(val theMap: Map[String, Any]) extends AnyVal {
 
+    /**
+     * Converts [[Map]] to [[Metadata]]
+     *
+     * @throws RuntimeException in case of unsupported value type
+     * @return [[Metadata]]
+     */
     def toMetadata: Metadata = {
       val builder = new MetadataBuilder()
       def unsupported(k: String, v: Any) =
-        throw new RuntimeException(s"Key '$k' has unsupported value type $v of type ${v.getClass.getName}")
-      def putCollection(key: String, seq: Seq[Any]): MetadataBuilder = seq match {
-        case booleanSeq(v) => builder.putBooleanArray(key, v.toArray)
-        case intSeq(v) => builder.putLongArray(key, v.map(_.toLong).toArray)
-        case longSeq(v) => builder.putLongArray(key, v.toArray)
-        case doubleSeq(v) => builder.putDoubleArray(key, v.toArray)
-        case stringSeq(v) => builder.putStringArray(key, v.toArray)
-        case metadataSeq(v) => builder.putMetadataArray(key, v.toArray)
+        throw new RuntimeException(s"Key '$k' has unsupported value $v of type ${v.getClass.getName}")
+      def putCollection(m: MetadataBuilder, key: String, seq: Seq[Any]): MetadataBuilder = seq match {
+        case booleanSeq(v) => m.putBooleanArray(key, v.toArray)
+        case intSeq(v) => m.putLongArray(key, v.map(_.toLong).toArray)
+        case longSeq(v) => m.putLongArray(key, v.toArray)
+        case doubleSeq(v) => m.putDoubleArray(key, v.toArray)
+        case floatSeq(v) => m.putDoubleArray(key, v.map(_.toDouble).toArray)
+        case stringSeq(v) => m.putStringArray(key, v.toArray)
+        case metadataSeq(v) => m.putMetadataArray(key, v.toArray)
         case _ => unsupported(key, seq)
       }
       theMap.foldLeft(builder) {
+        case (m, (_, null)) => m
+        case (m, (_, None)) => m
         case (m, (k, v: Boolean)) => m.putBoolean(k, v)
+        case (m, (k, v: Float)) => m.putDouble(k, v)
         case (m, (k, v: Double)) => m.putDouble(k, v)
         case (m, (k, v: Long)) => m.putLong(k, v)
         case (m, (k, v: Int)) => m.putLong(k, v.toLong)
         case (m, (k, v: String)) => m.putString(k, v)
         case (m, (k, v: PipelineStage)) => m.putString(k, v.getClass.getName)
         case (m, (k, v: Metadata)) => m.putMetadata(k, v)
-        case (m, (k, v: Seq[_])) => putCollection(k, v)
-        case (m, (k, v: Array[_])) => putCollection(k, v)
-        case (m, (k, v: Map[_, _])) => m.putMetadata(k, v.map { case (k, v) => k.toString -> v }.toMetadata)
-        case (m, (k, v: Option[_])) => if (v.nonEmpty) { v.get match {
-          case vt: Boolean => m.putBoolean(k, vt)
-          case vt: Double => m.putDouble(k, vt)
-          case vt: Long => m.putLong(k, vt)
-          case vt: Int => m.putLong(k, vt.toLong)
-          case vt: String => m.putString(k, vt)
-        }} else m
+        case (m, (k, v: Seq[_])) => putCollection(m, k, v)
+        case (m, (k, v: Array[_])) => putCollection(m, k, v)
+        case (m, (k, v: Map[_, _])) => m.putMetadata(k, v.map { case (key, vv) => key.toString -> vv }.toMetadata)
+        case (m, (k, Some(v: Boolean))) => m.putBoolean(k, v)
+        case (m, (k, Some(v: Float))) => m.putDouble(k, v)
+        case (m, (k, Some(v: Double))) => m.putDouble(k, v)
+        case (m, (k, Some(v: Long))) => m.putLong(k, v)
+        case (m, (k, Some(v: Int))) => m.putLong(k, v.toLong)
+        case (m, (k, Some(v: String))) => m.putString(k, v)
         case (_, (k, v)) => unsupported(k, v)
       }.build()
     }

--- a/utils/src/test/scala/com/salesforce/op/utils/spark/RichMetadataTest.scala
+++ b/utils/src/test/scala/com/salesforce/op/utils/spark/RichMetadataTest.scala
@@ -31,7 +31,7 @@
 package com.salesforce.op.utils.spark
 
 import com.salesforce.op.test.TestCommon
-import org.apache.spark.sql.types.MetadataWrapper
+import org.apache.spark.sql.types.{MetadataBuilder, MetadataWrapper}
 import org.json4s.DefaultFormats
 import org.json4s.jackson.Serialization
 import org.junit.runner.RunWith
@@ -53,7 +53,7 @@ class RichMetadataTest extends FlatSpec with TestCommon {
   private val map2 = Map(
     "1" -> 1L, "2" -> 1.0, "3" -> false, "4" -> "2",
     "5" -> Array(1L, 2L), "6" -> Array(x = true), "7" -> Array("1"), "8" -> Seq(1L), "9" -> Seq(1.0),
-    "10" -> Seq(true), "12" -> "12"
+    "10" -> Seq(true), "12" -> "12", "13" -> 11.5f
   )
 
   private val meta1 = map1.toMetadata
@@ -65,12 +65,13 @@ class RichMetadataTest extends FlatSpec with TestCommon {
   }
 
   it should "throw an error on unsupported type in a map" in {
-    the[RuntimeException] thrownBy Map("a" -> TestClass("test")).toMetadata
+    intercept[RuntimeException](Map("a" -> TestClass("test")).toMetadata).getMessage shouldBe
+      "Key 'a' has unsupported value TestClass(test) of type com.salesforce.op.utils.spark.TestClass"
   }
 
   it should "create a MetaDataWrapper with non empty map from a metadata " in {
     val wrap = meta1.wrapped
-
+    meta1.underlyingMap shouldBe wrap.underlyingMap
     wrap shouldBe a[MetadataWrapper]
     meta1.isEmpty shouldBe false
   }
@@ -79,11 +80,13 @@ class RichMetadataTest extends FlatSpec with TestCommon {
     val mergedMap = Map(
       "1" -> 2L, "2" -> 2.0, "3" -> true, "4" -> "12",
       "5" -> Array(1L, 1L, 2L), "6" -> Array(true, true), "7" -> Array("1", "1"),
-      "8" -> Seq(1L, 1L), "9" -> Seq(1.0, 1.0), "10" -> Seq(true, true), "11" -> Seq("1"), "12" -> "12"
+      "8" -> Seq(1L, 1), "9" -> Seq(1.0, 1.0f), "10" -> Seq(true, true), "11" -> Seq("1"), "12" -> "12",
+      "13" -> 11.5f
     )
 
     val mergedMetadata = meta1.deepMerge(map2.toMetadata)
     mergedMetadata.json shouldBe Serialization.write(mergedMap)
+    mergedMetadata.prettyJson shouldBe Serialization.writePretty(mergedMap)
   }
 
   it should "deep merge the Array of metadata" in {
@@ -98,7 +101,11 @@ class RichMetadataTest extends FlatSpec with TestCommon {
     the[RuntimeException] thrownBy meta1.deepMerge(Map("1" -> "test").toMetadata)
   }
 
-  it should "be false on different maps when compared using deep equals " in {
+  it should "be true on the same map when compared using deep equals" in {
+    meta1.deepEquals(meta1) shouldBe true
+  }
+
+  it should "be false on different maps when compared using deep equals" in {
     meta1.deepEquals(map2.toMetadata) shouldBe false
   }
 
@@ -116,6 +123,12 @@ class RichMetadataTest extends FlatSpec with TestCommon {
 
     richMetaDataWithSummary.getSummaryMetadata() shouldBe expectedSummaryMetadata
     richMetaDataWithSummary.containsSummaryMetadata() shouldBe true
+  }
+
+  it should "ignore empty values in maps" in {
+    Map("None" -> None, "NULL" -> null).toMetadata shouldBe new MetadataBuilder().build()
+    Map("None" -> None, "NULL" -> null, "OKKey" -> "ok!", "SomeKey" -> Some("ok")).toMetadata shouldBe
+      new MetadataBuilder().putString("OKKey", "ok!").putString("SomeKey", "ok").build()
   }
 }
 

--- a/utils/src/test/scala/com/salesforce/op/utils/spark/RichMetadataTest.scala
+++ b/utils/src/test/scala/com/salesforce/op/utils/spark/RichMetadataTest.scala
@@ -127,8 +127,8 @@ class RichMetadataTest extends FlatSpec with TestCommon {
 
   it should "ignore empty values in maps" in {
     Map("None" -> None, "NULL" -> null).toMetadata shouldBe new MetadataBuilder().build()
-    Map("None" -> None, "NULL" -> null, "OKKey" -> "ok!", "SomeKey" -> Some("ok")).toMetadata shouldBe
-      new MetadataBuilder().putString("OKKey", "ok!").putString("SomeKey", "ok").build()
+    Map("None" -> None, "NULL" -> null, "a" -> "b", "c" -> Some("d")).toMetadata shouldBe
+      new MetadataBuilder().putString("a", "b").putString("c", "d").build()
   }
 }
 


### PR DESCRIPTION
**Related issues**
Currently we fail to produce meta with maps with values of `Map("a" -> null)`, `Map("f" -> 1.2f)` and ``Map("f" -> Seq(1.2f))``

**Describe the proposed solution**
- Skipping `None`, `null` values
- Added conversion of float values to double

**Describe alternatives you've considered**
NA

**Additional context**
@msouder stumbled upon this problem while running XGBoost
