### PR TITLE
Refactored splitter tests

### DIFF
--- a/core/src/main/scala/com/salesforce/op/stages/impl/selector/ModelSelector.scala
+++ b/core/src/main/scala/com/salesforce/op/stages/impl/selector/ModelSelector.scala
@@ -146,7 +146,7 @@ E <: Estimator[_] with OpPipelineStage2[RealNN, OPVector, Prediction]]
       }
     require(!datasetWithID.isEmpty, "Dataset cannot be empty")
 
-    val ModelData(trainData, met) = splitter match {
+    val ModelData(trainData, splitterSummary) = splitter match {
       case Some(spltr) => spltr.prepare(datasetWithID)
       case None => ModelData(datasetWithID, None)
     }
@@ -174,7 +174,7 @@ E <: Estimator[_] with OpPipelineStage2[RealNN, OPVector, Prediction]]
       validationType = ValidationType.fromValidator(validator),
       validationParameters = validator.getParams(),
       dataPrepParameters = splitter.map(_.extractParamMap().getAsMap()).getOrElse(Map()),
-      dataPrepResults = met,
+      dataPrepResults = splitterSummary,
       evaluationMetric = validator.evaluator.name,
       problemType = ProblemType.fromEvalMetrics(trainingEval),
       bestModelUID = estimator.uid,

--- a/core/src/main/scala/com/salesforce/op/stages/impl/tuning/DataBalancer.scala
+++ b/core/src/main/scala/com/salesforce/op/stages/impl/tuning/DataBalancer.scala
@@ -33,7 +33,7 @@ package com.salesforce.op.stages.impl.tuning
 import com.salesforce.op.UID
 import com.salesforce.op.stages.impl.selector.ModelSelectorNames
 import org.apache.spark.ml.param._
-import org.apache.spark.sql.{Dataset, Row}
+import org.apache.spark.sql.{DataFrame, Dataset, Row}
 import org.apache.spark.sql.types.{Metadata, MetadataBuilder}
 import org.slf4j.LoggerFactory
 
@@ -123,19 +123,50 @@ class DataBalancer(uid: String = UID[DataBalancer]) extends Splitter(uid = uid) 
    * @return balanced training set and a test set
    */
   def prepare(data: Dataset[Row]): ModelData = {
+    val negativeData = data.filter(_.getDouble(0) == 0.0).persist()
+    val positiveData = data.filter(_.getDouble(0) == 1.0).persist()
+    val negativeCount = negativeData.count()
+    val positiveCount = positiveData.count()
+    val seed = getSeed
 
-    val ds = data.persist()
+    if (!(isSet(isPositiveSmall) ||
+      isSet(downSampleFraction) ||
+      isSet(upSampleFraction) ||
+      isSet(alreadyBalancedFraction))
+    ) {
+      estimate(positiveCount = positiveCount, negativeCount = negativeCount, seed = seed)
+    }
 
-    val Array(negativeData, positiveData) = Array(0.0, 1.0).map(label => ds.filter(_.getDouble(0) == label).persist())
-    val balancerSeed = getSeed
+    // If these conditions are met, that means that we have enough information to balance the data : upSample,
+    // downSample and which class is in minority
+    val balanced: DataFrame = {
+      if (isSet(isPositiveSmall) && isSet(downSampleFraction) && isSet(upSampleFraction)) {
+        val (down, up) = ($(downSampleFraction), $(upSampleFraction))
+        log.info(s"Sample fractions: downSample of $down, upSample of $up")
+        val (smallData, bigData) =
+          if ($(isPositiveSmall)) (positiveData, negativeData) else (negativeData, positiveData)
+        rebalance(
+          smallData = smallData,
+          upSampleFraction = up,
+          bigData = bigData,
+          downSampleFraction = down,
+          seed = seed
+        )
+      } else {
+        // Data is already balanced, but need to be sampled
+        val fraction = $(alreadyBalancedFraction)
+        log.info(s"Data is already balanced, yet it will be sampled by a fraction of $fraction")
+        sampleBalancedData(
+          fraction = fraction,
+          seed = seed,
+          data = data,
+          positiveData = positiveData,
+          negativeData = negativeData
+        )
+      }
+    }
 
-    prepareData(
-      data = ds,
-      positiveData = positiveData,
-      negativeData = negativeData,
-      seed = balancerSeed
-    )
-
+    ModelData(balanced.persist(), summary)
   }
 
   override def copy(extra: ParamMap): DataBalancer = {
@@ -143,25 +174,15 @@ class DataBalancer(uid: String = UID[DataBalancer]) extends Splitter(uid = uid) 
     copyValues(copy, extra)
   }
 
-
-
   /**
    * Estimate if data needs to be balanced or not. If so, computes sample fractions and sets the appropriate params
    *
-   * @param data            input data
-   * @param positiveData    data with positives only
-   * @param negativeData    data with negatives only
+   * @param positiveCount   number of positives
+   * @param negativeCount   number of negatives
    * @param seed            seed
    * @return balanced data
    */
-  private[op] def estimate[T](
-    data: Dataset[T],
-    positiveData: Dataset[T],
-    negativeData: Dataset[T],
-    seed: Long
-  ): Unit = {
-    val positiveCount = positiveData.count()
-    val negativeCount = negativeData.count()
+  private[op] def estimate[T](positiveCount: Long, negativeCount: Long, seed: Long): Unit = {
     val totalCount = positiveCount + negativeCount
     val sampleF = getSampleFraction
     log.info(s"Data has $positiveCount positive and $negativeCount negative.")
@@ -180,8 +201,7 @@ class DataBalancer(uid: String = UID[DataBalancer]) extends Splitter(uid = uid) 
 
     if (smallCount.toDouble / totalCount.toDouble >= sampleF) {
       log.info(
-        s"Not resampling data: $smallCount small count and $bigCount big count is greater than" +
-          s" requested $sampleF"
+        s"Not resampling data: $smallCount small count and $bigCount big count is greater than requested $sampleF"
       )
       // if data is too big downsample
       val fraction = if (maxTrainSample < totalCount) maxTrainSample / totalCount.toDouble else 1.0
@@ -202,8 +222,7 @@ class DataBalancer(uid: String = UID[DataBalancer]) extends Splitter(uid = uid) 
         desiredFraction = sampleF, upSamplingFraction = upSample, downSamplingFraction = downSample))
 
       val (posFraction, negFraction) =
-        if (positiveCount < negativeCount) (upSample, downSample)
-        else (downSample, upSample)
+        if (positiveCount < negativeCount) (upSample, downSample) else (downSample, upSample)
 
       val newPositiveCount = math.rint(positiveCount * posFraction)
       val newNegativeCount = math.rint(negativeCount * negFraction)
@@ -223,43 +242,6 @@ class DataBalancer(uid: String = UID[DataBalancer]) extends Splitter(uid = uid) 
 
     }
   }
-  /**
-   * Preparing data
-   *
-   * @param data            input data
-   * @param positiveData    data with positives only
-   * @param negativeData    data with negatives only
-   * @param seed            seed
-   * @return balanced data
-   */
-  private[op] def prepareData[T](
-    data: Dataset[T],
-    positiveData: Dataset[T],
-    negativeData: Dataset[T],
-    seed: Long
-  ): ModelData = {
-
-    if (!(isSet(isPositiveSmall) || isSet(downSampleFraction) ||
-      isSet(upSampleFraction) || isSet(alreadyBalancedFraction))) {
-      estimate(data = data, positiveData = positiveData, negativeData = negativeData, seed = seed)
-    }
-
-    // If these conditions are met, that means that we have enough information to balance the data : upSample,
-    // downSample and which class is in minority
-    if (isSet(isPositiveSmall) && isSet(downSampleFraction) && isSet(upSampleFraction)) {
-      val (down, up) = ($(downSampleFraction), $(upSampleFraction))
-      log.info(s"Sample fractions: downSample of $down, upSample of $up")
-      val (smallData, bigData) = if ($(isPositiveSmall)) (positiveData, negativeData) else (negativeData, positiveData)
-      new ModelData(rebalance(smallData, up, bigData, down, seed).toDF().persist(), summary)
-    } else { // Data is already balanced, but need to be sampled
-      val fraction = $(alreadyBalancedFraction)
-      log.info(s"Data is already balanced, yet it will be sampled by a fraction of $fraction")
-      val balanced = sampleBalancedData(fraction = fraction, seed = seed,
-        data = data, positiveData = positiveData, negativeData = negativeData).toDF()
-      new ModelData(balanced.persist(), summary)
-    }
-  }
-
 
   /**
    *
@@ -284,7 +266,6 @@ class DataBalancer(uid: String = UID[DataBalancer]) extends Splitter(uid = uid) 
       case 1.0 => smallData // if upSample == 1.0, no need to upSample
       case u => smallData.sample(withReplacement = false, u, seed = seed) // downsample instead
     }
-
     smallDataTrain.union(bigDataTrain)
   }
 
@@ -330,9 +311,7 @@ trait DataBalancerParams extends Params {
   )
   setDefault(sampleFraction, SplitterParamsDefault.SampleFractionDefault)
 
-  def setSampleFraction(value: Double): this.type = {
-    set(sampleFraction, value)
-  }
+  def setSampleFraction(value: Double): this.type = set(sampleFraction, value)
 
   def getSampleFraction: Double = $(sampleFraction)
 
@@ -350,9 +329,7 @@ trait DataBalancerParams extends Params {
   )
   setDefault(maxTrainingSample, SplitterParamsDefault.MaxTrainingSampleDefault)
 
-  def setMaxTrainingSample(value: Int): this.type = {
-    set(maxTrainingSample, value)
-  }
+  def setMaxTrainingSample(value: Int): this.type = set(maxTrainingSample, value)
 
   def getMaxTrainingSample: Int = $(maxTrainingSample)
 
@@ -366,9 +343,7 @@ trait DataBalancerParams extends Params {
     "fraction to sample minority data", ParamValidators.gt(0.0) // it can be a downSample fraction
   )
 
-  private[op] def setUpSampleFraction(value: Double): this.type = {
-    set(upSampleFraction, value)
-  }
+  private[op] def setUpSampleFraction(value: Double): this.type = set(upSampleFraction, value)
 
   private[op] def getUpSampleFraction: Double = $(upSampleFraction)
 
@@ -385,9 +360,7 @@ trait DataBalancerParams extends Params {
     )
   )
 
-  private[op] def setDownSampleFraction(value: Double): this.type = {
-    set(downSampleFraction, value)
-  }
+  private[op] def setDownSampleFraction(value: Double): this.type = set(downSampleFraction, value)
 
   private[op] def getDownSampleFraction: Double = $(downSampleFraction)
 
@@ -400,9 +373,7 @@ trait DataBalancerParams extends Params {
   private[op] final val isPositiveSmall = new BooleanParam(this, "isPositiveSmall",
     "whether or not positive data is in minority")
 
-  private[op] def setIsPositiveSmall(value: Boolean): this.type = {
-    set(isPositiveSmall, value)
-  }
+  private[op] def setIsPositiveSmall(value: Boolean): this.type = set(isPositiveSmall, value)
 
   private[op] def getIsPositiveSmall: Boolean = $(isPositiveSmall)
 
@@ -417,9 +388,7 @@ trait DataBalancerParams extends Params {
     ParamValidators.inRange(lowerBound = 0.0, upperBound = 1.0, lowerInclusive = false, upperInclusive = true)
   )
 
-  private[op] def setAlreadyBalancedFraction(value: Double): this.type = {
-    set(alreadyBalancedFraction, value)
-  }
+  private[op] def setAlreadyBalancedFraction(value: Double): this.type = set(alreadyBalancedFraction, value)
 
   private[op] def getAlreadyBalancedFraction: Double = $(alreadyBalancedFraction)
 }

--- a/core/src/main/scala/com/salesforce/op/stages/impl/tuning/DataCutter.scala
+++ b/core/src/main/scala/com/salesforce/op/stages/impl/tuning/DataCutter.scala
@@ -85,7 +85,7 @@ class DataCutter(uid: String = UID[DataCutter]) extends Splitter(uid = uid) with
   def prepare(data: Dataset[Row]): ModelData = {
     import data.sparkSession.implicits._
 
-    val keep =
+    val keep: Set[Double] =
       if (!isSet(labelsToKeep) || !isSet(labelsToDrop)) {
         val labels = data.map(r => r.getDouble(0) -> 1L)
         val labelCounts = labels.groupBy(labels.columns(0)).sum(labels.columns(1)).persist()
@@ -96,9 +96,9 @@ class DataCutter(uid: String = UID[DataCutter]) extends Splitter(uid = uid) with
       } else getLabelsToKeep.toSet
 
     val dataUse = data.filter(r => keep.contains(r.getDouble(0)))
+    val summary = DataCutterSummary(labelsKept = getLabelsToKeep, labelsDropped = getLabelsToDrop)
 
-    val labelsMeta = DataCutterSummary(labelsKept = getLabelsToKeep, labelsDropped = getLabelsToDrop)
-    new ModelData(dataUse, Option(labelsMeta))
+    ModelData(dataUse, Some(summary))
   }
 
   /**
@@ -146,9 +146,7 @@ private[impl] trait DataCutterParams extends Params {
   )
   setDefault(maxLabelCategories, SplitterParamsDefault.MaxLabelCategoriesDefault)
 
-  def setMaxLabelCategories(value: Int): this.type = {
-    set(maxLabelCategories, value)
-  }
+  def setMaxLabelCategories(value: Int): this.type = set(maxLabelCategories, value)
 
   def getMaxLabelCategories: Int = $(maxLabelCategories)
 
@@ -159,9 +157,7 @@ private[impl] trait DataCutterParams extends Params {
   )
   setDefault(minLabelFraction, SplitterParamsDefault.MinLabelFractionDefault)
 
-  def setMinLabelFraction(value: Double): this.type = {
-    set(minLabelFraction, value)
-  }
+  def setMinLabelFraction(value: Double): this.type = set(minLabelFraction, value)
 
   def getMinLabelFraction: Double = $(minLabelFraction)
 
@@ -185,18 +181,18 @@ private[impl] trait DataCutterParams extends Params {
 /**
  * Summary of results for data cutter
  * @param labelsKept labels retained
- * @param labelsDropped labels dropped by datacutter
+ * @param labelsDropped labels dropped by data cutter
  */
 case class DataCutterSummary
 (
-  labelsKept: Array[Double],
-  labelsDropped: Array[Double]
+  labelsKept: Seq[Double],
+  labelsDropped: Seq[Double]
 ) extends SplitterSummary {
   override def toMetadata(): Metadata = {
     new MetadataBuilder()
       .putString(SplitterSummary.ClassName, this.getClass.getName)
-      .putDoubleArray(ModelSelectorNames.LabelsKept, labelsKept)
-      .putDoubleArray(ModelSelectorNames.LabelsDropped, labelsDropped)
+      .putDoubleArray(ModelSelectorNames.LabelsKept, labelsKept.toArray)
+      .putDoubleArray(ModelSelectorNames.LabelsDropped, labelsDropped.toArray)
       .build()
   }
 }

--- a/core/src/main/scala/com/salesforce/op/stages/impl/tuning/DataSplitter.scala
+++ b/core/src/main/scala/com/salesforce/op/stages/impl/tuning/DataSplitter.scala
@@ -68,7 +68,7 @@ class DataSplitter(uid: String = UID[DataSplitter]) extends Splitter(uid = uid) 
    * @param data
    * @return Training set test set
    */
-  def prepare(data: Dataset[Row]): ModelData = ModelData(data, Option(DataSplitterSummary()))
+  def prepare(data: Dataset[Row]): ModelData = ModelData(data, Some(DataSplitterSummary()))
 
   override def copy(extra: ParamMap): DataSplitter = {
     val copy = new DataSplitter(uid)

--- a/core/src/main/scala/com/salesforce/op/stages/impl/tuning/DataSplitter.scala
+++ b/core/src/main/scala/com/salesforce/op/stages/impl/tuning/DataSplitter.scala
@@ -68,8 +68,7 @@ class DataSplitter(uid: String = UID[DataSplitter]) extends Splitter(uid = uid) 
    * @param data
    * @return Training set test set
    */
-  def prepare(data: Dataset[Row]): ModelData =
-    new ModelData(data, Option(DataSplitterSummary()))
+  def prepare(data: Dataset[Row]): ModelData = ModelData(data, Option(DataSplitterSummary()))
 
   override def copy(extra: ParamMap): DataSplitter = {
     val copy = new DataSplitter(uid)
@@ -78,7 +77,7 @@ class DataSplitter(uid: String = UID[DataSplitter]) extends Splitter(uid = uid) 
 }
 
 /**
- * Empty class because no summary information for a datasplitter
+ * Empty class because no summary information for a data splitter
  */
 case class DataSplitterSummary() extends SplitterSummary {
   override def toMetadata(): Metadata = new MetadataBuilder()

--- a/core/src/main/scala/com/salesforce/op/stages/impl/tuning/OpCrossValidation.scala
+++ b/core/src/main/scala/com/salesforce/op/stages/impl/tuning/OpCrossValidation.scala
@@ -136,10 +136,14 @@ private[op] class OpCrossValidation[M <: Model[_], E <: Estimator[_]]
    * @param splitter  used to estimate splitter params prior to cv
    * @return Array((TrainRDD, ValidationRDD), Index)
    */
-  private[op] override def createTrainValidationSplits[T](stratifyCondition: Boolean,
-    dataset: Dataset[T], label: String, splitter: Option[Splitter] = None): Array[(RDD[Row], RDD[Row])] = {
+  private[op] override def createTrainValidationSplits[T](
+    stratifyCondition: Boolean,
+    dataset: Dataset[T],
+    label: String,
+    splitter: Option[Splitter]
+  ): Array[(RDD[Row], RDD[Row])] = {
 
-    // TODO : Implement our own kFold method for better performance in a separate PR
+    // TODO: Implement our own kFold method for better performance in a separate PR
 
     // get param that stores the label column
     val labelCol = evaluator.getParam(ValidatorParamDefaults.LabelCol)
@@ -160,13 +164,12 @@ private[op] class OpCrossValidation[M <: Model[_], E <: Estimator[_]]
     }
   }
 
-
   private def stratifyKFolds(rddsByClass: Array[RDD[Row]]): Array[(RDD[Row], RDD[Row])] = {
     // Cross Validation's Train/Validation data for each class
     val foldsByClass = rddsByClass.map(rdd => MLUtils.kFold(rdd, numFolds, seed)).toSeq
 
     if (foldsByClass.isEmpty) {
-      throw new RuntimeException("Dataset is too small for CV forlds selected some empty datasets are created")
+      throw new RuntimeException("Dataset is too small for CV folds selected some empty datasets are created")
     }
     // Merging Train/Validation data one by one
     foldsByClass.reduce[Array[(RDD[Row], RDD[Row])]] {

--- a/core/src/main/scala/com/salesforce/op/stages/impl/tuning/OpTrainValidationSplit.scala
+++ b/core/src/main/scala/com/salesforce/op/stages/impl/tuning/OpTrainValidationSplit.scala
@@ -91,16 +91,16 @@ private[op] class OpTrainValidationSplit[M <: Model[_], E <: Estimator[_]]
    * Creates Train Validation Splits For TS
    *
    * @param stratifyCondition condition to do stratify ts
-   * @param dataset dataset to split
-   * @param label name of label in dataset
-   * @param splitter  used to estimate splitter params prior to ts
+   * @param dataset           dataset to split
+   * @param label             name of label in dataset
+   * @param splitter          used to estimate splitter params prior to ts
    * @return Array[(Train, Test)]
    */
   private[op] override def createTrainValidationSplits[T](
     stratifyCondition: Boolean,
     dataset: Dataset[T],
     label: String,
-    splitter: Option[Splitter] = None
+    splitter: Option[Splitter]
   ): Array[(RDD[Row], RDD[Row])] = {
 
     // get param that stores the label column

--- a/core/src/test/scala/com/salesforce/op/stages/impl/tuning/DataBalancerTest.scala
+++ b/core/src/test/scala/com/salesforce/op/stages/impl/tuning/DataBalancerTest.scala
@@ -106,11 +106,10 @@ class DataBalancerTest extends FlatSpec with TestSparkContext {
     balancer.getDownSampleFraction shouldBe downSample
     balancer.getIsPositiveSmall shouldBe false
 
-
     // Rerun balancer with set params
     val metadata = balancer.summary
     val ModelData(expected2, _) = balancer.prepare(data)
-    withClue("Data balancer should no update the metadata"){
+    withClue("Data balancer should not update the metadata"){
       balancer.summary shouldBe metadata
     }
     expected.collect() shouldBe expected2.collect()
@@ -135,9 +134,7 @@ class DataBalancerTest extends FlatSpec with TestSparkContext {
       balancer.summary shouldBe metadata
     }
     expected.collect() shouldBe expected2.collect()
-
   }
-
 
   it should "remember that data is already balanced, but needs to be sample because too big" in {
     val fraction = 0.01

--- a/core/src/test/scala/com/salesforce/op/stages/impl/tuning/DataBalancerTest.scala
+++ b/core/src/test/scala/com/salesforce/op/stages/impl/tuning/DataBalancerTest.scala
@@ -61,7 +61,7 @@ class DataBalancerTest extends FlatSpec with TestSparkContext with SplitterSumma
 
   val data = positiveData.union(negativeData)
 
-  val dataBalancer = new DataBalancer().setSeed(seed)
+  val dataBalancer = DataBalancer(seed = seed)
 
   Spec[DataBalancer] should "compute the sample proportions" in {
     dataBalancer.getProportions(100, 9900, 0.5, 100000) shouldEqual(50.0 / 99.0, 50.0)
@@ -74,7 +74,6 @@ class DataBalancerTest extends FlatSpec with TestSparkContext with SplitterSumma
 
   it should "set the data balancing params correctly" in {
     dataBalancer
-      .setSeed(seed)
       .setSampleFraction(0.4)
       .setMaxTrainingSample(80)
       .setSeed(11L)

--- a/core/src/test/scala/com/salesforce/op/stages/impl/tuning/DataBalancerTest.scala
+++ b/core/src/test/scala/com/salesforce/op/stages/impl/tuning/DataBalancerTest.scala
@@ -105,11 +105,7 @@ class DataBalancerTest extends FlatSpec with TestSparkContext with SplitterSumma
   it should "balance and remember the fractions" in {
     val fraction = 0.4
     val maxSize = 2000
-    val balancer = new DataBalancer()
-      .setSampleFraction(fraction)
-      .setMaxTrainingSample(maxSize)
-      .setSeed(11L)
-
+    val balancer = DataBalancer(sampleFraction = fraction, maxTrainingSample = maxSize, seed = 11L)
     val res1 = balancer.prepare(data)
     val (downSample, upSample) = balancer.getProportions(smallCount, bigCount, fraction, maxSize)
 
@@ -122,10 +118,7 @@ class DataBalancerTest extends FlatSpec with TestSparkContext with SplitterSumma
   it should "remember that data is already balanced" in {
     val fraction = 0.01
     val maxSize = 20000
-    val balancer = new DataBalancer()
-      .setSampleFraction(0.01)
-      .setMaxTrainingSample(maxSize)
-      .setSeed(11L)
+    val balancer = DataBalancer(sampleFraction = fraction, maxTrainingSample = maxSize, seed = 11L)
     val res1 = balancer.prepare(data)
 
     balancer.getAlreadyBalancedFraction shouldBe 1.0
@@ -135,10 +128,7 @@ class DataBalancerTest extends FlatSpec with TestSparkContext with SplitterSumma
   it should "remember that data is already balanced, but needs to be sample because too big" in {
     val fraction = 0.01
     val maxSize = 100
-    val balancer = new DataBalancer()
-      .setSampleFraction(fraction)
-      .setMaxTrainingSample(maxSize)
-      .setSeed(11L)
+    val balancer = DataBalancer(sampleFraction = fraction, maxTrainingSample = maxSize, seed = 11L)
     val res1 = balancer.prepare(data)
 
     balancer.getAlreadyBalancedFraction shouldBe maxSize.toDouble / (smallCount + bigCount)

--- a/core/src/test/scala/com/salesforce/op/stages/impl/tuning/DataCutterTest.scala
+++ b/core/src/test/scala/com/salesforce/op/stages/impl/tuning/DataCutterTest.scala
@@ -56,7 +56,7 @@ class DataCutterTest extends FlatSpec with TestSparkContext with SplitterSummary
   val seed = 42L
 
   Spec[DataCutter] should "not filter out any data when the parameters are permissive" in {
-    val dc1 = DataCutter(seed = seed).setMinLabelFraction(0.0).setMaxLabelCategories(100000)
+    val dc1 = DataCutter(seed = seed, minLabelFraction = 0.0, maxLabelCategories = 100000)
     val split1 = dc1.prepare(randDF)
 
     split1.train.count() shouldBe dataSize
@@ -66,7 +66,7 @@ class DataCutterTest extends FlatSpec with TestSparkContext with SplitterSummary
       s shouldBe DataCutterSummary(dc1.getLabelsToKeep, dc1.getLabelsToDrop)
     }
 
-    val dc2 = DataCutter(seed = seed).setMinLabelFraction(0.0).setMaxLabelCategories(100000)
+    val dc2 = DataCutter(seed = seed, minLabelFraction = 0.0, maxLabelCategories = 100000)
     val split2 = dc2.prepare(biasDF)
 
     split2.train.count() shouldBe dataSize
@@ -78,15 +78,12 @@ class DataCutterTest extends FlatSpec with TestSparkContext with SplitterSummary
   }
 
   it should "throw an error when all the data is filtered out" in {
-    val dataCutter = DataCutter(seed = seed).setMinLabelFraction(0.4)
+    val dataCutter = DataCutter(seed = seed, minLabelFraction = 0.4)
     assertThrows[RuntimeException](dataCutter.prepare(randDF))
   }
 
   it should "filter out all but the top N label categories" in {
-    val dc1 =  DataCutter(seed = seed)
-      .setMinLabelFraction(0.0)
-      .setMaxLabelCategories(100)
-      .setReserveTestFraction(0.5)
+    val dc1 = DataCutter(seed = seed, minLabelFraction = 0.0, maxLabelCategories = 100, reserveTestFraction = 0.5)
     val split1 = dc1.prepare(randDF)
 
     findDistinct(split1.train).count() shouldBe 100
@@ -108,10 +105,7 @@ class DataCutterTest extends FlatSpec with TestSparkContext with SplitterSummary
   }
 
   it should "filter out anything that does not have at least the specified data fraction" in {
-    val dc1 = DataCutter(seed = seed)
-      .setMinLabelFraction(0.0012)
-      .setMaxLabelCategories(100000)
-      .setReserveTestFraction(0.5)
+    val dc1 = DataCutter(seed = seed, minLabelFraction = 0.0012, maxLabelCategories = 100000, reserveTestFraction = 0.5)
     val split1 = dc1.prepare(randDF)
 
     val distinct = findDistinct(randDF).count()
@@ -123,7 +117,7 @@ class DataCutterTest extends FlatSpec with TestSparkContext with SplitterSummary
       s shouldBe DataCutterSummary(dc1.getLabelsToKeep, dc1.getLabelsToDrop)
     }
 
-    val dc2 = DataCutter(seed = seed).setMinLabelFraction(0.20).setReserveTestFraction(0.5)
+    val dc2 = DataCutter(seed = seed, minLabelFraction = 0.2, reserveTestFraction = 0.5)
     val split2 = dc2.prepare(biasDF)
     findDistinct(split2.train).count() shouldBe 3
     assertDataCutterSummary(split2.summary) { s =>

--- a/core/src/test/scala/com/salesforce/op/stages/impl/tuning/DataCutterTest.scala
+++ b/core/src/test/scala/com/salesforce/op/stages/impl/tuning/DataCutterTest.scala
@@ -39,8 +39,7 @@ import org.scalatest.junit.JUnitRunner
 
 
 @RunWith(classOf[JUnitRunner])
-class DataCutterTest extends FlatSpec with TestSparkContext {
-
+class DataCutterTest extends FlatSpec with TestSparkContext with SplitterSummaryAsserts {
   import spark.implicits._
 
   val labels = RandomIntegral.integrals(0, 1000).withProbabilityOfEmpty(0).limit(100000)
@@ -57,24 +56,25 @@ class DataCutterTest extends FlatSpec with TestSparkContext {
   val seed = 42L
 
   Spec[DataCutter] should "not filter out any data when the parameters are permissive" in {
-    val dataCutter = DataCutter(seed = seed).setMinLabelFraction(0.0).setMaxLabelCategories(100000)
-    val split = dataCutter.prepare(randDF)
-    split.train.count() shouldBe dataSize
+    val dc1 = DataCutter(seed = seed).setMinLabelFraction(0.0).setMaxLabelCategories(100000)
+    val split1 = dc1.prepare(randDF)
 
-    val keptMeta = split.summary.get.asInstanceOf[DataCutterSummary].labelsKept
-    keptMeta.length shouldBe 1000
-    keptMeta should contain theSameElementsAs dataCutter.getLabelsToKeep
-    val dropMeta = split.summary.get.asInstanceOf[DataCutterSummary].labelsDropped
-    dropMeta.length shouldBe 0
-    dropMeta should contain theSameElementsAs dataCutter.getLabelsToDrop
+    split1.train.count() shouldBe dataSize
+    assertDataCutterSummary(split1.summary) { s =>
+      s.labelsKept.length shouldBe 1000
+      s.labelsDropped.length shouldBe 0
+      s shouldBe DataCutterSummary(dc1.getLabelsToKeep, dc1.getLabelsToDrop)
+    }
 
-    val split2 = DataCutter(seed = seed)
-      .setMinLabelFraction(0.0)
-      .setMaxLabelCategories(100000)
-      .prepare(biasDF)
+    val dc2 = DataCutter(seed = seed).setMinLabelFraction(0.0).setMaxLabelCategories(100000)
+    val split2 = dc2.prepare(biasDF)
+
     split2.train.count() shouldBe dataSize
-    split2.summary.get.asInstanceOf[DataCutterSummary].labelsKept.length shouldBe 1000
-    split2.summary.get.asInstanceOf[DataCutterSummary].labelsDropped.length shouldBe 0
+    assertDataCutterSummary(split2.summary) { s =>
+      s.labelsKept.length shouldBe 1000
+      s.labelsDropped.length shouldBe 0
+      s shouldBe DataCutterSummary(dc2.getLabelsToKeep, dc2.getLabelsToDrop)
+    }
   }
 
   it should "throw an error when all the data is filtered out" in {
@@ -83,50 +83,68 @@ class DataCutterTest extends FlatSpec with TestSparkContext {
   }
 
   it should "filter out all but the top N label categories" in {
-    val split = DataCutter(seed = seed)
+    val dc1 =  DataCutter(seed = seed)
       .setMinLabelFraction(0.0)
       .setMaxLabelCategories(100)
       .setReserveTestFraction(0.5)
-      .prepare(randDF)
+    val split1 = dc1.prepare(randDF)
 
-    findDistinct(split.train).count() shouldBe 100
-    split.summary.get.asInstanceOf[DataCutterSummary].labelsKept.length shouldBe 100
-    split.summary.get.asInstanceOf[DataCutterSummary].labelsDropped.length shouldBe 900
+    findDistinct(split1.train).count() shouldBe 100
+    assertDataCutterSummary(split1.summary) { s =>
+      s.labelsKept.length shouldBe 100
+      s.labelsDropped.length shouldBe 900
+      s shouldBe DataCutterSummary(dc1.getLabelsToKeep, dc1.getLabelsToDrop)
+    }
 
-    val split2 = DataCutter(seed = seed).setMaxLabelCategories(3).prepare(biasDF)
+    val dc2 = DataCutter(seed = seed).setMaxLabelCategories(3)
+    val split2 = dc2.prepare(biasDF)
+
     findDistinct(split2.train).collect().toSet shouldEqual Set(0.0, 1.0, 2.0)
-    split2.summary.get.asInstanceOf[DataCutterSummary].labelsKept.length shouldBe 3
-    split2.summary.get.asInstanceOf[DataCutterSummary].labelsDropped.length shouldBe 997
+    assertDataCutterSummary(split2.summary) { s =>
+      s.labelsKept.length shouldBe 3
+      s.labelsDropped.length shouldBe 997
+      s shouldBe DataCutterSummary(dc2.getLabelsToKeep, dc2.getLabelsToDrop)
+    }
   }
 
   it should "filter out anything that does not have at least the specified data fraction" in {
-    val split = DataCutter(seed = seed)
+    val dc1 = DataCutter(seed = seed)
       .setMinLabelFraction(0.0012)
       .setMaxLabelCategories(100000)
       .setReserveTestFraction(0.5)
-      .prepare(randDF)
+    val split1 = dc1.prepare(randDF)
 
     val distinct = findDistinct(randDF).count()
-    val distTrain = findDistinct(split.train)
+    val distTrain = findDistinct(split1.train)
     distTrain.count() < distinct shouldBe true
     distTrain.count() > 0 shouldBe true
-    split.summary.get.asInstanceOf[DataCutterSummary].labelsKept.length +
-      split.summary.get.asInstanceOf[DataCutterSummary].labelsDropped.length shouldBe distinct
+    assertDataCutterSummary(split1.summary) { s =>
+      s.labelsKept.length + s.labelsDropped.length shouldBe distinct
+      s shouldBe DataCutterSummary(dc1.getLabelsToKeep, dc1.getLabelsToDrop)
+    }
 
-    val split2 = DataCutter(seed = seed).setMinLabelFraction(0.20).setReserveTestFraction(0.5).prepare(biasDF)
+    val dc2 = DataCutter(seed = seed).setMinLabelFraction(0.20).setReserveTestFraction(0.5)
+    val split2 = dc2.prepare(biasDF)
     findDistinct(split2.train).count() shouldBe 3
-    split2.summary.get.asInstanceOf[DataCutterSummary].labelsKept.length shouldBe 3
-    split2.summary.get.asInstanceOf[DataCutterSummary].labelsDropped.length shouldBe 997
+    assertDataCutterSummary(split2.summary) { s =>
+      s.labelsKept.length shouldBe 3
+      s.labelsDropped.length shouldBe 997
+      s shouldBe DataCutterSummary(dc2.getLabelsToKeep, dc2.getLabelsToDrop)
+    }
   }
 
-  it should "filter out using the var labelsToKeep" in {
+  it should "filter out using labels to keep/drop params" in {
     val keep = Set(0.0, 1.0)
     val drop = Set(5.0, 7.0)
-    val dataCutter = DataCutter(seed = seed).setLabels(keep = keep, drop = drop)
-    val split = dataCutter.prepare(randDF)
+    val dc = DataCutter(seed = seed).setLabels(keep = keep, drop = drop)
+    val split = dc.prepare(randDF)
+
     findDistinct(split.train).collect().sorted shouldBe Array(0.0, 1.0)
-    dataCutter.getLabelsToKeep shouldBe keep.toArray
-    dataCutter.getLabelsToDrop shouldBe drop.toArray
+    dc.getLabelsToKeep shouldBe keep.toArray
+    dc.getLabelsToDrop shouldBe drop.toArray
+    assertDataCutterSummary(split.summary) { s =>
+      s shouldBe DataCutterSummary(dc.getLabelsToKeep, dc.getLabelsToDrop)
+    }
   }
 
   private def findDistinct(d: Dataset[_]): Dataset[Double] = d.toDF().map(_.getDouble(0)).distinct()

--- a/core/src/test/scala/com/salesforce/op/stages/impl/tuning/DataCutterTest.scala
+++ b/core/src/test/scala/com/salesforce/op/stages/impl/tuning/DataCutterTest.scala
@@ -30,7 +30,6 @@
 
 package com.salesforce.op.stages.impl.tuning
 
-import com.salesforce.op.stages.impl.selector.ModelSelectorNames
 import com.salesforce.op.test.TestSparkContext
 import com.salesforce.op.testkit.{RandomIntegral, RandomReal, RandomVector}
 import org.apache.spark.sql.Dataset
@@ -61,6 +60,7 @@ class DataCutterTest extends FlatSpec with TestSparkContext {
     val dataCutter = DataCutter(seed = seed).setMinLabelFraction(0.0).setMaxLabelCategories(100000)
     val split = dataCutter.prepare(randDF)
     split.train.count() shouldBe dataSize
+
     val keptMeta = split.summary.get.asInstanceOf[DataCutterSummary].labelsKept
     keptMeta.length shouldBe 1000
     keptMeta should contain theSameElementsAs dataCutter.getLabelsToKeep
@@ -78,11 +78,8 @@ class DataCutterTest extends FlatSpec with TestSparkContext {
   }
 
   it should "throw an error when all the data is filtered out" in {
-    val dataCutter = DataCutter(seed = seed)
-      .setMinLabelFraction(0.4)
-    assertThrows[RuntimeException] {
-      dataCutter.prepare(randDF)
-    }
+    val dataCutter = DataCutter(seed = seed).setMinLabelFraction(0.4)
+    assertThrows[RuntimeException](dataCutter.prepare(randDF))
   }
 
   it should "filter out all but the top N label categories" in {

--- a/core/src/test/scala/com/salesforce/op/stages/impl/tuning/DataSplitterTest.scala
+++ b/core/src/test/scala/com/salesforce/op/stages/impl/tuning/DataSplitterTest.scala
@@ -71,7 +71,7 @@ class DataSplitterTest extends FlatSpec with TestSparkContext with SplitterSumma
   it should "keep the data unchanged when prepare is called" in {
     val ModelData(train, summary) = dataSplitter.prepare(data)
     train.collect().zip(data.collect()).foreach { case (a, b) => a shouldBe b }
-    assertDataSplitterSummary(summary, DataSplitterSummary())
+    assertDataSplitterSummary(summary) { s => s shouldBe DataSplitterSummary() }
   }
 
 }

--- a/core/src/test/scala/com/salesforce/op/stages/impl/tuning/DataSplitterTest.scala
+++ b/core/src/test/scala/com/salesforce/op/stages/impl/tuning/DataSplitterTest.scala
@@ -38,7 +38,7 @@ import org.scalatest.FlatSpec
 import org.scalatest.junit.JUnitRunner
 
 @RunWith(classOf[JUnitRunner])
-class DataSplitterTest extends FlatSpec with TestSparkContext {
+class DataSplitterTest extends FlatSpec with TestSparkContext with SplitterSummaryAsserts {
   import spark.implicits._
 
   val seed = 1234L
@@ -50,23 +50,28 @@ class DataSplitterTest extends FlatSpec with TestSparkContext {
 
   val dataSplitter = new DataSplitter().setSeed(seed)
 
-  Spec[DataSplitter] should "split the data in the appropriate proportion" in {
-    val (train0, test0) = dataSplitter.setReserveTestFraction(0.0).split(data)
-    test0.count() shouldBe 0
-    train0.count() shouldBe dataCount
-
-    val (train2, test2) = dataSplitter.setReserveTestFraction(0.2).split(data)
-    math.abs(test2.count() - 200) < 30 shouldBe true
-    math.abs(train2.count() - 800) < 30 shouldBe true
-
-    val (train6, test6) = dataSplitter.setReserveTestFraction(0.6).split(data)
-    math.abs(test6.count() - 600) < 30 shouldBe true
-    math.abs(train6.count() - 400) < 30 shouldBe true
+  Spec[DataSplitter] should "split the data in the appropriate proportion - 0.0" in {
+    val (train, test) = dataSplitter.setReserveTestFraction(0.0).split(data)
+    test.count() shouldBe 0
+    train.count() shouldBe dataCount
   }
 
-  it should "wrap the data in the the ModelData class without changing it when prepare is called" in {
-    val train = dataSplitter.prepare(data)
-    train.train.collect().zip(data.collect()).foreach{ case (a, b) => a shouldBe b }
+  it should "split the data in the appropriate proportion - 0.2" in {
+    val (train, test) = dataSplitter.setReserveTestFraction(0.2).split(data)
+    math.abs(test.count() - 200) < 30 shouldBe true
+    math.abs(train.count() - 800) < 30 shouldBe true
+  }
+
+  it should "split the data in the appropriate proportion - 0.6" in {
+    val (train, test) = dataSplitter.setReserveTestFraction(0.6).split(data)
+    math.abs(test.count() - 600) < 30 shouldBe true
+    math.abs(train.count() - 400) < 30 shouldBe true
+  }
+
+  it should "keep the data unchanged when prepare is called" in {
+    val ModelData(train, summary) = dataSplitter.prepare(data)
+    train.collect().zip(data.collect()).foreach { case (a, b) => a shouldBe b }
+    assertDataSplitterSummary(summary, DataSplitterSummary())
   }
 
 }

--- a/core/src/test/scala/com/salesforce/op/stages/impl/tuning/DataSplitterTest.scala
+++ b/core/src/test/scala/com/salesforce/op/stages/impl/tuning/DataSplitterTest.scala
@@ -48,7 +48,7 @@ class DataSplitterTest extends FlatSpec with TestSparkContext with SplitterSumma
     RandomRDDs.normalVectorRDD(sc, 1000, 3, seed = seed)
       .map(v => (1.0, Vectors.dense(v.toArray), "A")).toDF()
 
-  val dataSplitter = new DataSplitter().setSeed(seed)
+  val dataSplitter = DataSplitter(seed = seed)
 
   Spec[DataSplitter] should "split the data in the appropriate proportion - 0.0" in {
     val (train, test) = dataSplitter.setReserveTestFraction(0.0).split(data)

--- a/core/src/test/scala/com/salesforce/op/stages/impl/tuning/OpValidatorTest.scala
+++ b/core/src/test/scala/com/salesforce/op/stages/impl/tuning/OpValidatorTest.scala
@@ -40,11 +40,11 @@ import org.apache.spark.ml.linalg.Vector
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.Row
 import org.junit.runner.RunWith
-import org.scalatest.{Assertion, FlatSpec}
+import org.scalatest.FlatSpec
 import org.scalatest.junit.JUnitRunner
 
 @RunWith(classOf[JUnitRunner])
-class OpValidatorTest extends FlatSpec with TestSparkContext {
+class OpValidatorTest extends FlatSpec with TestSparkContext with SplitterSummaryAsserts {
   // Random Data
   val count = 1000
   val sizeOfVector = 2
@@ -134,29 +134,5 @@ class OpValidatorTest extends FlatSpec with TestSparkContext {
       math.abs(expected - actual) should be < 0.065
     }
   }
-
-  private def assertDataBalancerSummary: Option[SplitterSummary] => Assertion = {
-    case Some(s: DataBalancerSummary) =>
-      val meta = s.toMetadata()
-      meta.getString(SplitterSummary.ClassName) shouldBe classOf[DataBalancerSummary].getName
-      meta.getLong(ModelSelectorNames.Positive) should be > 0L
-      meta.getLong(ModelSelectorNames.Negative) should be > 0L
-      meta.getDouble(ModelSelectorNames.Desired) should be > 0.0
-      meta.getDouble(ModelSelectorNames.UpSample) should be >= 0.0
-      meta.getDouble(ModelSelectorNames.DownSample) should be > 0.0
-    case x =>
-      fail(s"Unexpected data balancer summary: $x")
-  }
-
-  private def assertDataCutterSummary: Option[SplitterSummary] => Assertion = {
-    case Some(s: DataCutterSummary) =>
-      val meta = s.toMetadata()
-      meta.getDoubleArray(ModelSelectorNames.LabelsKept).foreach(_ should be >= 0.0)
-      meta.getDoubleArray(ModelSelectorNames.LabelsDropped).foreach(_ should be >= 0.0)
-      meta.getString(SplitterSummary.ClassName) shouldBe classOf[DataCutterSummary].getName
-    case x =>
-      fail(s"Unexpected data cutter summary: $x")
-  }
-
 
 }

--- a/core/src/test/scala/com/salesforce/op/stages/impl/tuning/OpValidatorTest.scala
+++ b/core/src/test/scala/com/salesforce/op/stages/impl/tuning/OpValidatorTest.scala
@@ -84,7 +84,9 @@ class OpValidatorTest extends FlatSpec with TestSparkContext with SplitterSummar
       assertFractions(Array(1 - p, p), train)
       assertFractions(Array(1 - p, p), validate)
     }
-    assertDataBalancerSummary(balancer.summary) { s => s shouldBe new DataBalancer().prepare(binaryDS).summary }
+    assertDataBalancerSummary(balancer.summary) { s =>
+      Some(s) shouldBe new DataBalancer().prepare(binaryDS).summary
+    }
   }
 
   it should "stratify multi class data" in {
@@ -104,7 +106,9 @@ class OpValidatorTest extends FlatSpec with TestSparkContext with SplitterSummar
       assertFractions(Array(1 - p, p), train)
       assertFractions(Array(1 - p, p), validate)
     }
-    assertDataBalancerSummary(balancer.summary) { s => s shouldBe new DataBalancer().prepare(binaryDS).summary }
+    assertDataBalancerSummary(balancer.summary) { s =>
+      Some(s) shouldBe new DataBalancer().prepare(binaryDS).summary
+    }
   }
 
   it should "stratify multi class data" in {

--- a/core/src/test/scala/com/salesforce/op/stages/impl/tuning/OpValidatorTest.scala
+++ b/core/src/test/scala/com/salesforce/op/stages/impl/tuning/OpValidatorTest.scala
@@ -84,8 +84,7 @@ class OpValidatorTest extends FlatSpec with TestSparkContext with SplitterSummar
       assertFractions(Array(1 - p, p), train)
       assertFractions(Array(1 - p, p), validate)
     }
-    assertDataBalancerSummary(balancer.summary)
-    new DataBalancer().prepare(binaryDS).summary shouldBe balancer.summary
+    assertDataBalancerSummary(balancer.summary) { s => s shouldBe Some(new DataBalancer().prepare(binaryDS).summary) }
   }
 
   it should "stratify multi class data" in {
@@ -95,7 +94,7 @@ class OpValidatorTest extends FlatSpec with TestSparkContext with SplitterSummar
       assertFractions(multiClassProbabilities, train)
       assertFractions(multiClassProbabilities, validate)
     }
-    assertDataCutterSummary(new DataCutter().prepare(multiDS).summary)
+    assertDataCutterSummary(new DataCutter().prepare(multiDS).summary)(_ => succeed)
   }
 
   Spec[OpTrainValidationSplit[_, _]] should "stratify binary class data" in {
@@ -105,8 +104,7 @@ class OpValidatorTest extends FlatSpec with TestSparkContext with SplitterSummar
       assertFractions(Array(1 - p, p), train)
       assertFractions(Array(1 - p, p), validate)
     }
-    assertDataBalancerSummary(balancer.summary)
-    new DataBalancer().prepare(binaryDS).summary shouldBe balancer.summary
+    assertDataBalancerSummary(balancer.summary) { s => s shouldBe Some(new DataBalancer().prepare(binaryDS).summary) }
   }
 
   it should "stratify multi class data" in {
@@ -115,7 +113,7 @@ class OpValidatorTest extends FlatSpec with TestSparkContext with SplitterSummar
       assertFractions(multiClassProbabilities, train)
       assertFractions(multiClassProbabilities, validate)
     }
-    assertDataCutterSummary(new DataCutter().prepare(multiDS).summary)
+    assertDataCutterSummary(new DataCutter().prepare(multiDS).summary)(_ => succeed)
   }
 
   /**

--- a/core/src/test/scala/com/salesforce/op/stages/impl/tuning/OpValidatorTest.scala
+++ b/core/src/test/scala/com/salesforce/op/stages/impl/tuning/OpValidatorTest.scala
@@ -84,7 +84,7 @@ class OpValidatorTest extends FlatSpec with TestSparkContext with SplitterSummar
       assertFractions(Array(1 - p, p), train)
       assertFractions(Array(1 - p, p), validate)
     }
-    assertDataBalancerSummary(balancer.summary) { s => s shouldBe Some(new DataBalancer().prepare(binaryDS).summary) }
+    assertDataBalancerSummary(balancer.summary) { s => s shouldBe new DataBalancer().prepare(binaryDS).summary }
   }
 
   it should "stratify multi class data" in {
@@ -104,7 +104,7 @@ class OpValidatorTest extends FlatSpec with TestSparkContext with SplitterSummar
       assertFractions(Array(1 - p, p), train)
       assertFractions(Array(1 - p, p), validate)
     }
-    assertDataBalancerSummary(balancer.summary) { s => s shouldBe Some(new DataBalancer().prepare(binaryDS).summary) }
+    assertDataBalancerSummary(balancer.summary) { s => s shouldBe new DataBalancer().prepare(binaryDS).summary }
   }
 
   it should "stratify multi class data" in {

--- a/core/src/test/scala/com/salesforce/op/stages/impl/tuning/SplitterSummaryAsserts.scala
+++ b/core/src/test/scala/com/salesforce/op/stages/impl/tuning/SplitterSummaryAsserts.scala
@@ -39,7 +39,9 @@ import org.scalatest.{Assertion, Matchers}
 trait SplitterSummaryAsserts {
   self: Matchers =>
 
-  def assertDataBalancerSummary: Option[SplitterSummary] => Assertion = {
+  def assertDataBalancerSummary(summary: Option[SplitterSummary])(
+    assert: DataBalancerSummary => Assertion
+  ): Assertion = summary match {
     case Some(s: DataBalancerSummary) =>
       val meta = s.toMetadata()
       meta.getString(SplitterSummary.ClassName) shouldBe classOf[DataBalancerSummary].getName
@@ -48,50 +50,33 @@ trait SplitterSummaryAsserts {
       meta.getDouble(ModelSelectorNames.Desired) should be > 0.0
       meta.getDouble(ModelSelectorNames.UpSample) should be >= 0.0
       meta.getDouble(ModelSelectorNames.DownSample) should be > 0.0
+      assert(s)
     case x =>
       fail(s"Unexpected data balancer summary: $x")
   }
 
-  def assertDataBalancerSummary(summary: Option[SplitterSummary], expected: DataBalancerSummary): Assertion = {
-    assertDataBalancerSummary(summary)
-    summary match {
-      case Some(s: DataBalancerSummary) => s shouldBe expected
-      case x => fail(s"Unexpected data balancer summary: $x")
-    }
-  }
-
-  def assertDataCutterSummary: Option[SplitterSummary] => Assertion = {
+  def assertDataCutterSummary(summary: Option[SplitterSummary])(
+    assert: DataCutterSummary => Assertion
+  ): Assertion = summary match {
     case Some(s: DataCutterSummary) =>
       val meta = s.toMetadata()
+      meta.getString(SplitterSummary.ClassName) shouldBe classOf[DataCutterSummary].getName
       meta.getDoubleArray(ModelSelectorNames.LabelsKept).foreach(_ should be >= 0.0)
       meta.getDoubleArray(ModelSelectorNames.LabelsDropped).foreach(_ should be >= 0.0)
-      meta.getString(SplitterSummary.ClassName) shouldBe classOf[DataCutterSummary].getName
+      assert(s)
     case x =>
       fail(s"Unexpected data cutter summary: $x")
   }
 
-  def assertDataCutterSummary(summary: Option[SplitterSummary], expected: DataCutterSummary): Assertion = {
-    assertDataCutterSummary(summary)
-    summary match {
-      case Some(s: DataCutterSummary) => s shouldBe expected
-      case x => fail(s"Unexpected data cutter summary: $x")
-    }
-  }
-
-  def assertDataSplitterSummary: Option[SplitterSummary] => Assertion = {
+  def assertDataSplitterSummary(summary: Option[SplitterSummary])(
+    assert: DataSplitterSummary => Assertion
+  ): Assertion = summary match {
     case Some(s: DataSplitterSummary) =>
       val meta = s.toMetadata()
       meta.getString(SplitterSummary.ClassName) shouldBe classOf[DataSplitterSummary].getName
+      assert(s)
     case x =>
       fail(s"Unexpected data splitter summary: $x")
-  }
-
-  def assertDataSplitterSummary(summary: Option[SplitterSummary], expected: DataSplitterSummary): Assertion = {
-    assertDataSplitterSummary(summary)
-    summary match {
-      case Some(s: DataSplitterSummary) => s shouldBe expected
-      case x => fail(s"Unexpected data splitter summary: $x")
-    }
   }
 
 }

--- a/core/src/test/scala/com/salesforce/op/stages/impl/tuning/SplitterSummaryAsserts.scala
+++ b/core/src/test/scala/com/salesforce/op/stages/impl/tuning/SplitterSummaryAsserts.scala
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2017, Salesforce.com, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.salesforce.op.stages.impl.tuning
+
+import com.salesforce.op.stages.impl.selector.ModelSelectorNames
+import org.scalatest.{Assertion, Matchers}
+
+/**
+ * Assertion helpers for [[SplitterSummary]] child classes
+ */
+trait SplitterSummaryAsserts {
+  self: Matchers =>
+
+  def assertDataBalancerSummary: Option[SplitterSummary] => Assertion = {
+    case Some(s: DataBalancerSummary) =>
+      val meta = s.toMetadata()
+      meta.getString(SplitterSummary.ClassName) shouldBe classOf[DataBalancerSummary].getName
+      meta.getLong(ModelSelectorNames.Positive) should be > 0L
+      meta.getLong(ModelSelectorNames.Negative) should be > 0L
+      meta.getDouble(ModelSelectorNames.Desired) should be > 0.0
+      meta.getDouble(ModelSelectorNames.UpSample) should be >= 0.0
+      meta.getDouble(ModelSelectorNames.DownSample) should be > 0.0
+    case x =>
+      fail(s"Unexpected data balancer summary: $x")
+  }
+
+  def assertDataBalancerSummary(summary: Option[SplitterSummary], expected: DataBalancerSummary): Assertion = {
+    assertDataBalancerSummary(summary)
+    summary match {
+      case Some(s: DataBalancerSummary) => s shouldBe expected
+      case x => fail(s"Unexpected data balancer summary: $x")
+    }
+  }
+
+  def assertDataCutterSummary: Option[SplitterSummary] => Assertion = {
+    case Some(s: DataCutterSummary) =>
+      val meta = s.toMetadata()
+      meta.getDoubleArray(ModelSelectorNames.LabelsKept).foreach(_ should be >= 0.0)
+      meta.getDoubleArray(ModelSelectorNames.LabelsDropped).foreach(_ should be >= 0.0)
+      meta.getString(SplitterSummary.ClassName) shouldBe classOf[DataCutterSummary].getName
+    case x =>
+      fail(s"Unexpected data cutter summary: $x")
+  }
+
+  def assertDataCutterSummary(summary: Option[SplitterSummary], expected: DataCutterSummary): Assertion = {
+    assertDataCutterSummary(summary)
+    summary match {
+      case Some(s: DataCutterSummary) => s shouldBe expected
+      case x => fail(s"Unexpected data cutter summary: $x")
+    }
+  }
+
+  def assertDataSplitterSummary: Option[SplitterSummary] => Assertion = {
+    case Some(s: DataSplitterSummary) =>
+      val meta = s.toMetadata()
+      meta.getString(SplitterSummary.ClassName) shouldBe classOf[DataSplitterSummary].getName
+    case x =>
+      fail(s"Unexpected data splitter summary: $x")
+  }
+
+  def assertDataSplitterSummary(summary: Option[SplitterSummary], expected: DataSplitterSummary): Assertion = {
+    assertDataSplitterSummary(summary)
+    summary match {
+      case Some(s: DataSplitterSummary) => s shouldBe expected
+      case x => fail(s"Unexpected data splitter summary: $x")
+    }
+  }
+
+}

--- a/core/src/test/scala/com/salesforce/op/stages/impl/tuning/SplitterSummaryAsserts.scala
+++ b/core/src/test/scala/com/salesforce/op/stages/impl/tuning/SplitterSummaryAsserts.scala
@@ -45,11 +45,11 @@ trait SplitterSummaryAsserts {
     case Some(s: DataBalancerSummary) =>
       val meta = s.toMetadata()
       meta.getString(SplitterSummary.ClassName) shouldBe classOf[DataBalancerSummary].getName
-      meta.getLong(ModelSelectorNames.Positive) should be > 0L
-      meta.getLong(ModelSelectorNames.Negative) should be > 0L
-      meta.getDouble(ModelSelectorNames.Desired) should be > 0.0
+      meta.getLong(ModelSelectorNames.Positive) should be >= 0L
+      meta.getLong(ModelSelectorNames.Negative) should be >= 0L
+      meta.getDouble(ModelSelectorNames.Desired) should be >= 0.0
       meta.getDouble(ModelSelectorNames.UpSample) should be >= 0.0
-      meta.getDouble(ModelSelectorNames.DownSample) should be > 0.0
+      meta.getDouble(ModelSelectorNames.DownSample) should be >= 0.0
       assert(s)
     case x =>
       fail(s"Unexpected data balancer summary: $x")


### PR DESCRIPTION
**Related issues**
Test code was too repetitive and was not testing splitter summary correctly.

**Describe the proposed solution**
- Added `SplitterSummaryAsserts` for asserting `SplitterSummary` classes 
- Refactored tests for `DataCutter`, `DataSplitter`, `DataBalancer` and `OpValidator` to use `SplitterSummaryAsserts`
- Minor idents and cleanups

**Describe alternatives you've considered**
NA

**Additional context**
TBD - also needs checks & tests for empty datasets - https://github.com/salesforce/TransmogrifAI/issues/161
