### PR TITLE
Improve test coverage for VectorsCombiner and make vector aggregator efficient 

### DIFF
--- a/core/src/main/scala/com/salesforce/op/stages/impl/feature/DecisionTreeNumericMapBucketizer.scala
+++ b/core/src/main/scala/com/salesforce/op/stages/impl/feature/DecisionTreeNumericMapBucketizer.scala
@@ -36,6 +36,7 @@ import com.salesforce.op.stages.AllowLabelAsInput
 import com.salesforce.op.stages.base.binary.{BinaryEstimator, BinaryModel}
 import com.salesforce.op.utils.spark.OpVectorColumnMetadata
 import com.salesforce.op.utils.spark.RichDataset._
+import com.salesforce.op.utils.spark.RichVector._
 import org.apache.spark.sql.Dataset
 import org.apache.spark.sql.types.Metadata
 
@@ -163,7 +164,7 @@ final class DecisionTreeNumericMapBucketizerModel[I2 <: OPMap[_]] private[op]
           input = cleanedInputMap.get(k)
         )
       }
-    VectorsCombiner.combine(vectors).toOPVector
+    combine(vectors).toOPVector
   }
 
 }

--- a/core/src/main/scala/com/salesforce/op/stages/impl/feature/OPCollectionHashingVectorizer.scala
+++ b/core/src/main/scala/com/salesforce/op/stages/impl/feature/OPCollectionHashingVectorizer.scala
@@ -36,6 +36,7 @@ import com.salesforce.op.features.types._
 import com.salesforce.op.stages.OpPipelineStageBase
 import com.salesforce.op.stages.base.sequence.SequenceTransformer
 import com.salesforce.op.utils.spark.{OpVectorColumnMetadata, OpVectorMetadata}
+import com.salesforce.op.utils.spark.RichVector._
 import org.apache.spark.ml.linalg.{DenseVector, SparseVector}
 import org.apache.spark.ml.param._
 import org.apache.spark.mllib.feature.HashingTF
@@ -265,7 +266,7 @@ private[op] trait HashingFun {
           fNameHashesWithInputs.map { case (featureNameHash, el) =>
             hasher.transform(prepare[T](el, params.hashWithIndex, params.prependFeatureName, featureNameHash)).asML
           }
-        VectorsCombiner.combine(hashedVecs).toOPVector
+        combine(hashedVecs).toOPVector
       }
     }
   }
@@ -379,7 +380,7 @@ private[op] trait MapHashingFun extends HashingFun {
               prepare[TextList](el, params.hashWithIndex, params.prependFeatureName, featureNameHash)
             ).asML
           })
-        VectorsCombiner.combine(hashedVecs.flatten).toOPVector
+        combine(hashedVecs.flatten).toOPVector
       }
     }
   }

--- a/core/src/main/scala/com/salesforce/op/stages/impl/feature/SmartTextMapVectorizer.scala
+++ b/core/src/main/scala/com/salesforce/op/stages/impl/feature/SmartTextMapVectorizer.scala
@@ -264,7 +264,8 @@ final class SmartTextMapVectorizerModel[T <: OPMap[String]] private[op]
     val textVector = hash(rowTextTokenized, keysText, args.hashingParams)
     val textNullIndicatorsVector =
       if (args.shouldTrackNulls) Seq(getNullIndicatorsVector(keysText, rowTextTokenized)) else Nil
-    VectorsCombiner.combineOP(Seq(categoricalVector, textVector) ++ textNullIndicatorsVector)
+
+    categoricalVector.combine(textVector, textNullIndicatorsVector: _*)
   }
 
   private def getNullIndicatorsVector(keysSeq: Seq[Seq[String]], inputs: Seq[Map[String, TextList]]): OPVector = {

--- a/core/src/main/scala/com/salesforce/op/stages/impl/feature/SmartTextVectorizer.scala
+++ b/core/src/main/scala/com/salesforce/op/stages/impl/feature/SmartTextVectorizer.scala
@@ -216,7 +216,7 @@ final class SmartTextVectorizerModel[T <: Text] private[op]
       val textVector: OPVector = hash[TextList](textTokens, getTextTransientFeatures, args.hashingParams)
       val textNullIndicatorsVector = if (args.shouldTrackNulls) Seq(getNullIndicatorsVector(textTokens)) else Seq.empty
 
-      VectorsCombiner.combineOP(Seq(categoricalVector, textVector) ++ textNullIndicatorsVector)
+      categoricalVector.combine(textVector, textNullIndicatorsVector: _*)
     }
   }
 

--- a/core/src/main/scala/com/salesforce/op/stages/impl/feature/VectorsCombiner.scala
+++ b/core/src/main/scala/com/salesforce/op/stages/impl/feature/VectorsCombiner.scala
@@ -81,42 +81,9 @@ class VectorsCombiner(uid: String = UID[VectorsCombiner])
 
 final class VectorsCombinerModel private[op] (operationName: String, uid: String)
   extends SequenceModel[OPVector, OPVector](operationName = operationName, uid = uid) {
-  def transformFn: Seq[OPVector] => OPVector = VectorsCombiner.combineOP
-}
-
-case object VectorsCombiner {
-
-  /**
-   * Combine multiple OP vectors into one
-   *
-   * @param vectors input vectors
-   * @return result vector
-   */
-  def combineOP(vectors: Seq[OPVector]): OPVector = {
-    new OPVector(combine(vectors.view.map(_.value)))
+  def transformFn: Seq[OPVector] => OPVector = s => s.toList match {
+    case v1 :: v2 :: tail => v1.combine(v2, tail: _*)
+    case v :: Nil => v
+    case Nil => OPVector.empty
   }
-
-  /**
-   * Combine multiple vectors into one
-   *
-   * @param vectors input vectors
-   * @return result vector
-   */
-  def combine(vectors: Seq[Vector]): Vector = {
-    val indices = ArrayBuffer.empty[Int]
-    val values = ArrayBuffer.empty[Double]
-
-    val size = vectors.foldLeft(0)((size, vector) => {
-      vector.foreachActive { case (i, v) =>
-        if (v != 0.0) {
-          indices += size + i
-          values += v
-        }
-      }
-      size + vector.size
-    })
-    Vectors.sparse(size, indices.toArray, values.toArray).compressed
-  }
-
 }
-

--- a/core/src/test/scala/com/salesforce/op/stages/impl/feature/SmartTextVectorizerTest.scala
+++ b/core/src/test/scala/com/salesforce/op/stages/impl/feature/SmartTextVectorizerTest.scala
@@ -91,7 +91,7 @@ class SmartTextVectorizerTest
     val textRes = transformed.collect(textVectorized)
     assertNominal(fieldText, Array.fill(textRes.head.value.size)(false), textRes)
     val (smart, expected) = result.map { case (smartVector, categoricalVector, textVector, nullVector) =>
-      val combined = VectorsCombiner.combineOP(Seq(categoricalVector, textVector, nullVector))
+      val combined = categoricalVector.combine(textVector, nullVector)
       smartVector -> combined
     }.unzip
 
@@ -139,7 +139,7 @@ class SmartTextVectorizerTest
     val textRes = transformed.collect(textVectorized)
     assertNominal(fieldText, Array.fill(textRes.head.value.size)(false), textRes)
     val (smart, expected) = result.map { case (smartVector, textVector, nullVector) =>
-      val combined = VectorsCombiner.combineOP(Seq(textVector, nullVector))
+      val combined = textVector.combine(nullVector)
       smartVector -> combined
     }.unzip
 

--- a/core/src/test/scala/com/salesforce/op/stages/impl/feature/VectorsCombinerTest.scala
+++ b/core/src/test/scala/com/salesforce/op/stages/impl/feature/VectorsCombinerTest.scala
@@ -48,7 +48,7 @@ class VectorsCombinerTest
   extends OpEstimatorSpec[OPVector, SequenceModel[OPVector, OPVector], VectorsCombiner]
     with PassengerSparkFixtureTest {
 
-  override def specName = classOf[VectorsCombiner].getSimpleName
+  override def specName: String = classOf[VectorsCombiner].getSimpleName
 
   val (inputData, f1, f2) = TestFeatureBuilder(Seq(
     Vectors.sparse(4, Array(0, 3), Array(1.0, 1.0)).toOPVector ->

--- a/features/src/main/scala/com/salesforce/op/aggregators/MonoidAggregatorDefaults.scala
+++ b/features/src/main/scala/com/salesforce/op/aggregators/MonoidAggregatorDefaults.scala
@@ -53,7 +53,7 @@ object MonoidAggregatorDefaults {
 
     val aggregator = weakTypeOf[O] match {
       // Vector
-      case wt if wt =:= weakTypeOf[OPVector] => UnionVector
+      case wt if wt =:= weakTypeOf[OPVector] => CombineVector
 
       // Lists
       case wt if wt =:= weakTypeOf[TextList] => ConcatTextList

--- a/features/src/main/scala/com/salesforce/op/aggregators/OPVector.scala
+++ b/features/src/main/scala/com/salesforce/op/aggregators/OPVector.scala
@@ -45,5 +45,16 @@ case object CombineVector
     with AggregatorDefaults[OPVector] {
   implicit val ttag = weakTypeTag[OPVector]
   val ftFactory = FeatureTypeFactory[OPVector]()
-  val monoid: Monoid[Vector] = Monoid.from(Vectors.zeros(0))((v1: Vector, v2: Vector) => v1.combine(v2))
+  val monoid: Monoid[Vector] = Monoid.from(Vectors.zeros(0))(_ combine _)
+}
+
+/**
+* Aggregator that gives the sum of Vector data
+*/
+case object SumVector
+  extends MonoidAggregator[Event[OPVector], Vector, OPVector]
+    with AggregatorDefaults[OPVector] {
+  implicit val ttag = weakTypeTag[OPVector]
+  val ftFactory = FeatureTypeFactory[OPVector]()
+  val monoid: Monoid[Vector] = Monoid.from(Vectors.zeros(0))(_ + _)
 }

--- a/features/src/main/scala/com/salesforce/op/aggregators/OPVector.scala
+++ b/features/src/main/scala/com/salesforce/op/aggregators/OPVector.scala
@@ -32,6 +32,7 @@ package com.salesforce.op.aggregators
 
 import com.salesforce.op.features.types._
 import com.twitter.algebird._
+import com.salesforce.op.utils.spark.RichVector._
 import org.apache.spark.ml.linalg.{Vector, Vectors}
 
 import scala.reflect.runtime.universe._
@@ -39,12 +40,10 @@ import scala.reflect.runtime.universe._
 /**
  * Aggregator that gives the union of Vector data
  */
-case object UnionVector
+case object CombineVector
   extends MonoidAggregator[Event[OPVector], Vector, OPVector]
     with AggregatorDefaults[OPVector] {
   implicit val ttag = weakTypeTag[OPVector]
   val ftFactory = FeatureTypeFactory[OPVector]()
-  val monoid: Monoid[Vector] = Monoid.from(Vectors.zeros(0))((v1: Vector, v2: Vector) =>
-    Vectors.dense(v1.toArray ++ v2.toArray)
-  )
+  val monoid: Monoid[Vector] = Monoid.from(Vectors.zeros(0))((v1: Vector, v2: Vector) => v1.combine(v2))
 }

--- a/features/src/main/scala/com/salesforce/op/features/types/OPVector.scala
+++ b/features/src/main/scala/com/salesforce/op/features/types/OPVector.scala
@@ -30,6 +30,7 @@
 
 package com.salesforce.op.features.types
 
+import com.salesforce.op.utils.spark.RichVector._
 import org.apache.spark.ml.linalg._
 
 /**
@@ -39,8 +40,37 @@ import org.apache.spark.ml.linalg._
  */
 class OPVector(val value: Vector) extends OPCollection {
   type Value = Vector
+
   final def isEmpty: Boolean = value.size == 0
+
+  /**
+   * Add vectors
+   *
+   * @param that another vector
+   * @throws IllegalArgumentException if the vectors have different sizes
+   * @return vector addition
+   */
+  def +(that: OPVector): OPVector = (value + that.value).toOPVector
+
+  /**
+   * Subtract vectors
+   *
+   * @param that another vector
+   * @throws IllegalArgumentException if the vectors have different sizes
+   * @return vector subtraction
+   */
+  def -(that: OPVector): OPVector = (value - that.value).toOPVector
+
+  /**
+   * Combine multiple vectors into one
+   *
+   * @param that  another vector
+   * @param other other vectors
+   * @return result vector
+   */
+  def combine(that: OPVector, other: OPVector*): OPVector = value.combine(that.value, other.map(_.value): _*).toOPVector
 }
+
 object OPVector {
   def apply(value: Vector): OPVector = new OPVector(value)
   def empty: OPVector = FeatureTypeDefaults.OPVector

--- a/features/src/main/scala/com/salesforce/op/features/types/OPVector.scala
+++ b/features/src/main/scala/com/salesforce/op/features/types/OPVector.scala
@@ -62,6 +62,15 @@ class OPVector(val value: Vector) extends OPCollection {
   def -(that: OPVector): OPVector = (value - that.value).toOPVector
 
   /**
+   * Dot product between vectors
+   *
+   * @param that another vector
+   * @throws IllegalArgumentException if the vectors have different sizes
+   * @return dot product
+   */
+  def dot(that: OPVector): Double = value dot that.value
+
+  /**
    * Combine multiple vectors into one
    *
    * @param that  another vector

--- a/features/src/main/scala/com/salesforce/op/utils/spark/RichVector.scala
+++ b/features/src/main/scala/com/salesforce/op/utils/spark/RichVector.scala
@@ -67,6 +67,20 @@ object RichVector {
     }
 
     /**
+     * Dot product between vectors
+     *
+     * @param that another vector
+     * @throws IllegalArgumentException if the vectors have different sizes
+     * @return dot product
+     */
+    def dot(that: Vector): Double = {
+      require(v.size == that.size,
+        s"Vectors must have the same length: a.length == b.length (${v.size} != ${that.size})"
+      )
+      v.toBreeze dot that.toBreeze
+    }
+
+    /**
      * Combine multiple vectors into one
      *
      * @param that  another vector

--- a/features/src/main/scala/com/salesforce/op/utils/spark/RichVector.scala
+++ b/features/src/main/scala/com/salesforce/op/utils/spark/RichVector.scala
@@ -31,7 +31,9 @@
 package com.salesforce.op.utils.spark
 
 import breeze.linalg.{DenseVector => BreezeDenseVector, SparseVector => BreezeSparseVector, Vector => BreezeVector}
-import org.apache.spark.ml.linalg.{DenseVector, SparseVector, Vector}
+import org.apache.spark.ml.linalg.{DenseVector, SparseVector, Vector, Vectors}
+
+import scala.collection.mutable.ArrayBuffer
 
 /**
  * [[org.apache.spark.ml.linalg.Vector]] enrichment functions
@@ -65,6 +67,16 @@ object RichVector {
     }
 
     /**
+     * Combine multiple vectors into one
+     *
+     * @param that  another vector
+     * @param other other vectors
+     * @return result vector
+     */
+    def combine(that: Vector, other: Vector*): Vector =
+      com.salesforce.op.utils.spark.RichVector.combine(v +: that +: other)
+
+    /**
      * Convert to [[breeze.linalg.Vector]]
      *
      * @return [[breeze.linalg.Vector]]
@@ -83,6 +95,28 @@ object RichVector {
       case d: BreezeDenseVector[Double]@unchecked => new DenseVector(d.data)
     }
 
+  }
+
+  /**
+   * Combine multiple vectors into one
+   *
+   * @param vectors input vectors
+   * @return result vector
+   */
+  def combine(vectors: Seq[Vector]): Vector = {
+    val indices = ArrayBuffer.empty[Int]
+    val values = ArrayBuffer.empty[Double]
+
+    val size = vectors.foldLeft(0)((size, vector) => {
+      vector.foreachActive { case (i, v) =>
+        if (v != 0.0) {
+          indices += size + i
+          values += v
+        }
+      }
+      size + vector.size
+    })
+    Vectors.sparse(size, indices.toArray, values.toArray).compressed
   }
 
 }

--- a/features/src/test/scala/com/salesforce/op/aggregators/MonoidAggregatorDefaultsTest.scala
+++ b/features/src/test/scala/com/salesforce/op/aggregators/MonoidAggregatorDefaultsTest.scala
@@ -523,6 +523,16 @@ class MonoidAggregatorDefaultsTest extends FlatSpec with TestCommon {
     assertDefaultAggr(vectorTestSeq, Vectors.dense(Array(0.1, 0.2, 1.0, 0.2)))
   }
 
+  Spec(SumVector.getClass) should "work" in {
+    val vectors = Seq(Array(0.1, 0.2), Array(1.0, -1.5), Array(0.2, 0.0)).map(Vectors.dense(_).toOPVector)
+    assertAggr(SumVector, vectors, Vectors.dense(Array(1.3, -1.3)))
+  }
+  it should "error on vectors of invalid sizes" in {
+    val vectors = Seq(Array(0.1, 0.2), Array(1.0)).map(Vectors.dense(_).toOPVector)
+    intercept[IllegalArgumentException](assertAggr(SumVector, vectors, Vectors.zeros(0))).getMessage shouldBe
+      "requirement failed: Vectors must have same length: x.length == y.length (1 != 2)"
+  }
+
   Spec[CustomMonoidAggregator[_]] should "work" in {
     val customAgg = new CustomMonoidAggregator[Real](zero = None, associativeFn = (r1, r2) => (r1 -> r2).map(_ + _))
     assertAggr(customAgg, realTestSeq, Option(doubleBase.flatten.sum))

--- a/features/src/test/scala/com/salesforce/op/aggregators/MonoidAggregatorDefaultsTest.scala
+++ b/features/src/test/scala/com/salesforce/op/aggregators/MonoidAggregatorDefaultsTest.scala
@@ -519,7 +519,7 @@ class MonoidAggregatorDefaultsTest extends FlatSpec with TestCommon {
     assertDefaultAggr(multiPickListMapTestSeq, expectedRes)
   }
 
-  Spec(UnionVector.getClass) should "work" in {
+  Spec(CombineVector.getClass) should "work" in {
     assertDefaultAggr(vectorTestSeq, Vectors.dense(Array(0.1, 0.2, 1.0, 0.2)))
   }
 

--- a/features/src/test/scala/com/salesforce/op/features/types/OPVectorTest.scala
+++ b/features/src/test/scala/com/salesforce/op/features/types/OPVectorTest.scala
@@ -49,7 +49,7 @@ class OPVectorTest extends FlatSpec with TestCommon {
   )
 
   Spec[OPVector] should "be empty" in {
-    val zero =  Vectors.zeros(0)
+    val zero = Vectors.zeros(0)
     new OPVector(zero).isEmpty shouldBe true
     new OPVector(zero).nonEmpty shouldBe false
     zero.toOPVector shouldBe a[OPVector]

--- a/features/src/test/scala/com/salesforce/op/features/types/OPVectorTest.scala
+++ b/features/src/test/scala/com/salesforce/op/features/types/OPVectorTest.scala
@@ -55,7 +55,17 @@ class OPVectorTest extends FlatSpec with TestCommon {
     zero.toOPVector shouldBe a[OPVector]
   }
 
-  it should "compare values correctly" in {
+  it should "error on size mismatch" in {
+    val ones = Array.fill(vectors.size)(Vectors.sparse(1, Array(0), Array(1.0)).toOPVector)
+    for {
+      (v1, v2) <- vectors.zip(ones)
+      res <- Seq(() => v1 + v2, () => v1 - v2, () => v1 dot v2)
+    } intercept[IllegalArgumentException](res()).getMessage should {
+      startWith("requirement failed: Vectors must") and include("same length")
+    }
+  }
+
+  it should "compare values" in {
     val zero = Vectors.zeros(0)
     new OPVector(zero) shouldBe new OPVector(zero)
     new OPVector(zero).value shouldBe zero
@@ -68,19 +78,25 @@ class OPVectorTest extends FlatSpec with TestCommon {
     OPVector.empty shouldBe new OPVector(zero)
   }
 
-  it should "'+' add correctly" in {
+  it should "'+' add" in {
     for {(v1, v2) <- vectors.zip(vectors)} {
       (v1 + v2) shouldBe (v1.value + v2.value).toOPVector
     }
   }
 
-  it should "'-' subtract correctly" in {
+  it should "'-' subtract" in {
     for {(v1, v2) <- vectors.zip(vectors)} {
       (v1 - v2) shouldBe (v1.value - v2.value).toOPVector
     }
   }
 
-  it should "combine correctly" in {
+  it should "compute dot product" in {
+    for {(v1, v2) <- vectors.zip(vectors)} {
+      (v1 dot v2) shouldBe (v1.value dot v2.value)
+    }
+  }
+
+  it should "combine" in {
     for {(v1, v2) <- vectors.zip(vectors)} {
       v1.combine(v2) shouldBe v1.value.combine(v2.value).toOPVector
       v1.combine(v2, v2, v1) shouldBe v1.value.combine(v2.value, v2.value, v1.value).toOPVector

--- a/features/src/test/scala/com/salesforce/op/features/types/OPVectorTest.scala
+++ b/features/src/test/scala/com/salesforce/op/features/types/OPVectorTest.scala
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2017, Salesforce.com, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.salesforce.op.features.types
+
+import com.salesforce.op.test.TestCommon
+import com.salesforce.op.utils.spark.RichVector._
+import org.apache.spark.ml.linalg.Vectors
+import org.junit.runner.RunWith
+import org.scalatest.FlatSpec
+import org.scalatest.junit.JUnitRunner
+
+
+@RunWith(classOf[JUnitRunner])
+class OPVectorTest extends FlatSpec with TestCommon {
+
+  val vectors = Seq(
+    Vectors.sparse(4, Array(0, 3), Array(1.0, 1.0)).toOPVector,
+    Vectors.dense(Array(2.0, 3.0, 4.0)).toOPVector,
+    // Purposely added a very large sparse vector to verify the efficiency
+    Vectors.sparse(100000000, Array(1), Array(777.0)).toOPVector
+  )
+
+  Spec[OPVector] should "be empty" in {
+    val zero =  Vectors.zeros(0)
+    new OPVector(zero).isEmpty shouldBe true
+    new OPVector(zero).nonEmpty shouldBe false
+    zero.toOPVector shouldBe a[OPVector]
+  }
+
+  it should "compare values correctly" in {
+    val zero = Vectors.zeros(0)
+    new OPVector(zero) shouldBe new OPVector(zero)
+    new OPVector(zero).value shouldBe zero
+
+    Vectors.dense(Array(1.0, 2.0)).toOPVector shouldBe Vectors.dense(Array(1.0, 2.0)).toOPVector
+    Vectors.sparse(5, Array(3, 4), Array(1.0, 2.0)).toOPVector shouldBe
+      Vectors.sparse(5, Array(3, 4), Array(1.0, 2.0)).toOPVector
+    Vectors.dense(Array(1.0, 2.0)).toOPVector should not be Vectors.dense(Array(2.0, 2.0)).toOPVector
+    new OPVector(Vectors.dense(Array(1.0, 2.0))) should not be Vectors.dense(Array(2.0, 2.0)).toOPVector
+    OPVector.empty shouldBe new OPVector(zero)
+  }
+
+  it should "'+' add correctly" in {
+    for {(v1, v2) <- vectors.zip(vectors)} {
+      (v1 + v2) shouldBe (v1.value + v2.value).toOPVector
+    }
+  }
+
+  it should "'-' subtract correctly" in {
+    for {(v1, v2) <- vectors.zip(vectors)} {
+      (v1 - v2) shouldBe (v1.value - v2.value).toOPVector
+    }
+  }
+
+  it should "combine correctly" in {
+    for {(v1, v2) <- vectors.zip(vectors)} {
+      v1.combine(v2) shouldBe v1.value.combine(v2.value).toOPVector
+      v1.combine(v2, v2, v1) shouldBe v1.value.combine(v2.value, v2.value, v1.value).toOPVector
+    }
+  }
+
+}


### PR DESCRIPTION
**Related issues**
1. `UnionVector` monoid aggregator is not efficient for sparse vectors.
2. `VectorsCombiner` stage has incomplete functional test coverage.

**Describe the proposed solution**
1. Moved `VectorsCombiner.combine` method to `RichVector` object
2. Added `OpEstimatorSpec` base class to `VectorsCombinerTest` to improve the functional test coverage
3. Added `+`, `-`, `dot`,`combine` methods to `OPVector` + test `OPVectorTest`
4. Added `combine` method to `RichVector` + tests
5. Renamed `UnionVector` monoid aggregator to `CombineVector` and made use of `RichVector.combine` at reduve
6. Bonus: added `SumVector` monoid aggregator

**Describe alternatives you've considered**
I could relocate `VectorsCombiner.combine` as-is to `utils` subproject, but it felt valuable enough to add `+`, `-`,`dot` and `combine` to `OPVector` as well.
