### PR TITLE
Allow convertion from Date and Timestamp Spark types to Date and DateTime TransmogrifAI types

### DIFF
--- a/features/src/main/scala/com/salesforce/op/features/FeatureSparkTypes.scala
+++ b/features/src/main/scala/com/salesforce/op/features/FeatureSparkTypes.scala
@@ -220,8 +220,7 @@ case object FeatureSparkTypes {
     case MapType(StringType, ArrayType(StringType, _), _) => weakTypeTag[types.MultiPickListMap]
     case MapType(StringType, ArrayType(DoubleType, _), _) => weakTypeTag[types.GeolocationMap]
     case VectorType => weakTypeTag[types.OPVector]
-    case BinaryType =>
-      throw new IllegalArgumentException("Spark BinaryType is currently not supported.")
+    case BinaryType => throw new IllegalArgumentException("Spark BinaryType is currently not supported")
     case _ => throw new IllegalArgumentException(s"No feature type tag mapping for Spark type $sparkType")
   }
 

--- a/features/src/main/scala/com/salesforce/op/features/types/FeatureTypeSparkConverter.scala
+++ b/features/src/main/scala/com/salesforce/op/features/types/FeatureTypeSparkConverter.scala
@@ -147,12 +147,18 @@ case object FeatureTypeSparkConverter {
 
       // Date & Time
       case wt if wt <:< weakTypeOf[t.DateTime] => (value: Any) =>
-        if (value == null) FeatureTypeDefaults.DateTime.value else Some(value.asInstanceOf[Long])
+        value match {
+          case null => FeatureTypeDefaults.DateTime.value
+          case v: Long => Some(v)
+          case v: java.util.Date => Some(v.getTime)
+          case v => throw new IllegalArgumentException(s"DateTime type mapping is not defined for ${v.getClass}")
+        }
       case wt if wt <:< weakTypeOf[t.Date] => (value: Any) =>
         value match {
           case null => FeatureTypeDefaults.Date.value
           case v: Int => Some(v.toLong)
           case v: Long => Some(v)
+          case v: java.util.Date => Some(v.getTime)
           case v => throw new IllegalArgumentException(s"Date type mapping is not defined for ${v.getClass}")
         }
 

--- a/features/src/test/scala/com/salesforce/op/features/FeatureBuilderTest.scala
+++ b/features/src/test/scala/com/salesforce/op/features/FeatureBuilderTest.scala
@@ -84,12 +84,26 @@ class FeatureBuilderTest extends FlatSpec with TestSparkContext {
     assertFeature[Row, Real](feature)(name = name, in = Row(1.0, "2"), out = 1.toReal, isResponse = true)
   }
 
-  it should "build features from a dataframe" in {
+  it should "build text & numeric features from a dataframe" in {
     val row = data.head()
     val (label, Array(fs, fl)) = FeatureBuilder.fromDataFrame[RealNN](data, response = "d")
     assertFeature(label)(name = "d", in = row, out = 2.0.toRealNN, isResponse = true)
     assertFeature(fs.asInstanceOf[Feature[Text]])(name = "s", in = row, out = "blah1".toText, isResponse = false)
     assertFeature(fl.asInstanceOf[Feature[Integral]])(name = "l", in = row, out = 10.toIntegral, isResponse = false)
+  }
+
+  it should "build time & date features from a dataframe " in {
+    val ts = java.sql.Timestamp.valueOf("2018-12-02 11:05:33.523")
+    val dt = java.sql.Date.valueOf("2018-12-1")
+    val df = spark.createDataFrame(Seq((1.0, ts, dt)))
+    val Array(lblName, tsName, dtName) = df.schema.fieldNames
+    val row = df.head()
+    val (label, Array(time, date)) = FeatureBuilder.fromDataFrame[RealNN](df, response = lblName)
+    assertFeature(label)(name = lblName, in = row, out = 1.0.toRealNN, isResponse = true)
+    assertFeature(time.asInstanceOf[Feature[DateTime]])(
+      name = tsName, in = row, out = ts.getTime.toDateTime, isResponse = false)
+    assertFeature(date.asInstanceOf[Feature[Date]])(
+      name = dtName, in = row, out = dt.getTime.toDate, isResponse = false)
   }
 
   it should "error on invalid response" in {

--- a/features/src/test/scala/com/salesforce/op/features/FeatureBuilderTest.scala
+++ b/features/src/test/scala/com/salesforce/op/features/FeatureBuilderTest.scala
@@ -92,7 +92,7 @@ class FeatureBuilderTest extends FlatSpec with TestSparkContext {
     assertFeature(fl.asInstanceOf[Feature[Integral]])(name = "l", in = row, out = 10.toIntegral, isResponse = false)
   }
 
-  it should "build time & date features from a dataframe " in {
+  it should "build time & date features from a dataframe" in {
     val ts = java.sql.Timestamp.valueOf("2018-12-02 11:05:33.523")
     val dt = java.sql.Date.valueOf("2018-12-1")
     val df = spark.createDataFrame(Seq((1.0, ts, dt)))

--- a/features/src/test/scala/com/salesforce/op/features/FeatureSparkTypeTest.scala
+++ b/features/src/test/scala/com/salesforce/op/features/FeatureSparkTypeTest.scala
@@ -90,7 +90,7 @@ class FeatureSparkTypeTest extends FlatSpec with TestCommon {
 
   it should "error for unsupported types" in {
     val error = intercept[IllegalArgumentException](FeatureSparkTypes.featureTypeTagOf(BinaryType, isNullable = false))
-    error.getMessage shouldBe "Spark BinaryType is currently not supported."
+    error.getMessage shouldBe "Spark BinaryType is currently not supported"
   }
 
   it should "error for unknown types" in {

--- a/features/src/test/scala/com/salesforce/op/features/FeatureSparkTypeTest.scala
+++ b/features/src/test/scala/com/salesforce/op/features/FeatureSparkTypeTest.scala
@@ -31,7 +31,7 @@
 package com.salesforce.op.features
 
 import com.salesforce.op.features.types.FeatureType
-import com.salesforce.op.test.TestSparkContext
+import com.salesforce.op.test.{TestCommon, TestSparkContext}
 import org.apache.spark.ml.linalg.SQLDataTypes.VectorType
 import org.apache.spark.sql.types._
 import org.junit.runner.RunWith
@@ -41,7 +41,7 @@ import org.scalatest.junit.JUnitRunner
 import scala.reflect.runtime.universe._
 
 @RunWith(classOf[JUnitRunner])
-class FeatureSparkTypeTest extends FlatSpec with TestSparkContext {
+class FeatureSparkTypeTest extends FlatSpec with TestCommon {
   val primitiveTypes = Seq(
     (DoubleType, weakTypeTag[types.Real], DoubleType),
     (FloatType, weakTypeTag[types.Real], DoubleType),


### PR DESCRIPTION
**Related issues**
This bug was discovered and reported through Gitter by @msouder 

**Describe the proposed solution**
Added specific cases for `java.util.Date` value conversions in `FeatureTypeSparkConverter` for `Date` and `DateTime`

**Describe alternatives you've considered**
N/A
