### PR TITLE
Possible solution for issue #154 (Geolocation to Country transformer)

### DIFF
--- a/core/src/main/java/geocode/GeoName.java
+++ b/core/src/main/java/geocode/GeoName.java
@@ -1,0 +1,116 @@
+/*
+The MIT License (MIT)
+[OSI Approved License]
+The MIT License (MIT)
+
+Copyright (c) 2014 Daniel Glasson
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+package geocode;
+
+import geocode.kdtree.KDNodeComparator;
+import static java.lang.Math.cos;
+import static java.lang.Math.sin;
+import static java.lang.Math.toRadians;
+
+import java.util.Comparator;
+
+/**
+ * Created by Daniel Glasson on 18/05/2014.
+ * This class works with a placenames files from http://download.geonames.org/export/dump/
+ */
+
+public class GeoName extends KDNodeComparator<GeoName> {
+    public String name;
+    public boolean majorPlace; // Major or minor place
+    public double latitude;
+    public double longitude;
+    public double point[] = new double[3]; // The 3D coordinates of the point
+    public String country;
+
+    GeoName(String data) {
+        String[] names = data.split("\t");
+        name = names[1];
+        majorPlace = names[6].equals("P");
+        latitude = Double.parseDouble(names[4]);
+        longitude = Double.parseDouble(names[5]);
+        setPoint();
+        country = names[8];
+    }
+
+    GeoName(Double latitude, Double longitude) {
+        name = country = "Search";
+        this.latitude = latitude;
+        this.longitude = longitude;
+        setPoint();
+    }
+
+    private void setPoint() {
+        point[0] = cos(toRadians(latitude)) * cos(toRadians(longitude));
+        point[1] = cos(toRadians(latitude)) * sin(toRadians(longitude));
+        point[2] = sin(toRadians(latitude));
+    }
+
+    @Override
+    public String toString() {
+        return name;
+    }
+
+    @Override
+    protected double squaredDistance(GeoName other) {
+        double x = this.point[0] - other.point[0];
+        double y = this.point[1] - other.point[1];
+        double z = this.point[2] - other.point[2];
+        return (x*x) + (y*y) + (z*z);
+    }
+
+    @Override
+    protected double axisSquaredDistance(GeoName other, int axis) {
+        double distance = point[axis] - other.point[axis];
+        return distance * distance;
+    }
+
+    @Override
+    protected Comparator<GeoName> getComparator(int axis) {
+        return GeoNameComparator.values()[axis];
+    }
+
+    protected static enum GeoNameComparator implements Comparator<GeoName> {
+        x {
+            @Override
+            public int compare(GeoName a, GeoName b) {
+                return Double.compare(a.point[0], b.point[0]);
+            }
+        },
+        y {
+            @Override
+            public int compare(GeoName a, GeoName b) {
+                return Double.compare(a.point[1], b.point[1]);
+            }
+        },
+        z {
+            @Override
+            public int compare(GeoName a, GeoName b) {
+                return Double.compare(a.point[2], b.point[2]);
+            }
+        };
+    }
+}

--- a/core/src/main/java/geocode/ReverseGeoCode.java
+++ b/core/src/main/java/geocode/ReverseGeoCode.java
@@ -1,0 +1,105 @@
+/*
+The MIT License (MIT)
+[OSI Approved License]
+The MIT License (MIT)
+
+Copyright (c) 2014 Daniel Glasson
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+package geocode;
+
+import geocode.kdtree.KDTree;
+
+import java.io.*;
+import java.util.ArrayList;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+
+/**
+ * https://github.com/AReallyGoodName/OfflineReverseGeocode
+ *
+ * Created by Daniel Glasson on 18/05/2014.
+ * Uses KD-trees to quickly find the nearest point
+ * 
+ * ReverseGeoCode reverseGeoCode = new ReverseGeoCode(new FileInputStream("c:\\AU.txt"), true);
+ * System.out.println("Nearest to -23.456, 123.456 is " + geocode.nearestPlace(-23.456, 123.456));
+ */
+public class ReverseGeoCode {
+    KDTree<GeoName> kdTree;
+    
+    // Get placenames from http://download.geonames.org/export/dump/
+    /**
+     * Parse the zipped geonames file.
+     * @param zippedPlacednames a {@link ZipInputStream} zip file downloaded from http://download.geonames.org/export/dump/; can not be null.
+     * @param majorOnly only include major cities in KD-tree.
+     * 
+     * @throws IOException if there is a problem reading the {@link ZipInputStream}.
+     * @throws NullPointerException if zippedPlacenames is {@code null}.
+     */
+    public ReverseGeoCode( ZipInputStream zippedPlacednames, boolean majorOnly ) throws IOException {
+        //depending on which zip file is given,
+        //country specific zip files have read me files
+        //that we should ignore
+        ZipEntry entry;
+        do{
+            entry = zippedPlacednames.getNextEntry();
+        }while(entry.getName().equals("readme.txt"));
+       
+        createKdTree(zippedPlacednames, majorOnly);
+        
+    }
+    /**
+     * Parse the raw text geonames file.
+     * @param placenames the text file downloaded from http://download.geonames.org/export/dump/; can not be null.
+     * @param majorOnly only include major cities in KD-tree.
+     * 
+     * @throws IOException if there is a problem reading the stream.
+     * @throws NullPointerException if zippedPlacenames is {@code null}.
+     */
+    public ReverseGeoCode( InputStream placenames, boolean majorOnly ) throws IOException {
+        createKdTree(placenames, majorOnly);
+    }
+    private void createKdTree(InputStream placenames, boolean majorOnly)
+            throws IOException {
+        ArrayList<GeoName> arPlaceNames;
+        arPlaceNames = new ArrayList<GeoName>();
+        // Read the geonames file in the directory
+        BufferedReader in = new BufferedReader(new InputStreamReader(placenames));
+        String str;
+        try {
+            while ((str = in.readLine()) != null) {
+                GeoName newPlace = new GeoName(str);
+                if ( !majorOnly || newPlace.majorPlace ) {
+                    arPlaceNames.add(newPlace);
+                }
+            }
+        } catch (IOException ex) {
+            throw ex;
+        }finally{
+            in.close();
+        }
+        kdTree = new KDTree<GeoName>(arPlaceNames);
+    }
+
+    public GeoName nearestPlace(double latitude, double longitude) {
+        return kdTree.findNearest(new GeoName(latitude,longitude));
+    }
+}

--- a/core/src/main/java/geocode/kdtree/KDNode.java
+++ b/core/src/main/java/geocode/kdtree/KDNode.java
@@ -1,0 +1,43 @@
+/*
+The MIT License (MIT)
+[OSI Approved License]
+The MIT License (MIT)
+
+Copyright (c) 2014 Daniel Glasson
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+package geocode.kdtree;
+
+/**
+ *
+ * @author Daniel Glasson
+ */
+public class KDNode<T extends KDNodeComparator<T>> {
+    KDNode<T> left;
+    KDNode<T> right;
+    T location;
+
+    public KDNode( KDNode<T> left, KDNode<T> right, T location ) {
+        this.left = left;
+        this.right = right;
+        this.location = location;
+    }
+}

--- a/core/src/main/java/geocode/kdtree/KDNodeComparator.java
+++ b/core/src/main/java/geocode/kdtree/KDNodeComparator.java
@@ -1,0 +1,46 @@
+/*
+The MIT License (MIT)
+[OSI Approved License]
+The MIT License (MIT)
+
+Copyright (c) 2014 Daniel Glasson
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+package geocode.kdtree;
+
+import java.util.Comparator;
+
+/**
+ *
+ * @author Daniel Glasson
+ * Make the user return a comparator for each axis
+ * Squared distances should be an optimisation
+ */
+public abstract class KDNodeComparator<T> { 
+    // This should return a comparator for whatever axis is passed in
+    protected abstract Comparator getComparator(int axis);
+    
+    // Return squared distance between current and other
+    protected abstract double squaredDistance(T other);
+    
+    // Return squared distance between one axis only
+    protected abstract double axisSquaredDistance(T other, int axis);
+}

--- a/core/src/main/java/geocode/kdtree/KDTree.java
+++ b/core/src/main/java/geocode/kdtree/KDTree.java
@@ -1,0 +1,78 @@
+/*
+The MIT License (MIT)
+[OSI Approved License]
+The MIT License (MIT)
+
+Copyright (c) 2014 Daniel Glasson
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+package geocode.kdtree;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ *
+ * @author Daniel Glasson
+ * A KD-Tree implementation to quickly find nearest points
+ * Currently implements createKDTree and findNearest as that's all that's required here
+ */
+public class KDTree<T extends KDNodeComparator<T>> {
+    private KDNode<T> root;
+
+    public KDTree( List<T> items ) {
+        root = createKDTree(items, 0);
+    }
+
+    public T findNearest( T search ) {
+        return findNearest(root, search, 0).location;
+    }
+        
+    // Only ever goes to log2(items.length) depth so lack of tail recursion is a non-issue
+    private KDNode<T> createKDTree( List<T> items, int depth ) {
+        if ( items.isEmpty() ) {
+            return null;
+        }
+        Collections.sort(items, items.get(0).getComparator(depth % 3));
+        int currentIndex = items.size()/2;
+        return new KDNode<T>(createKDTree(new ArrayList<T>(items.subList(0, currentIndex)), depth+1), createKDTree(new ArrayList<T>(items.subList(currentIndex + 1, items.size())), depth+1), items.get(currentIndex));
+    }
+
+    private KDNode<T> findNearest(KDNode<T> currentNode, T search, int depth) {
+        int direction = search.getComparator(depth % 3).compare( search, currentNode.location );
+        KDNode<T> next = (direction < 0) ? currentNode.left : currentNode.right;
+        KDNode<T> other = (direction < 0) ? currentNode.right : currentNode.left;
+        KDNode<T> best = (next == null) ? currentNode : findNearest(next, search, depth + 1); // Go to a leaf
+        if ( currentNode.location.squaredDistance(search) < best.location.squaredDistance(search) ) {
+            best = currentNode; // Set best as required
+        } 
+        if ( other != null ) {
+            if ( currentNode.location.axisSquaredDistance(search, depth % 3) < best.location.squaredDistance(search) ) {
+                KDNode<T> possibleBest = findNearest( other, search, depth + 1 );
+                if (  possibleBest.location.squaredDistance(search) < best.location.squaredDistance(search) ) {
+                    best = possibleBest;
+                }
+            }
+        }
+        return best; // Work back up
+    }
+}

--- a/core/src/main/java/geocode/kdtree/KDTree.java
+++ b/core/src/main/java/geocode/kdtree/KDTree.java
@@ -46,16 +46,6 @@ public class KDTree<T extends KDNodeComparator<T>> {
     public T findNearest( T search ) {
         return findNearest(root, search, 0).location;
     }
-        
-    // Only ever goes to log2(items.length) depth so lack of tail recursion is a non-issue
-    private KDNode<T> createKDTree( List<T> items, int depth ) {
-        if ( items.isEmpty() ) {
-            return null;
-        }
-        Collections.sort(items, items.get(0).getComparator(depth % 3));
-        int currentIndex = items.size()/2;
-        return new KDNode<T>(createKDTree(new ArrayList<T>(items.subList(0, currentIndex)), depth+1), createKDTree(new ArrayList<T>(items.subList(currentIndex + 1, items.size())), depth+1), items.get(currentIndex));
-    }
 
     private KDNode<T> findNearest(KDNode<T> currentNode, T search, int depth) {
         int direction = search.getComparator(depth % 3).compare( search, currentNode.location );
@@ -64,7 +54,7 @@ public class KDTree<T extends KDNodeComparator<T>> {
         KDNode<T> best = (next == null) ? currentNode : findNearest(next, search, depth + 1); // Go to a leaf
         if ( currentNode.location.squaredDistance(search) < best.location.squaredDistance(search) ) {
             best = currentNode; // Set best as required
-        } 
+        }
         if ( other != null ) {
             if ( currentNode.location.axisSquaredDistance(search, depth % 3) < best.location.squaredDistance(search) ) {
                 KDNode<T> possibleBest = findNearest( other, search, depth + 1 );
@@ -74,5 +64,15 @@ public class KDTree<T extends KDNodeComparator<T>> {
             }
         }
         return best; // Work back up
+    }
+        
+    // Only ever goes to log2(items.length) depth so lack of tail recursion is a non-issue
+    private KDNode<T> createKDTree( List<T> items, int depth ) {
+        if ( items.isEmpty() ) {
+            return null;
+        }
+        Collections.sort(items, items.get(0).getComparator(depth % 3));
+        int currentIndex = items.size()/2;
+        return new KDNode<T>(createKDTree(new ArrayList<T>(items.subList(0, currentIndex)), depth+1), createKDTree(new ArrayList<T>(items.subList(currentIndex + 1, items.size())), depth+1), items.get(currentIndex));
     }
 }

--- a/core/src/main/scala/com/salesforce/op/stages/impl/feature/GeolocationToCountryTransformer.scala
+++ b/core/src/main/scala/com/salesforce/op/stages/impl/feature/GeolocationToCountryTransformer.scala
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2017, Salesforce.com, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.salesforce.op.stages.impl.feature
+
+import com.salesforce.op.UID
+import com.salesforce.op.features.types.{Geolocation, Text}
+import com.salesforce.op.stages.base.unary.UnaryTransformer
+import geocode.ReverseGeoCode
+
+class GeolocationToCountryTransformer(uid: String = UID[GeolocationToCountryTransformer])
+  extends UnaryTransformer[Geolocation, Text](operationName = "geoToCountry", uid = uid) {
+
+  override def transformFn: Geolocation => Text = (geolocation: Geolocation) => {
+    if (geolocation == null || geolocation.lat == null || geolocation.lon == null) {
+      new Text("")
+    }
+
+    val lat: Double = geolocation.lat
+    val long: Double = geolocation.lon
+
+    new Text(getCountryName(lat, long))
+  }
+
+  private[op] def getCountryName(lat: Double, long: Double): String = {
+    GeolocationToCountryTransformer.reverseGeoCode.nearestPlace(lat, long).country
+  }
+}
+
+object GeolocationToCountryTransformer {
+  val reverseGeoCode = new ReverseGeoCode(
+    getClass.getClassLoader.getResourceAsStream("geolocation/cities1000.txt"), true)
+}

--- a/core/src/main/scala/com/salesforce/op/stages/impl/feature/GeolocationToCountryTransformer.scala
+++ b/core/src/main/scala/com/salesforce/op/stages/impl/feature/GeolocationToCountryTransformer.scala
@@ -39,14 +39,12 @@ class GeolocationToCountryTransformer(uid: String = UID[GeolocationToCountryTran
   extends UnaryTransformer[Geolocation, Text](operationName = "geoToCountry", uid = uid) {
 
   override def transformFn: Geolocation => Text = (geolocation: Geolocation) => {
-    if (geolocation == null || geolocation.lat == null || geolocation.lon == null) {
-      new Text("")
+    geolocation match {
+      case gl if (gl.lat.equals(Double.NaN) || gl.lon.equals(Double.NaN)) => new Text("")
+      case gl => {
+        new Text(getCountryName(gl.lat, gl.lon))
+      }
     }
-
-    val lat: Double = geolocation.lat
-    val long: Double = geolocation.lon
-
-    new Text(getCountryName(lat, long))
   }
 
   private[op] def getCountryName(lat: Double, long: Double): String = {

--- a/core/src/test/scala/com/salesforce/op/stages/impl/feature/GeolocationToCountryTransformerTest.scala
+++ b/core/src/test/scala/com/salesforce/op/stages/impl/feature/GeolocationToCountryTransformerTest.scala
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2017, Salesforce.com, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.salesforce.op.stages.impl.feature
+
+import com.salesforce.op.features.types.{Geolocation, Text}
+import com.salesforce.op.test.{OpTransformerSpec, TestFeatureBuilder}
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+
+@RunWith(classOf[JUnitRunner])
+class GeolocationToCountryTransformerTest extends OpTransformerSpec[Text, GeolocationToCountryTransformer] {
+
+  val sample = Seq[Geolocation](
+    Geolocation((36.7, -119.4, 3.0)),
+    Geolocation((43.6, -79.3, 3.0)),
+    Geolocation((31.2, 121.4, 3.0)),
+    Geolocation((28.7, 77.1, 3.0)),
+    Geolocation((-22.9, -43.1, 3.0))
+  )
+  val (inputData, f1) = TestFeatureBuilder(sample)
+  val transformer: GeolocationToCountryTransformer = new GeolocationToCountryTransformer().setInput(f1)
+  val expectedResult: Seq[Text] = Seq(Text("US"), Text("CA"), Text("CN"), Text("IN"), Text("BR"))
+}

--- a/core/src/test/scala/com/salesforce/op/stages/impl/feature/GeolocationToCountryTransformerTest.scala
+++ b/core/src/test/scala/com/salesforce/op/stages/impl/feature/GeolocationToCountryTransformerTest.scala
@@ -43,9 +43,10 @@ class GeolocationToCountryTransformerTest extends OpTransformerSpec[Text, Geoloc
     Geolocation((43.6, -79.3, 3.0)),
     Geolocation((31.2, 121.4, 3.0)),
     Geolocation((28.7, 77.1, 3.0)),
-    Geolocation((-22.9, -43.1, 3.0))
+    Geolocation((-22.9, -43.1, 3.0)),
+    Geolocation(Seq.empty[Double])
   )
   val (inputData, f1) = TestFeatureBuilder(sample)
   val transformer: GeolocationToCountryTransformer = new GeolocationToCountryTransformer().setInput(f1)
-  val expectedResult: Seq[Text] = Seq(Text("US"), Text("CA"), Text("CN"), Text("IN"), Text("BR"))
+  val expectedResult: Seq[Text] = Seq(Text("US"), Text("CA"), Text("CN"), Text("IN"), Text("BR"), Text(""))
 }


### PR DESCRIPTION
Uses reverse geolocation lookup code at https://github.com/AReallyGoodName/OfflineReverseGeocode

**Related issues**
https://github.com/salesforce/TransmogrifAI/issues/154

**Describe the proposed solution**
The proposed solution, implemented in com.salesforce.op.stages.impl.feature.GeolocationToCountryTransformer, uses latitude and longitude of Geolocation to look up the country code. It uses an offline reverse geocode lookup code at https://github.com/AReallyGoodName/OfflineReverseGeocode. The database for offline lookup is in file core/src/main/resources/geolocation/cities1000.txt. This file has been downloaded from http://download.geonames.org/export/dump/.
The companion object, GeolocationToCountryTransformer, loads the file once, which is then referenced as a static field.

**Describe alternatives you've considered**
An alternative approach is to perform a reverse lookup using a remote service, like the ones listed below:
http://www.geonames.org/export/web-services.html#countrysubdiv
https://developers.google.com/maps/documentation/geocoding/start?csw=1#ReverseGeocoding
Drawbacks:
- needs API license
- latency
- would need a fallback offline approach

**Additional context**
None
