### PR TITLE
Mt/fd type

### DIFF
--- a/core/src/main/scala/com/salesforce/op/OpWorkflow.scala
+++ b/core/src/main/scala/com/salesforce/op/OpWorkflow.scala
@@ -537,7 +537,7 @@ class OpWorkflow(val uid: String = UID[OpWorkflow]) extends OpWorkflowCore {
     rawFeatureFilter = Option {
       new RawFeatureFilter(
         trainingReader = training.get,
-        scoreReader = scoringReader,
+        scoringReader = scoringReader,
         bins = bins,
         minFill = minFillRate,
         maxFillDifference = maxFillDifference,

--- a/core/src/main/scala/com/salesforce/op/OpWorkflowCore.scala
+++ b/core/src/main/scala/com/salesforce/op/OpWorkflowCore.scala
@@ -32,7 +32,7 @@ package com.salesforce.op
 
 import com.salesforce.op.utils.stages.FitStagesUtil._
 import com.salesforce.op.utils.stages.FitStagesUtil
-import com.salesforce.op.features.OPFeature
+import com.salesforce.op.features.{FeatureDistributionType, OPFeature}
 import com.salesforce.op.features.types.FeatureType
 import com.salesforce.op.filters.FeatureDistribution
 import com.salesforce.op.readers.{CustomReader, Reader, ReaderKey}
@@ -195,10 +195,24 @@ private[op] trait OpWorkflowCore {
   final def getParameters(): OpParams = parameters
 
   /**
-   * Get raw feature distribution information computed during raw feature filter
+   * Get raw feature distribution information computed on training and scoring data during raw feature filter
    * @return sequence of feature distribution information
    */
   final def getRawFeatureDistributions(): Array[FeatureDistribution] = rawFeatureDistributions
+
+  /**
+   * Get raw feature distribution information computed on training data during raw feature filter
+   * @return sequence of feature distribution information
+   */
+  final def getRawTrainingFeatureDistributions(): Array[FeatureDistribution] =
+    rawFeatureDistributions.filter(_.`type` == FeatureDistributionType.Training)
+
+  /**
+   * Get raw feature distribution information computed on scoring data during raw feature filter
+   * @return sequence of feature distribution information
+   */
+  final def getRawScoringFeatureDistributions(): Array[FeatureDistribution] =
+    rawFeatureDistributions.filter(_.`type` == FeatureDistributionType.Scoring)
 
   /**
    * Determine if any of the raw features do not have a matching reader

--- a/core/src/main/scala/com/salesforce/op/OpWorkflowModelReader.scala
+++ b/core/src/main/scala/com/salesforce/op/OpWorkflowModelReader.scala
@@ -32,10 +32,9 @@ package com.salesforce.op
 
 import com.salesforce.op.OpWorkflowModelReadWriteShared.FieldNames._
 import com.salesforce.op.features.{FeatureJsonHelper, OPFeature, TransientFeature}
-import com.salesforce.op.stages.{OpPipelineStageReader, _}
-import OpPipelineStageReadWriteShared._
 import com.salesforce.op.filters.FeatureDistribution
-import com.salesforce.op.utils.json.JsonUtils
+import com.salesforce.op.stages.OpPipelineStageReadWriteShared._
+import com.salesforce.op.stages.{OpPipelineStageReader, _}
 import org.apache.spark.ml.util.MLReader
 import org.json4s.JsonAST.{JArray, JNothing, JValue}
 import org.json4s.jackson.JsonMethods.parse
@@ -158,7 +157,7 @@ class OpWorkflowModelReader(val workflow: OpWorkflow) extends MLReader[OpWorkflo
   private def resolveRawFeatureDistributions(json: JValue): Try[Array[FeatureDistribution]] = {
     if ((json \ RawFeatureDistributions.entryName) != JNothing) { // for backwards compatibility
       val distString = (json \ RawFeatureDistributions.entryName).extract[String]
-      JsonUtils.fromString[Array[FeatureDistribution]](distString)
+      FeatureDistribution.fromJson(distString)
     } else {
       Success(Array.empty[FeatureDistribution])
     }

--- a/core/src/main/scala/com/salesforce/op/OpWorkflowModelWriter.scala
+++ b/core/src/main/scala/com/salesforce/op/OpWorkflowModelWriter.scala
@@ -31,8 +31,8 @@
 package com.salesforce.op
 
 import com.salesforce.op.features.FeatureJsonHelper
+import com.salesforce.op.filters.FeatureDistribution
 import com.salesforce.op.stages.{OpPipelineStageBase, OpPipelineStageWriter}
-import com.salesforce.op.utils.json.JsonUtils
 import enumeratum._
 import org.apache.hadoop.fs.Path
 import org.apache.spark.ml.util.MLWriter
@@ -81,8 +81,7 @@ class OpWorkflowModelWriter(val model: OpWorkflowModel) extends MLWriter {
       (FN.AllFeatures.entryName -> allFeaturesJArray) ~
       (FN.Parameters.entryName -> model.parameters.toJson(pretty = false)) ~
       (FN.TrainParameters.entryName -> model.trainingParams.toJson(pretty = false)) ~
-      (FN.RawFeatureDistributions.entryName -> JsonUtils.toJsonString(model.getRawFeatureDistributions(),
-        pretty = false))
+      (FN.RawFeatureDistributions.entryName -> FeatureDistribution.toJson(model.getRawFeatureDistributions()))
   }
 
   private def resultFeaturesJArray(): JArray =

--- a/core/src/main/scala/com/salesforce/op/filters/AllFeatureInformation.scala
+++ b/core/src/main/scala/com/salesforce/op/filters/AllFeatureInformation.scala
@@ -43,7 +43,8 @@ package com.salesforce.op.filters
  *                               2nd level keys correspond to predictor keys with values being
  *                               null-label leakage corr. value
  */
-private[op] case class AllFeatureInformation(
+private[op] case class AllFeatureInformation
+(
   responseSummaries: Map[FeatureKey, Summary],
   responseDistributions: Array[FeatureDistribution],
   predictorSummaries: Map[FeatureKey, Summary],

--- a/core/src/main/scala/com/salesforce/op/filters/AllFeatureInformation.scala
+++ b/core/src/main/scala/com/salesforce/op/filters/AllFeatureInformation.scala
@@ -34,17 +34,19 @@ package com.salesforce.op.filters
  * Contains all feature distribution summaries and null label-leakage correlations used to
  * determine dropped features in [[RawFeatureFilter]].
  *
- * @param responseSummaries response summaries
- * @param responseDistributions response distributions
- * @param predictorSummaries predictor summaries
+ * @param responseSummaries      response summaries
+ * @param responseDistributions  response distributions
+ * @param predictorSummaries     predictor summaries
  * @param predictorDistributions predictor distributions
- * @param correlationInfo null label-leakage correlation map
- *                        1st level keys correspond to response keys
- *                        2nd level keys correspond to predictor keys with values being null-label leakage corr. value
+ * @param correlationInfo        null label-leakage correlation map
+ *                               1st level keys correspond to response keys
+ *                               2nd level keys correspond to predictor keys with values being
+ *                               null-label leakage corr. value
  */
 private[op] case class AllFeatureInformation(
-    responseSummaries: Map[FeatureKey, Summary],
-    responseDistributions: Array[FeatureDistribution],
-    predictorSummaries: Map[FeatureKey, Summary],
-    predictorDistributions: Array[FeatureDistribution],
-    correlationInfo: Map[FeatureKey, Map[FeatureKey, Double]])
+  responseSummaries: Map[FeatureKey, Summary],
+  responseDistributions: Array[FeatureDistribution],
+  predictorSummaries: Map[FeatureKey, Summary],
+  predictorDistributions: Array[FeatureDistribution],
+  correlationInfo: Map[FeatureKey, Map[FeatureKey, Double]]
+)

--- a/core/src/main/scala/com/salesforce/op/filters/FeatureDistribution.scala
+++ b/core/src/main/scala/com/salesforce/op/filters/FeatureDistribution.scala
@@ -82,7 +82,6 @@ case class FeatureDistribution
     )
     check("Name", name, fd.name)
     check("Key", key, fd.key)
-    check("Type", `type`, fd.`type`)
   }
 
   /**
@@ -103,7 +102,7 @@ case class FeatureDistribution
     val combinedDist = distribution + fd.distribution
     // summary info can be empty or min max if hist is empty but should otherwise match so take the longest info
     val combinedSummary = if (summaryInfo.length > fd.summaryInfo.length) summaryInfo else fd.summaryInfo
-    FeatureDistribution(name, key, count + fd.count, nulls + fd.nulls, combinedDist, combinedSummary)
+    FeatureDistribution(name, key, count + fd.count, nulls + fd.nulls, combinedDist, combinedSummary, `type`)
   }
 
   /**
@@ -150,13 +149,13 @@ case class FeatureDistribution
 
   override def toString(): String = {
     val valStr = Seq(
+      "type" -> `type`.toString,
       "name" -> name,
       "key" -> key,
       "count" -> count.toString,
       "nulls" -> nulls.toString,
       "distribution" -> distribution.mkString("[", ",", "]"),
-      "summaryInfo" -> summaryInfo.mkString("[", ",", "]"),
-      "type" -> `type`.toString
+      "summaryInfo" -> summaryInfo.mkString("[", ",", "]")
     ).map { case (n, v) => s"$n = $v" }.mkString(", ")
 
     s"${getClass.getSimpleName}($valStr)"
@@ -226,7 +225,7 @@ object FeatureDistribution {
       value.map(seq => 0L -> histValues(seq, summary, bins, textBinsFormula))
         .getOrElse(1L -> (Array(summary.min, summary.max, summary.sum, summary.count) -> new Array[Double](bins)))
 
-    new FeatureDistribution(
+    FeatureDistribution(
       name = name,
       key = key,
       count = 1L,

--- a/core/src/main/scala/com/salesforce/op/filters/FeatureDistribution.scala
+++ b/core/src/main/scala/com/salesforce/op/filters/FeatureDistribution.scala
@@ -30,23 +30,30 @@
 
 package com.salesforce.op.filters
 
-import com.salesforce.op.features.FeatureDistributionLike
+import java.util.Objects
+
+import com.salesforce.op.features.{FeatureDistributionLike, FeatureDistributionType}
 import com.salesforce.op.stages.impl.feature.{HashAlgorithm, Inclusion, NumericBucketizer}
+import com.salesforce.op.utils.json.EnumEntrySerializer
 import com.twitter.algebird.Monoid._
 import com.twitter.algebird.Operators._
 import com.twitter.algebird.Semigroup
 import org.apache.spark.mllib.feature.HashingTF
+import org.json4s.jackson.Serialization
+import org.json4s.{DefaultFormats, Formats}
+
+import scala.util.Try
 
 /**
  * Class containing summary information for a feature
  *
- * @param name name of the feature
- * @param key map key associated with distribution (when the feature is a map)
- * @param count total count of feature seen
- * @param nulls number of empties seen in feature
+ * @param name         name of the feature
+ * @param key          map key associated with distribution (when the feature is a map)
+ * @param count        total count of feature seen
+ * @param nulls        number of empties seen in feature
  * @param distribution binned counts of feature values (hashed for strings, evenly spaced bins for numerics)
- * @param summaryInfo either min and max number of tokens for text data,
- *                    or splits used for bins for numeric data
+ * @param summaryInfo  either min and max number of tokens for text data, or splits used for bins for numeric data
+ * @param `type`       feature distribution type: training or scoring
  */
 case class FeatureDistribution
 (
@@ -55,7 +62,8 @@ case class FeatureDistribution
   count: Long,
   nulls: Long,
   distribution: Array[Double],
-  summaryInfo: Array[Double]
+  summaryInfo: Array[Double],
+  `type`: FeatureDistributionType = FeatureDistributionType.Training
 ) extends FeatureDistributionLike {
 
   /**
@@ -68,8 +76,9 @@ case class FeatureDistribution
    *
    * @param fd distribution to compare to
    */
-  def checkMatch(fd: FeatureDistribution): Unit =
-    require(name == fd.name && key == fd.key, "Name and key must match to compare or combine FeatureDistribution")
+  private def checkMatch(fd: FeatureDistribution): Unit =
+    require(name == fd.name && key == fd.key && `type` == fd.`type`,
+      "Name, key and type must match to compare or combine FeatureDistribution")
 
   /**
    * Get fill rate of feature
@@ -135,11 +144,29 @@ case class FeatureDistribution
   }
 
   override def toString(): String = {
-    s"Name=$name, Key=$key, Count=$count, Nulls=$nulls, Histogram=${distribution.toList}, BinInfo=${summaryInfo.toList}"
+    val valStr = Seq(
+      "name" -> name,
+      "key" -> key,
+      "count" -> count.toString,
+      "nulls" -> nulls.toString,
+      "distribution" -> distribution.mkString("[", ",", "]"),
+      "summaryInfo" -> summaryInfo.mkString("[", ",", "]"),
+      "type" -> `type`.toString
+    ).map { case (n, v) => s"$n = $v" }.mkString(", ")
+
+    s"${getClass.getSimpleName}($valStr)"
   }
+
+  override def equals(that: Any): Boolean = that match {
+    case FeatureDistribution(`name`, `key`, `count`, `nulls`, d, s, `type`) =>
+      distribution.deep == d.deep && summaryInfo.deep == s.deep
+    case _ => false
+  }
+
+  override def hashCode(): Int = Objects.hashCode(name, key, count, nulls, distribution, summaryInfo, `type`)
 }
 
-private[op] object FeatureDistribution {
+object FeatureDistribution {
 
   val MaxBins = 100000
 
@@ -147,45 +174,68 @@ private[op] object FeatureDistribution {
     override def plus(l: FeatureDistribution, r: FeatureDistribution) = l.reduce(r)
   }
 
+  implicit val formats: Formats = DefaultFormats +
+    EnumEntrySerializer.json4s[FeatureDistributionType](FeatureDistributionType)
+
+  /**
+   * Feature distributions to json
+   *
+   * @param fd feature distributions
+   * @return json array
+   */
+  def toJson(fd: Array[FeatureDistribution]): String = Serialization.write[Array[FeatureDistribution]](fd)
+
+  /**
+   * Feature distributions from json
+   *
+   * @param json feature distributions json
+   * @return feature distributions array
+   */
+  def fromJson(json: String): Try[Array[FeatureDistribution]] = Try {
+    Serialization.read[Array[FeatureDistribution]](json)
+  }
+
   /**
    * Facilitates feature distribution retrieval from computed feature summaries
    *
-   * @param featureKey feature key
-   * @param summary feature summary
-   * @param value optional processed sequence
-   * @param bins number of histogram bins
+   * @param featureKey      feature key
+   * @param summary         feature summary
+   * @param value           optional processed sequence
+   * @param bins            number of histogram bins
    * @param textBinsFormula formula to compute the text features bin size.
    *                        Input arguments are [[Summary]] and number of bins to use in computing feature distributions
    *                        (histograms for numerics, hashes for strings). Output is the bins for the text features.
-   * @return a pair consisting of response and predictor feature distributions (in this order)
+   * @param `type`          feature distribution type: training or scoring
    * @return feature distribution given the provided information
    */
-  def apply(
+  private[op] def apply(
     featureKey: FeatureKey,
     summary: Summary,
     value: Option[ProcessedSeq],
     bins: Int,
     textBinsFormula: (Summary, Int) => Int
   ): FeatureDistribution = {
-    val (nullCount, (summaryInfo, distribution)): (Int, (Array[Double], Array[Double])) =
-      value.map(seq => 0 -> histValues(seq, summary, bins, textBinsFormula))
-        .getOrElse(1 -> (Array(summary.min, summary.max, summary.sum, summary.count) -> new Array[Double](bins)))
+    val (name, key) = featureKey
+    val (nullCount, (summaryInfo, distribution)) =
+      value.map(seq => 0L -> histValues(seq, summary, bins, textBinsFormula))
+        .getOrElse(1L -> (Array(summary.min, summary.max, summary.sum, summary.count) -> new Array[Double](bins)))
 
     FeatureDistribution(
-      name = featureKey._1,
-      key = featureKey._2,
-      count = 1,
+      name = name,
+      key = key,
+      count = 1L,
       nulls = nullCount,
       summaryInfo = summaryInfo,
-      distribution = distribution)
+      distribution = distribution
+    )
   }
 
   /**
    * Function to put data into histogram of counts
    *
-   * @param values  values to bin
-   * @param summary summary info for feature (max, min, etc)
-   * @param bins    number of bins to produce
+   * @param values          values to bin
+   * @param summary         summary info for feature (max, min, etc)
+   * @param bins            number of bins to produce
    * @param textBinsFormula formula to compute the text features bin size.
    *                        Input arguments are [[Summary]] and number of bins to use in computing feature distributions
    *                        (histograms for numerics, hashes for strings). Output is the bins for the text features.

--- a/core/src/main/scala/com/salesforce/op/filters/PreparedFeatures.scala
+++ b/core/src/main/scala/com/salesforce/op/filters/PreparedFeatures.scala
@@ -40,14 +40,15 @@ import org.apache.spark.mllib.linalg.{DenseVector, SparseVector, Vector, Vectors
 import org.apache.spark.sql.Row
 
 /**
- * Class representing processed reponses and predictors keyed by their respective feature key
+ * Class representing processed responses and predictors keyed by their respective feature key
  *
  * @param responses prepared responses
  * @param predictors prepared predictors
  */
 private[filters] case class PreparedFeatures(
     responses: Map[FeatureKey, ProcessedSeq],
-    predictors: Map[FeatureKey, ProcessedSeq]) {
+    predictors: Map[FeatureKey, ProcessedSeq]
+) {
 
   /**
    * Computes summaries keyed by feature keys for this observation.

--- a/core/src/main/scala/com/salesforce/op/filters/PreparedFeatures.scala
+++ b/core/src/main/scala/com/salesforce/op/filters/PreparedFeatures.scala
@@ -45,7 +45,8 @@ import org.apache.spark.sql.Row
  * @param responses prepared responses
  * @param predictors prepared predictors
  */
-private[filters] case class PreparedFeatures(
+private[filters] case class PreparedFeatures
+(
   responses: Map[FeatureKey, ProcessedSeq],
   predictors: Map[FeatureKey, ProcessedSeq]
 ) {

--- a/core/src/main/scala/com/salesforce/op/filters/RawFeatureFilter.scala
+++ b/core/src/main/scala/com/salesforce/op/filters/RawFeatureFilter.scala
@@ -379,7 +379,7 @@ object RawFeatureFilter {
  * @param cleanedData          RFF cleaned data
  * @param featuresToDrop       raw features dropped by RFF
  * @param mapKeysToDrop        keys in map features dropped by RFF
- * @param featureDistributions the feature distributions calculated from the training data
+ * @param featureDistributions the feature distributions calculated from the training and scoring data
  */
 case class FilteredRawData
 (

--- a/core/src/main/scala/com/salesforce/op/filters/RawFeatureFilter.scala
+++ b/core/src/main/scala/com/salesforce/op/filters/RawFeatureFilter.scala
@@ -33,7 +33,6 @@ package com.salesforce.op.filters
 import com.salesforce.op.OpParams
 import com.salesforce.op.features.types._
 import com.salesforce.op.features.{OPFeature, TransientFeature}
-import com.salesforce.op.filters.FeatureDistribution._
 import com.salesforce.op.filters.Summary._
 import com.salesforce.op.readers.{DataFrameFieldNames, Reader}
 import com.salesforce.op.stages.impl.feature.TimePeriod
@@ -130,7 +129,8 @@ class RawFeatureFilter[T]
   private[op] def computeFeatureStats(
     data: DataFrame,
     features: Array[OPFeature],
-    allFeatureInfo: Option[AllFeatureInformation] = None): AllFeatureInformation = {
+    allFeatureInfo: Option[AllFeatureInformation] = None
+  ): AllFeatureInformation = {
     val (responses, predictors): (Array[TransientFeature], Array[TransientFeature]) = {
       val (allResponses, allPredictors) = features.partition(_.isResponse)
       val respOut = allResponses.map(TransientFeature(_)).flatMap {
@@ -182,7 +182,8 @@ class RawFeatureFilter[T]
       responseDistributions = responseDistributions,
       predictorSummaries = predictorSummaries,
       predictorDistributions = predictorDistributions,
-      correlationInfo = correlationInfo)
+      correlationInfo = correlationInfo
+    )
   }
 
   /**

--- a/core/src/test/resources/log4j.properties
+++ b/core/src/test/resources/log4j.properties
@@ -13,8 +13,9 @@ log4j.logger.org.eclipse.jetty=ERROR
 # Hadoop
 log4j.logger.org.apache.parquet.hadoop=WARN
 
-# Spark Avro
+# Avro
 log4j.logger.com.databricks.spark.avro=WARN
+log4j.logger.org.apache.avro.mapreduce.AvroKeyInputFormat=ERROR
 
 # TransmogrifAI logging
 log4j.logger.com.salesforce.op=ERROR

--- a/core/src/test/scala/com/salesforce/op/ModelInsightsTest.scala
+++ b/core/src/test/scala/com/salesforce/op/ModelInsightsTest.scala
@@ -30,9 +30,8 @@
 
 package com.salesforce.op
 
-import com.salesforce.op.features.Feature
-import com.salesforce.op._
-import com.salesforce.op.features.types.{PickList, Real, RealNN}
+import com.salesforce.op.features.types._
+import com.salesforce.op.features.{Feature, FeatureDistributionType}
 import com.salesforce.op.filters.FeatureDistribution
 import com.salesforce.op.stages.impl.classification.{BinaryClassificationModelSelector, BinaryClassificationModelsToTry, MultiClassificationModelSelector, OpLogisticRegression}
 import com.salesforce.op.stages.impl.preparators._
@@ -40,8 +39,7 @@ import com.salesforce.op.stages.impl.regression.{OpLinearRegression, RegressionM
 import com.salesforce.op.stages.impl.selector.ModelSelectorNames.EstimatorType
 import com.salesforce.op.stages.impl.selector.SelectedModel
 import com.salesforce.op.stages.impl.selector.ValidationType._
-import com.salesforce.op.stages.impl.selector.{ModelEvaluation, ProblemType, SelectedModel, ValidationType}
-import com.salesforce.op.stages.impl.tuning.{DataCutter, DataSplitter, SplitterSummary}
+import com.salesforce.op.stages.impl.tuning.{DataCutter, DataSplitter}
 import com.salesforce.op.test.PassengerSparkFixtureTest
 import com.salesforce.op.utils.spark.{OpVectorColumnMetadata, OpVectorMetadata}
 import org.apache.spark.ml.param.ParamMap
@@ -520,11 +518,19 @@ class ModelInsightsTest extends FlatSpec with PassengerSparkFixtureTest {
     val wfRawFeatureDistributions = modelWithRFF.getRawFeatureDistributions()
     val wfDistributionsGrouped = wfRawFeatureDistributions.groupBy(_.name)
 
-    /*
-    Currently, raw features that aren't explicitly blacklisted, but are not used because they are inputs to
-    explicitly blacklisted features are not present as raw features in the model, nor in ModelInsights. For example,
-    weight is explicitly blacklisted here, which means that height will not be added as a raw feature even though
-    it's not explicitly blacklisted itself.
+    val trainingDistributions = modelWithRFF.getRawTrainingFeatureDistributions()
+    trainingDistributions.foreach(d => d.`type` shouldBe FeatureDistributionType.Training)
+
+    val scoringDistributions = modelWithRFF.getRawScoringFeatureDistributions()
+    scoringDistributions.foreach(d => d.`type` shouldBe FeatureDistributionType.Scoring)
+
+    trainingDistributions ++ scoringDistributions shouldBe wfRawFeatureDistributions
+
+    /**
+     * Currently, raw features that aren't explicitly blacklisted, but are not used because they are inputs to
+     * explicitly blacklisted features are not present as raw features in the model, nor in ModelInsights. For example,
+     * weight is explicitly blacklisted here, which means that height will not be added as a raw feature even though
+     * it's not explicitly blacklisted itself.
      */
     val insights = modelWithRFF.modelInsights(predWithMaps)
     insights.features.foreach(f =>

--- a/core/src/test/scala/com/salesforce/op/OpWorkflowTest.scala
+++ b/core/src/test/scala/com/salesforce/op/OpWorkflowTest.scala
@@ -163,20 +163,23 @@ class OpWorkflowTest extends FlatSpec with PassengerSparkFixtureTest {
         trainingReader = Option(dataReader),
         scoringReader = None,
         minFillRate = 0.7,
-        protectedFeatures = Array(height, weight))
+        protectedFeatures = Array(height, weight)
+      )
 
     val wfM = wf.train()
-    wf.rawFeatures.foreach{ f =>
+    wf.rawFeatures.foreach { f =>
       f.distributions.nonEmpty shouldBe true
       f.name shouldEqual f.distributions.head.name
     }
-    wfM.rawFeatures.foreach{ f =>
+    wfM.rawFeatures.foreach { f =>
       f.distributions.nonEmpty shouldBe true
       f.name shouldEqual f.distributions.head.name
     }
     wf.getRawFeatureDistributions().length shouldBe 13
+    wf.getRawTrainingFeatureDistributions() shouldBe wf.getRawFeatureDistributions()
+    wf.getRawScoringFeatureDistributions().length shouldBe 0 // since the scoringReader is not set
     val data = wfM.score()
-    data.schema.fields.size shouldBe 3
+    data.schema.fields.length shouldBe 3
     val Array(whyNotNormed2, prob2) = wfM.getUpdatedFeatures(Array(whyNotNormed, pred))
     data.select(whyNotNormed2.name, prob2.name).count() shouldBe 6
   }
@@ -240,8 +243,8 @@ class OpWorkflowTest extends FlatSpec with PassengerSparkFixtureTest {
     val pred = BinaryClassificationModelSelector().setInput(survivedNum, fv).getOutput()
     val wf = new OpWorkflow()
       .setResultFeatures(pred)
-      .withRawFeatureFilter( Option(dataReader), Option(simpleReader),
-        maxFillRatioDiff = 1.0 ) // only height and the female key of maps should meet this criteria
+      .withRawFeatureFilter(Option(dataReader), Option(simpleReader),
+        maxFillRatioDiff = 1.0) // only height and the female key of maps should meet this criteria
     val data = wf.computeDataUpTo(weight)
 
     data.schema.fields.map(_.name).toSet shouldEqual

--- a/core/src/test/scala/com/salesforce/op/features/FeaturesTest.scala
+++ b/core/src/test/scala/com/salesforce/op/features/FeaturesTest.scala
@@ -40,7 +40,7 @@ import org.scalatest.junit.JUnitRunner
 import scala.util.{Failure, Success}
 
 
-// scalastyle:off
+// scalastyle:off indentation
 @RunWith(classOf[JUnitRunner])
 class FeaturesTest extends WordSpec with PassengerFeaturesTest with TestCommon {
 
@@ -85,30 +85,6 @@ class FeaturesTest extends WordSpec with PassengerFeaturesTest with TestCommon {
         numericMap.name shouldBe "numericMap"
         booleanMap.name shouldBe "booleanMap"
         survived.name shouldBe "survived"
-
-        /* The features below are the outputs of estimators or transformers which will not actually be fit until fit method
-       * is called somewhere in the pipeline
-       */
-        // simple interaction transformation syntax
-        // Full transformer would look like:
-        // val density = DivideTransformer.setNumerator(weight).setDenominator(height).getOutput
-        //  val density = weight / height
-        //
-        //  // Full transformer would look like:
-        //  // pivotedGender = PivotEstimator.setPivotSize(2).setInputCol(gender) // gender.pivot()
-        //  val pivotedGender = new PivotEstimator.setPivotSize(2).setInputCol(gender)
-        //
-        //  val boardedDaysAgo = new DaysAgoTransformer.setInputCol(boarded)
-        //
-        //  // have all normalizations be part of one transformer
-        //  val normedAge = new NormEstimator.setNormType(NormTypes.range).setInputCol(age)
-        //
-        //  // allow pivots into bins by correlation with label
-        //  val stringMapPivot = new PivotEstimator.setPivotSize(3).setCorrelatedWith(survived).setInputCol(stringMap)
-        //
-        //  val descriptionHash = new HashTransformer.setNumberHashes(5).setInputCol(description)
-        //
-        //  val survivedNumeric = new NumericTransformer.setInputCol(survived)
       }
       "can be changed" in {
         val foo = (age + height).alias
@@ -200,19 +176,19 @@ class FeaturesTest extends WordSpec with PassengerFeaturesTest with TestCommon {
           val summaryInfo: Array[Double] = Array(0.5)
           val name: String = age.name
           val key: Option[String] = None
+          val `type` = FeatureDistributionType.Training
         }
+        age.distributions shouldBe Nil
         val newAge = age.withDistributions(Seq(distrib))
         newAge.name shouldEqual age.name
         newAge.isResponse shouldEqual age.isResponse
         newAge.originStage shouldEqual age.originStage
         newAge.parents shouldEqual age.parents
         newAge.uid shouldEqual age.uid
-        newAge.distributions.length shouldEqual 1
-        newAge.distributions.head shouldEqual distrib
+        newAge.distributions shouldBe Seq(distrib)
       }
     }
     // TODO: test other feature methods
-
   }
 
 }

--- a/core/src/test/scala/com/salesforce/op/features/FeaturesTest.scala
+++ b/core/src/test/scala/com/salesforce/op/features/FeaturesTest.scala
@@ -169,7 +169,7 @@ class FeaturesTest extends WordSpec with PassengerFeaturesTest with TestCommon {
     }
     "with distributions" should {
       "make a copy of the feature containing the specified distributions" in {
-        val distrib = new FeatureDistributionLike {
+        val distrib1 = new FeatureDistributionLike {
           val count: Long = 1L
           val nulls: Long = 1L
           val distribution: Array[Double] = Array(0.5)
@@ -178,14 +178,25 @@ class FeaturesTest extends WordSpec with PassengerFeaturesTest with TestCommon {
           val key: Option[String] = None
           val `type` = FeatureDistributionType.Training
         }
+        val distrib2 = new FeatureDistributionLike {
+          val count: Long = 1L
+          val nulls: Long = 1L
+          val distribution: Array[Double] = Array(0.5)
+          val summaryInfo: Array[Double] = Array(0.5)
+          val name: String = age.name
+          val key: Option[String] = None
+          val `type` = FeatureDistributionType.Scoring
+        }
         age.distributions shouldBe Nil
-        val newAge = age.withDistributions(Seq(distrib))
+        val newAge = age.withDistributions(Seq(distrib1, distrib2))
         newAge.name shouldEqual age.name
         newAge.isResponse shouldEqual age.isResponse
         newAge.originStage shouldEqual age.originStage
         newAge.parents shouldEqual age.parents
         newAge.uid shouldEqual age.uid
-        newAge.distributions shouldBe Seq(distrib)
+        newAge.distributions shouldBe Seq(distrib1, distrib2)
+        newAge.trainingDistributions shouldBe Seq(distrib1)
+        newAge.scoringDistributions shouldBe Seq(distrib2)
       }
     }
     // TODO: test other feature methods

--- a/core/src/test/scala/com/salesforce/op/filters/FeatureDistributionTest.scala
+++ b/core/src/test/scala/com/salesforce/op/filters/FeatureDistributionTest.scala
@@ -223,8 +223,8 @@ class FeatureDistributionTest extends FlatSpec with PassengerSparkFixtureTest wi
       "requirement failed: Name must match to compare or combine feature distributions: A != boo"
 
     intercept[IllegalArgumentException](
-      fd1.relativeFillRatio(fd1.copy(`type` = FeatureDistributionType.Scoring))) should have message
-      "requirement failed: Type must match to compare or combine feature distributions: Training != Scoring"
+      fd1.relativeFillRatio(fd1.copy(key = Some("zz")))) should have message
+      "requirement failed: Key must match to compare or combine feature distributions: A != zz"
 
     intercept[IllegalArgumentException](fd1.relativeFillRate(fd1.copy(key = Some("k")))) should have message
       "requirement failed: Key must match to compare or combine feature distributions: None != Some(k)"

--- a/core/src/test/scala/com/salesforce/op/filters/RawFeatureFilterTest.scala
+++ b/core/src/test/scala/com/salesforce/op/filters/RawFeatureFilterTest.scala
@@ -31,14 +31,11 @@
 package com.salesforce.op.filters
 
 import com.salesforce.op.OpParams
-import com.salesforce.op.features.{FeatureDistributionType, OPFeature, TransientFeature}
+import com.salesforce.op.features.{FeatureDistributionType, OPFeature}
 import com.salesforce.op.readers.DataFrameFieldNames
-import com.salesforce.op.stages.impl.feature.HashAlgorithm
 import com.salesforce.op.test.{Passenger, PassengerSparkFixtureTest}
 import com.salesforce.op.utils.spark.RichDataset._
 import com.twitter.algebird.Operators._
-import org.apache.spark.mllib.feature.HashingTF
-import org.apache.spark.sql.DataFrame
 import org.junit.runner.RunWith
 import org.scalatest.FlatSpec
 import org.scalatest.junit.JUnitRunner
@@ -88,8 +85,7 @@ class RawFeatureFilterTest extends FlatSpec with PassengerSparkFixtureTest with 
   it should "correctly determine which features to exclude based on the stats of training fill rate" in {
     // only fill rate matters
     val filter = new RawFeatureFilter(simpleReader, Some(dataReader), 10, 0.2, 1.0, Double.PositiveInfinity, 1.0, 1.0)
-    val (excludedTrainF, excludedTrainMK) =
-      filter.getFeaturesToExclude(trainSummaries, Seq.empty, Map.empty)
+    val (excludedTrainF, excludedTrainMK) = filter.getFeaturesToExclude(trainSummaries, Seq.empty, Map.empty)
     excludedTrainF.toSet shouldEqual Set("B", "D")
     excludedTrainMK.keySet shouldEqual Set("C")
     excludedTrainMK.head._2 shouldEqual Set("2")
@@ -99,8 +95,7 @@ class RawFeatureFilterTest extends FlatSpec with PassengerSparkFixtureTest with 
     // only fill rate matters
 
     val filter = new RawFeatureFilter(simpleReader, Some(dataReader), 10, 0.2, 1.0, Double.PositiveInfinity, 1.0, 1.0)
-    val (excludedBothF, excludedBothMK) =
-      filter.getFeaturesToExclude(trainSummaries, scoreSummaries, Map.empty)
+    val (excludedBothF, excludedBothMK) = filter.getFeaturesToExclude(trainSummaries, scoreSummaries, Map.empty)
     excludedBothF.toSet shouldEqual Set("B", "D")
     excludedBothMK.keySet shouldEqual Set("C")
     excludedBothMK.head._2 shouldEqual Set("2")
@@ -109,8 +104,7 @@ class RawFeatureFilterTest extends FlatSpec with PassengerSparkFixtureTest with 
   it should "correctly determine which features to exclude based on the stats of relative fill rate" in {
     // relative fill rate matters
     val filter2 = new RawFeatureFilter(simpleReader, Some(dataReader), 10, 0.0, 0.5, Double.PositiveInfinity, 1.0, 1.0)
-    val (excludedBothRelF, excludedBothRelMK) =
-      filter2.getFeaturesToExclude(trainSummaries, scoreSummaries, Map.empty)
+    val (excludedBothRelF, excludedBothRelMK) = filter2.getFeaturesToExclude(trainSummaries, scoreSummaries, Map.empty)
     excludedBothRelF.toSet shouldEqual Set("A")
     excludedBothRelMK.isEmpty shouldBe true
   }
@@ -137,8 +131,7 @@ class RawFeatureFilterTest extends FlatSpec with PassengerSparkFixtureTest with 
   it should "correctly determine which features to exclude based on all the stats" in {
     // all
     val filter4 = new RawFeatureFilter(simpleReader, Some(dataReader), 10, 0.1, 0.5, Double.PositiveInfinity, 0.5, 1.0)
-    val (excludedBothAllF, excludedBothAllMK) =
-      filter4.getFeaturesToExclude(trainSummaries, scoreSummaries, Map.empty)
+    val (excludedBothAllF, excludedBothAllMK) = filter4.getFeaturesToExclude(trainSummaries, scoreSummaries, Map.empty)
     excludedBothAllF.toSet shouldEqual Set("A", "B", "C", "D")
     excludedBothAllMK.isEmpty shouldBe true
   }
@@ -208,7 +201,8 @@ class RawFeatureFilterTest extends FlatSpec with PassengerSparkFixtureTest with 
       maxFillRatioDiff = Double.PositiveInfinity,
       maxJSDivergence = 0.0,
       maxCorrelation = 1.0,
-      jsDivergenceProtectedFeatures = Set(boardedTime.name, boardedTimeAsDateTime.name))
+      jsDivergenceProtectedFeatures = Set(boardedTime.name, boardedTimeAsDateTime.name)
+    )
 
     val filteredRawData = filter.generateFilteredRaw(features, params)
     filteredRawData.featuresToDrop.toSet shouldEqual Set(age, gender, height, weight, description, boarded)

--- a/core/src/test/scala/com/salesforce/op/filters/RawFeatureFilterTest.scala
+++ b/core/src/test/scala/com/salesforce/op/filters/RawFeatureFilterTest.scala
@@ -106,7 +106,7 @@ class RawFeatureFilterTest extends FlatSpec with PassengerSparkFixtureTest with 
     val filter2 = new RawFeatureFilter(simpleReader, Some(dataReader), 10, 0.0, 0.5, Double.PositiveInfinity, 1.0, 1.0)
     val (excludedBothRelF, excludedBothRelMK) = filter2.getFeaturesToExclude(trainSummaries, scoreSummaries, Map.empty)
     excludedBothRelF.toSet shouldEqual Set("A")
-    excludedBothRelMK.isEmpty shouldBe true
+    excludedBothRelMK shouldBe empty
   }
 
   it should "correctly determine which features to exclude based on the stats of fill rate ratio" in {
@@ -115,7 +115,7 @@ class RawFeatureFilterTest extends FlatSpec with PassengerSparkFixtureTest with 
     val (excludedBothRelFR, excludedBothRelMKR) =
       filter4.getFeaturesToExclude(trainSummaries, scoreSummaries, Map.empty)
     excludedBothRelFR.toSet shouldEqual Set("D", "A", "B")
-    excludedBothRelMKR.isEmpty shouldBe true
+    excludedBothRelMKR shouldBe empty
   }
 
   it should "correctly determine which features to exclude based on the stats of js distance" in {
@@ -133,7 +133,7 @@ class RawFeatureFilterTest extends FlatSpec with PassengerSparkFixtureTest with 
     val filter4 = new RawFeatureFilter(simpleReader, Some(dataReader), 10, 0.1, 0.5, Double.PositiveInfinity, 0.5, 1.0)
     val (excludedBothAllF, excludedBothAllMK) = filter4.getFeaturesToExclude(trainSummaries, scoreSummaries, Map.empty)
     excludedBothAllF.toSet shouldEqual Set("A", "B", "C", "D")
-    excludedBothAllMK.isEmpty shouldBe true
+    excludedBothAllMK shouldBe empty
   }
 
   it should "correctly clean the dataframe returned and give the features to blacklist" in {
@@ -143,8 +143,8 @@ class RawFeatureFilterTest extends FlatSpec with PassengerSparkFixtureTest with 
       Array(survPred, age, gender, height, weight, description, boarded, stringMap, numericMap, booleanMap)
     val filter = new RawFeatureFilter(dataReader, Some(simpleReader), 10, 0.0, 1.0, Double.PositiveInfinity, 1.0, 1.0)
     val filteredRawData = filter.generateFilteredRaw(features, params)
-    filteredRawData.featuresToDrop.isEmpty shouldBe true
-    filteredRawData.mapKeysToDrop.isEmpty shouldBe true
+    filteredRawData.featuresToDrop shouldBe empty
+    filteredRawData.mapKeysToDrop shouldBe empty
     filteredRawData.cleanedData.schema.fields should contain theSameElementsAs passengersDataSet.schema.fields
 
     val filter1 = new RawFeatureFilter(dataReader, Some(simpleReader), 10, 0.5, 0.5, Double.PositiveInfinity, 1.0, 1.0)
@@ -163,7 +163,7 @@ class RawFeatureFilterTest extends FlatSpec with PassengerSparkFixtureTest with 
       Array(survived, age, gender, height, weight, description, boarded, stringMap, numericMap, booleanMap)
     val filter = new RawFeatureFilter(dataReader, Some(simpleReader), 10, 0.5, 0.5, Double.PositiveInfinity, 1.0, 1.0)
     val filteredRawData = filter.generateFilteredRaw(features, params)
-    filteredRawData.featuresToDrop.isEmpty shouldBe true
+    filteredRawData.featuresToDrop shouldBe empty
     filteredRawData.cleanedData.schema.fields should contain theSameElementsAs passengersDataSet.schema.fields
     filteredRawData.cleanedData.collect(stringMap)
       .foreach(m => if (m.nonEmpty) m.value.keySet shouldEqual Set("Female"))
@@ -258,11 +258,12 @@ class RawFeatureFilterTest extends FlatSpec with PassengerSparkFixtureTest with 
     val params = new OpParams()
     val features: Array[OPFeature] =
       Array(survived, age, gender, height, weight, description, boarded, stringMap, numericMap, booleanMap)
-    val FilteredRawData(df, dropped, droppedKeyValue, _) =
+    val FilteredRawData(df, dropped, droppedKeyValue, featureDistributions) =
       getFilter(maxCorrelation).generateFilteredRaw(features, params)
 
     dropped should contain theSameElementsAs expectedDropped
     droppedKeyValue should contain theSameElementsAs expectedDroppedMapKeys
+
     df.schema.fields.map(_.name) should contain theSameElementsAs
       DataFrameFieldNames.KeyFieldName +: features.diff(dropped).map(_.name)
     if (expectedMapKeys.nonEmpty) {

--- a/core/src/test/scala/com/salesforce/op/filters/RawFeatureFilterTest.scala
+++ b/core/src/test/scala/com/salesforce/op/filters/RawFeatureFilterTest.scala
@@ -31,7 +31,7 @@
 package com.salesforce.op.filters
 
 import com.salesforce.op.OpParams
-import com.salesforce.op.features.{OPFeature, TransientFeature}
+import com.salesforce.op.features.{FeatureDistributionType, OPFeature, TransientFeature}
 import com.salesforce.op.readers.DataFrameFieldNames
 import com.salesforce.op.stages.impl.feature.HashAlgorithm
 import com.salesforce.op.test.{Passenger, PassengerSparkFixtureTest}
@@ -45,11 +45,12 @@ import org.scalatest.junit.JUnitRunner
 
 @RunWith(classOf[JUnitRunner])
 class RawFeatureFilterTest extends FlatSpec with PassengerSparkFixtureTest with FiltersTestData {
+
   Spec[RawFeatureFilter[_]] should "compute feature stats correctly" in {
     val features: Array[OPFeature] =
       Array(survived, age, gender, height, weight, description, boarded, stringMap, numericMap, booleanMap)
     val filter = new RawFeatureFilter(simpleReader, Some(dataReader), 10, 0.1, 0.8, Double.PositiveInfinity, 0.7, 1.0)
-    val allFeatureInfo = filter.computeFeatureStats(passengersDataSet, features)
+    val allFeatureInfo = filter.computeFeatureStats(passengersDataSet, features, FeatureDistributionType.Training)
 
     allFeatureInfo.responseSummaries.size shouldBe 1
     allFeatureInfo.responseSummaries.headOption.map(_._2) shouldEqual Option(Summary(0, 1, 1, 2))
@@ -200,7 +201,7 @@ class RawFeatureFilterTest extends FlatSpec with PassengerSparkFixtureTest with 
       Array(survived, age, gender, height, weight, description, boarded, boardedTime, boardedTimeAsDateTime)
     val filter = new RawFeatureFilter(
       trainingReader = dataReader,
-      scoreReader = Some(simpleReader),
+      scoringReader = Some(simpleReader),
       bins = 10,
       minFill = 0.0,
       maxFillDifference = 1.0,
@@ -252,7 +253,7 @@ class RawFeatureFilterTest extends FlatSpec with PassengerSparkFixtureTest with 
   ): Unit = {
     def getFilter(maxCorrelation: Double): RawFeatureFilter[Passenger] = new RawFeatureFilter(
       trainingReader = dataReader,
-      scoreReader = Some(simpleReader),
+      scoringReader = Some(simpleReader),
       bins = 10,
       minFill = 0.0,
       maxFillDifference = 1.0,

--- a/features/src/main/scala/com/salesforce/op/aggregators/OPVector.scala
+++ b/features/src/main/scala/com/salesforce/op/aggregators/OPVector.scala
@@ -31,8 +31,8 @@
 package com.salesforce.op.aggregators
 
 import com.salesforce.op.features.types._
-import com.twitter.algebird._
 import com.salesforce.op.utils.spark.RichVector._
+import com.twitter.algebird._
 import org.apache.spark.ml.linalg.{Vector, Vectors}
 
 import scala.reflect.runtime.universe._
@@ -49,8 +49,8 @@ case object CombineVector
 }
 
 /**
-* Aggregator that gives the sum of Vector data
-*/
+ * Aggregator that gives the sum of Vector data
+ */
 case object SumVector
   extends MonoidAggregator[Event[OPVector], Vector, OPVector]
     with AggregatorDefaults[OPVector] {

--- a/features/src/main/scala/com/salesforce/op/features/FeatureDistributionLike.scala
+++ b/features/src/main/scala/com/salesforce/op/features/FeatureDistributionLike.scala
@@ -75,8 +75,6 @@ trait FeatureDistributionLike {
 
 }
 
-
-
 /**
  *Feature Distribution Type
  */

--- a/features/src/main/scala/com/salesforce/op/features/FeatureDistributionLike.scala
+++ b/features/src/main/scala/com/salesforce/op/features/FeatureDistributionLike.scala
@@ -30,6 +30,8 @@
 
 package com.salesforce.op.features
 
+import enumeratum._
+
 
 /**
  * Keeps the distribution information for features
@@ -62,7 +64,26 @@ trait FeatureDistributionLike {
   val distribution: Array[Double]
 
   /**
-   *  either min and max number of tokens for text data, or number of splits used for bins for numeric data
+   * either min and max number of tokens for text data, or number of splits used for bins for numeric data
    */
   val summaryInfo: Array[Double]
+
+  /**
+   * feature distribution type: training or scoring
+   */
+  val `type`: FeatureDistributionType
+
+}
+
+
+
+/**
+ *Feature Distribution Type
+ */
+sealed trait FeatureDistributionType extends EnumEntry with Serializable
+
+object FeatureDistributionType extends Enum[FeatureDistributionType] {
+  val values = findValues
+  case object Training extends FeatureDistributionType
+  case object Scoring extends FeatureDistributionType
 }

--- a/features/src/main/scala/com/salesforce/op/features/FeatureLike.scala
+++ b/features/src/main/scala/com/salesforce/op/features/FeatureLike.scala
@@ -161,11 +161,16 @@ trait FeatureLike[O <: FeatureType] {
   final override def hashCode: Int = uid.hashCode
 
   final override def toString: String = {
-    val oid = Option(originStage).map(_.uid).orNull
-    val pids = parents.map(_.uid).mkString("[", ",", "]")
-    s"${this.getClass.getSimpleName}(" +
-      s"name = $name, uid = $uid, isResponse = $isResponse, originStage = $oid, parents = $pids," +
-      s" distributions = ${distributions})"
+    val valStr = Seq(
+      "name" -> name,
+      "uid" -> uid,
+      "isResponse" -> name,
+      "originStage" -> Option(originStage).map(_.uid).orNull,
+      "parents" -> parents.map(_.uid).mkString("[", ",", "]"),
+      "distributions" -> distributions.map(_.toString).mkString("[", ",", "]")
+    ).map { case (n, v) => s"$n = $v" }.mkString(", ")
+
+    s"${getClass.getSimpleName}($valStr)"
   }
 
   /**

--- a/features/src/main/scala/com/salesforce/op/features/FeatureLike.scala
+++ b/features/src/main/scala/com/salesforce/op/features/FeatureLike.scala
@@ -73,11 +73,6 @@ trait FeatureLike[O <: FeatureType] {
   val parents: Seq[OPFeature]
 
   /**
-   * The distribution information of the feature (is a sequence because map features have distribution for each key)
-   */
-  val distributions: Seq[FeatureDistributionLike]
-
-  /**
    * Weak type tag of the feature type O
    */
   implicit val wtt: WeakTypeTag[O]
@@ -86,6 +81,26 @@ trait FeatureLike[O <: FeatureType] {
    * A handy logger instance
    */
   @transient protected lazy val log = LoggerFactory.getLogger(this.getClass)
+
+  /**
+   * The distribution information of the feature
+   * (is a sequence because map features have distribution for each key)
+   */
+  val distributions: Seq[FeatureDistributionLike]
+
+  /**
+   * The distribution information of the feature computed during training
+   * (is a sequence because map features have distribution for each key)
+   */
+  final def trainingDistributions: Seq[FeatureDistributionLike] =
+    distributions.filter(_.`type` == FeatureDistributionType.Training)
+
+  /**
+   * The distribution information of the feature computed during scoring
+   * (is a sequence because map features have distribution for each key)
+   */
+  final def scoringDistributions: Seq[FeatureDistributionLike] =
+    distributions.filter(_.`type` == FeatureDistributionType.Scoring)
 
   /**
    * Check whether this feature's type [[O]] is a subtype of the given feature type [[T]]

--- a/features/src/main/scala/com/salesforce/op/features/types/OPVector.scala
+++ b/features/src/main/scala/com/salesforce/op/features/types/OPVector.scala
@@ -41,6 +41,11 @@ import org.apache.spark.ml.linalg._
 class OPVector(val value: Vector) extends OPCollection {
   type Value = Vector
 
+  /**
+   * Is vector empty
+   *
+   * @return true if empty, false otherwise
+   */
   final def isEmpty: Boolean = value.size == 0
 
   /**

--- a/helloworld/src/main/resources/log4j.properties
+++ b/helloworld/src/main/resources/log4j.properties
@@ -35,6 +35,9 @@ log4j.logger.breeze.optimize=FATAL
 # BLAS & LAPACK
 log4j.logger.com.github.fommil.netlib=ERROR
 
+# Avro
+log4j.logger.org.apache.avro.mapreduce.AvroKeyInputFormat=ERROR
+
 # TransmogrifAI logging
 log4j.logger.com.salesforce.op=INFO
 log4j.logger.com.salesforce.op.utils.spark.OpSparkListener=OFF

--- a/local/src/test/resources/log4j.properties
+++ b/local/src/test/resources/log4j.properties
@@ -13,8 +13,9 @@ log4j.logger.org.eclipse.jetty=ERROR
 # Hadoop
 log4j.logger.org.apache.parquet.hadoop=WARN
 
-# Spark Avro
+# Avro
 log4j.logger.com.databricks.spark.avro=WARN
+log4j.logger.org.apache.avro.mapreduce.AvroKeyInputFormat=ERROR
 
 # TransmogrifAI logging
 log4j.logger.com.salesforce.op=ERROR

--- a/readers/src/test/resources/log4j.properties
+++ b/readers/src/test/resources/log4j.properties
@@ -10,5 +10,19 @@ log4j.logger.Remoting=ERROR
 # Ignore messages below warning level from Jetty, because it's a bit verbose
 log4j.logger.org.eclipse.jetty=ERROR
 
+# Hadoop
+log4j.logger.org.apache.parquet.hadoop=WARN
+
+# Avro
+log4j.logger.com.databricks.spark.avro=WARN
+log4j.logger.org.apache.avro.mapreduce.AvroKeyInputFormat=ERROR
+
 # TransmogrifAI logging
 log4j.logger.com.salesforce.op=ERROR
+log4j.logger.com.salesforce.op.utils.spark.OpSparkListener=OFF
+
+# Breeze
+log4j.logger.breeze.optimize=ERROR
+
+# BLAS & LAPACK
+log4j.logger.com.github.fommil.netlib=ERROR

--- a/utils/src/main/scala/com/salesforce/op/utils/io/avro/AvroInOut.scala
+++ b/utils/src/main/scala/com/salesforce/op/utils/io/avro/AvroInOut.scala
@@ -174,7 +174,7 @@ object AvroInOut {
      * @return
      */
     def writeAvro(path: String, schema: String)
-                 (implicit job: Job = Job.getInstance(rdd.sparkContext.hadoopConfiguration)): Unit = {
+      (implicit job: Job = Job.getInstance(rdd.sparkContext.hadoopConfiguration)): Unit = {
       AvroJob.setOutputKeySchema(job, new Schema.Parser().parse(schema))
       writeAvro(path)(job)
     }


### PR DESCRIPTION
**Related issues**
Scoring feature distributions are not exposed from `RawFeatureFilter`

**Describe the proposed solution**
Return training and scoring feature distributions in single collection from `RawFeatureFilter`, but add a type to distinguish between them.

- Added `type` enum field for `FeatureDistribution` with `Training` and `Scoring` possible values.
- Made sure OpWorkflow can read / write old feature distributions (without the `type`).
- Added tests

**Describe alternatives you've considered**
Add an alternative collection with scoring feature distributions everywhere in RawFeatureFilter, OpWorkflow etc.

**Additional context**
This is an important piece of information that we don't want to loose ;)
