### PR TITLE
Export model selector defaults + metadata fixes

### DIFF
--- a/core/src/main/scala/com/salesforce/op/evaluators/EvaluationMetrics.scala
+++ b/core/src/main/scala/com/salesforce/op/evaluators/EvaluationMetrics.scala
@@ -30,8 +30,8 @@
 
 package com.salesforce.op.evaluators
 
-import com.salesforce.op.utils.spark.RichMetadata._
 import com.salesforce.op.utils.json.{JsonLike, JsonUtils}
+import com.salesforce.op.utils.spark.RichMetadata._
 import enumeratum.{Enum, EnumEntry}
 import org.apache.spark.sql.types.Metadata
 
@@ -50,10 +50,13 @@ trait EvaluationMetrics extends JsonLike {
   def toMap: Map[String, Any] = JsonUtils.toMap(JsonUtils.toJsonTree(this))
 
   /**
-   * Convert metrics into metadata for saving
-   * @return metadata
+   * Convert metrics into [[Metadata]] for saving
+   *
+   * @param skipUnsupported skip unsupported values
+   * @throws RuntimeException in case of unsupported value type
+   * @return [[Metadata]] metadata
    */
-  def toMetadata: Metadata = this.toMap.toMetadata
+  def toMetadata(skipUnsupported: Boolean = false): Metadata = this.toMap.toMetadata(skipUnsupported)
 
 }
 

--- a/core/src/main/scala/com/salesforce/op/stages/impl/classification/BinaryClassificationModelSelector.scala
+++ b/core/src/main/scala/com/salesforce/op/stages/impl/classification/BinaryClassificationModelSelector.scala
@@ -35,7 +35,7 @@ import com.salesforce.op.stages.impl.ModelsToTry
 import com.salesforce.op.stages.impl.classification.{BinaryClassificationModelsToTry => MTT}
 import com.salesforce.op.stages.impl.selector.ModelSelectorNames.{EstimatorType, ModelType}
 import com.salesforce.op.stages.impl.selector.{DefaultSelectorParams, ModelSelector, ModelSelectorFactory}
-import com.salesforce.op.stages.impl.tuning.{DataSplitter, Splitter, _}
+import com.salesforce.op.stages.impl.tuning._
 import enumeratum.Enum
 import org.apache.spark.ml.param.ParamMap
 import org.apache.spark.ml.tuning.ParamGridBuilder
@@ -130,8 +130,8 @@ case object BinaryClassificationModelSelector extends ModelSelectorFactory {
         .addGrid(xgb.minChildWeight, DefaultSelectorParams.MinChildWeight)
         .build()
 
-      Seq(lr -> lrParams, rf -> rfParams, gbt -> gbtParams, svc -> svcParams, nb -> nbParams, dt -> dtParams,
-        xgb -> xgbParams)
+      Seq(lr -> lrParams, rf -> rfParams, gbt -> gbtParams, svc -> svcParams,
+        nb -> nbParams, dt -> dtParams, xgb -> xgbParams)
     }
   }
 
@@ -181,7 +181,7 @@ case object BinaryClassificationModelSelector extends ModelSelectorFactory {
       trainTestEvaluators = Seq(new OpBinaryClassificationEvaluator, new OpBinScoreEvaluator) ++ trainTestEvaluators,
       modelTypesToUse = modelTypesToUse,
       modelsAndParameters = modelsAndParameters,
-      defaults = Defaults
+      modelDefaults = Defaults
     )
   }
 
@@ -226,7 +226,7 @@ case object BinaryClassificationModelSelector extends ModelSelectorFactory {
       trainTestEvaluators = Seq(new OpBinaryClassificationEvaluator) ++ trainTestEvaluators,
       modelTypesToUse = modelTypesToUse,
       modelsAndParameters = modelsAndParameters,
-      defaults = Defaults
+      modelDefaults = Defaults
     )
   }
 

--- a/core/src/main/scala/com/salesforce/op/stages/impl/classification/MultiClassificationModelSelector.scala
+++ b/core/src/main/scala/com/salesforce/op/stages/impl/classification/MultiClassificationModelSelector.scala
@@ -46,54 +46,71 @@ import org.apache.spark.ml.tuning.ParamGridBuilder
  */
 case object MultiClassificationModelSelector extends ModelSelectorFactory {
 
-  private[op] val modelNames: Seq[MultiClassClassificationModelsToTry] = Seq(MTT.OpLogisticRegression,
-    MTT.OpRandomForestClassifier) // OpDecisionTreeClassifier and OpNaiveBayes off by default
+  /**
+   * Default model types and model parameters for problem type
+   */
+  case object Defaults extends ModelDefaults[MultiClassClassificationModelsToTry] {
 
-  protected def defaultModelsAndParams: Seq[(EstimatorType, Array[ParamMap])] = {
-    val lr = new OpLogisticRegression()
-    val lrParams = new ParamGridBuilder()
-      .addGrid(lr.fitIntercept, DefaultSelectorParams.FitIntercept)
-      .addGrid(lr.maxIter, DefaultSelectorParams.MaxIterLin)
-      .addGrid(lr.regParam, DefaultSelectorParams.Regularization)
-      .addGrid(lr.elasticNetParam, DefaultSelectorParams.ElasticNet)
-      .addGrid(lr.standardization, DefaultSelectorParams.Standardized)
-      .addGrid(lr.tol, DefaultSelectorParams.Tol)
-      .build()
+    /**
+     * Subset of models to use in model selector
+     *
+     * Note: [[OpDecisionTreeClassifier]], [[OpNaiveBayes]] and [[OpXGBoostClassifier]] are off by default
+     */
+    val modelTypesToUse: Seq[MultiClassClassificationModelsToTry] = Seq(
+      MTT.OpLogisticRegression, MTT.OpRandomForestClassifier
+    )
 
-    val rf = new OpRandomForestClassifier()
-    val rfParams = new ParamGridBuilder()
-      .addGrid(rf.maxDepth, DefaultSelectorParams.MaxDepth)
-      .addGrid(rf.impurity, DefaultSelectorParams.ImpurityClass)
-      .addGrid(rf.maxBins, DefaultSelectorParams.MaxBin)
-      .addGrid(rf.minInfoGain, DefaultSelectorParams.MinInfoGain)
-      .addGrid(rf.minInstancesPerNode, DefaultSelectorParams.MinInstancesPerNode)
-      .addGrid(rf.numTrees, DefaultSelectorParams.MaxTrees)
-      .addGrid(rf.subsamplingRate, DefaultSelectorParams.SubsampleRate)
-      .build()
+    /**
+     * Default models and parameters (must be a def) to use in model selector
+     *
+     * @return defaults for problem type
+     */
+    def modelsAndParams: Seq[(EstimatorType, Array[ParamMap])] = {
+      val lr = new OpLogisticRegression()
+      val lrParams = new ParamGridBuilder()
+        .addGrid(lr.fitIntercept, DefaultSelectorParams.FitIntercept)
+        .addGrid(lr.maxIter, DefaultSelectorParams.MaxIterLin)
+        .addGrid(lr.regParam, DefaultSelectorParams.Regularization)
+        .addGrid(lr.elasticNetParam, DefaultSelectorParams.ElasticNet)
+        .addGrid(lr.standardization, DefaultSelectorParams.Standardized)
+        .addGrid(lr.tol, DefaultSelectorParams.Tol)
+        .build()
 
-    val nb = new OpNaiveBayes()
-    val nbParams = new ParamGridBuilder()
-      .addGrid(nb.smoothing, DefaultSelectorParams.NbSmoothing)
-      .build()
+      val rf = new OpRandomForestClassifier()
+      val rfParams = new ParamGridBuilder()
+        .addGrid(rf.maxDepth, DefaultSelectorParams.MaxDepth)
+        .addGrid(rf.impurity, DefaultSelectorParams.ImpurityClass)
+        .addGrid(rf.maxBins, DefaultSelectorParams.MaxBin)
+        .addGrid(rf.minInfoGain, DefaultSelectorParams.MinInfoGain)
+        .addGrid(rf.minInstancesPerNode, DefaultSelectorParams.MinInstancesPerNode)
+        .addGrid(rf.numTrees, DefaultSelectorParams.MaxTrees)
+        .addGrid(rf.subsamplingRate, DefaultSelectorParams.SubsampleRate)
+        .build()
 
-    val dt = new OpDecisionTreeClassifier()
-    val dtParams = new ParamGridBuilder()
-      .addGrid(dt.maxDepth, DefaultSelectorParams.MaxDepth)
-      .addGrid(dt.impurity, DefaultSelectorParams.ImpurityClass)
-      .addGrid(dt.maxBins, DefaultSelectorParams.MaxBin)
-      .addGrid(dt.minInfoGain, DefaultSelectorParams.MinInfoGain)
-      .addGrid(dt.minInstancesPerNode, DefaultSelectorParams.MinInstancesPerNode)
-      .build()
+      val nb = new OpNaiveBayes()
+      val nbParams = new ParamGridBuilder()
+        .addGrid(nb.smoothing, DefaultSelectorParams.NbSmoothing)
+        .build()
 
-    val xgb = new OpXGBoostClassifier()
-    val xgbParams = new ParamGridBuilder()
-      .addGrid(xgb.numRound, DefaultSelectorParams.NumRound)
-      .addGrid(xgb.eta, DefaultSelectorParams.Eta)
-      .addGrid(xgb.maxDepth, DefaultSelectorParams.MaxDepth)
-      .addGrid(xgb.minChildWeight, DefaultSelectorParams.MinChildWeight)
-      .build()
+      val dt = new OpDecisionTreeClassifier()
+      val dtParams = new ParamGridBuilder()
+        .addGrid(dt.maxDepth, DefaultSelectorParams.MaxDepth)
+        .addGrid(dt.impurity, DefaultSelectorParams.ImpurityClass)
+        .addGrid(dt.maxBins, DefaultSelectorParams.MaxBin)
+        .addGrid(dt.minInfoGain, DefaultSelectorParams.MinInfoGain)
+        .addGrid(dt.minInstancesPerNode, DefaultSelectorParams.MinInstancesPerNode)
+        .build()
 
-    Seq(lr -> lrParams, rf -> rfParams, nb -> nbParams, dt -> dtParams, xgb -> xgbParams)
+      val xgb = new OpXGBoostClassifier()
+      val xgbParams = new ParamGridBuilder()
+        .addGrid(xgb.numRound, DefaultSelectorParams.NumRound)
+        .addGrid(xgb.eta, DefaultSelectorParams.Eta)
+        .addGrid(xgb.maxDepth, DefaultSelectorParams.MaxDepth)
+        .addGrid(xgb.minChildWeight, DefaultSelectorParams.MinChildWeight)
+        .build()
+
+      Seq(lr -> lrParams, rf -> rfParams, nb -> nbParams, dt -> dtParams, xgb -> xgbParams)
+    }
   }
 
   /**
@@ -131,15 +148,19 @@ case object MultiClassificationModelSelector extends ModelSelectorFactory {
     seed: Long = ValidatorParamDefaults.Seed,
     stratify: Boolean = ValidatorParamDefaults.Stratify,
     parallelism: Int = ValidatorParamDefaults.Parallelism,
-    modelTypesToUse: Seq[MultiClassClassificationModelsToTry] = modelNames,
+    modelTypesToUse: Seq[MultiClassClassificationModelsToTry] = Defaults.modelTypesToUse,
     modelsAndParameters: Seq[(EstimatorType, Array[ParamMap])] = Seq.empty
   ): ModelSelector[ModelType, EstimatorType] = {
     val cv = new OpCrossValidation[ModelType, EstimatorType](
       numFolds = numFolds, seed = seed, validationMetric, stratify = stratify, parallelism = parallelism
     )
-    selector(cv, splitter = splitter,
+    selector(cv,
+      splitter = splitter,
       trainTestEvaluators = Seq(new OpMultiClassificationEvaluator) ++ trainTestEvaluators,
-      modelTypesToUse = modelTypesToUse, modelsAndParameters = modelsAndParameters)
+      modelTypesToUse = modelTypesToUse,
+      modelsAndParameters = modelsAndParameters,
+      defaults = Defaults
+    )
   }
 
   /**
@@ -172,15 +193,19 @@ case object MultiClassificationModelSelector extends ModelSelectorFactory {
     seed: Long = ValidatorParamDefaults.Seed,
     stratify: Boolean = ValidatorParamDefaults.Stratify,
     parallelism: Int = ValidatorParamDefaults.Parallelism,
-    modelTypesToUse: Seq[MultiClassClassificationModelsToTry] = modelNames,
+    modelTypesToUse: Seq[MultiClassClassificationModelsToTry] = Defaults.modelTypesToUse,
     modelsAndParameters: Seq[(EstimatorType, Array[ParamMap])] = Seq.empty
   ): ModelSelector[ModelType, EstimatorType] = {
     val ts = new OpTrainValidationSplit[ModelType, EstimatorType](
       trainRatio = trainRatio, seed = seed, validationMetric, stratify = stratify, parallelism = parallelism
     )
-    selector(ts, splitter = splitter,
+    selector(ts,
+      splitter = splitter,
       trainTestEvaluators = Seq(new OpMultiClassificationEvaluator) ++ trainTestEvaluators,
-      modelTypesToUse = modelTypesToUse, modelsAndParameters = modelsAndParameters)
+      modelTypesToUse = modelTypesToUse,
+      modelsAndParameters = modelsAndParameters,
+      defaults = Defaults
+    )
   }
 }
 

--- a/core/src/main/scala/com/salesforce/op/stages/impl/classification/MultiClassificationModelSelector.scala
+++ b/core/src/main/scala/com/salesforce/op/stages/impl/classification/MultiClassificationModelSelector.scala
@@ -159,7 +159,7 @@ case object MultiClassificationModelSelector extends ModelSelectorFactory {
       trainTestEvaluators = Seq(new OpMultiClassificationEvaluator) ++ trainTestEvaluators,
       modelTypesToUse = modelTypesToUse,
       modelsAndParameters = modelsAndParameters,
-      defaults = Defaults
+      modelDefaults = Defaults
     )
   }
 
@@ -204,7 +204,7 @@ case object MultiClassificationModelSelector extends ModelSelectorFactory {
       trainTestEvaluators = Seq(new OpMultiClassificationEvaluator) ++ trainTestEvaluators,
       modelTypesToUse = modelTypesToUse,
       modelsAndParameters = modelsAndParameters,
-      defaults = Defaults
+      modelDefaults = Defaults
     )
   }
 }

--- a/core/src/main/scala/com/salesforce/op/stages/impl/feature/TextLenTransformer.scala
+++ b/core/src/main/scala/com/salesforce/op/stages/impl/feature/TextLenTransformer.scala
@@ -31,8 +31,7 @@
 package com.salesforce.op.stages.impl.feature
 
 import com.salesforce.op.UID
-import com.salesforce.op.features.types._
-import com.salesforce.op.features.types.{OPVector, TextList}
+import com.salesforce.op.features.types.{OPVector, TextList, _}
 import com.salesforce.op.stages.base.sequence.SequenceTransformer
 import com.salesforce.op.utils.spark.{OpVectorColumnMetadata, OpVectorMetadata}
 import org.apache.spark.ml.linalg.Vectors
@@ -57,12 +56,11 @@ class TextLenTransformer[T <: TextList](uid: String = UID[TextLenTransformer[_]]
     super.onGetMetadata()
     val tf = getTransientFeatures()
     val colMeta = tf.map(f => new OpVectorColumnMetadata(
-        parentFeatureName = Seq(f.name),
-        parentFeatureType = Seq(f.typeName),
-        grouping = Some(f.name),
-        descriptorValue = Option(OpVectorColumnMetadata.TextLenString)
-      )
-    )
+      parentFeatureName = Seq(f.name),
+      parentFeatureType = Seq(f.typeName),
+      grouping = Some(f.name),
+      descriptorValue = Option(OpVectorColumnMetadata.TextLenString)
+    ))
 
     setMetadata(
       OpVectorMetadata(vectorOutputName, colMeta, Transmogrifier.inputFeaturesToHistory(tf, stageName)).toMetadata

--- a/core/src/main/scala/com/salesforce/op/stages/impl/package.scala
+++ b/core/src/main/scala/com/salesforce/op/stages/impl/package.scala
@@ -41,6 +41,24 @@ package object impl {
   trait ModelsToTry extends EnumEntry with Serializable
 
   trait MetadataLike {
-    def toMetadata(): Metadata
+
+    /**
+     * Converts to [[Metadata]]
+     *
+     * @throws RuntimeException in case of unsupported value type
+     * @return [[Metadata]] metadata
+     */
+    def toMetadata(): Metadata = toMetadata(skipUnsupported = false)
+
+    /**
+     * Converts to [[Metadata]]
+     *
+     * @param skipUnsupported skip unsupported values
+     * @throws RuntimeException in case of unsupported value type
+     * @return [[Metadata]] metadata
+     */
+    def toMetadata(skipUnsupported: Boolean): Metadata
+
   }
+
 }

--- a/core/src/main/scala/com/salesforce/op/stages/impl/regression/RegressionModelSelector.scala
+++ b/core/src/main/scala/com/salesforce/op/stages/impl/regression/RegressionModelSelector.scala
@@ -32,7 +32,7 @@ package com.salesforce.op.stages.impl.regression
 
 import com.salesforce.op.evaluators._
 import com.salesforce.op.stages.impl.ModelsToTry
-import com.salesforce.op.stages.impl.regression.{RegressionModelsToTry => RTT}
+import com.salesforce.op.stages.impl.regression.{RegressionModelsToTry => MTT}
 import com.salesforce.op.stages.impl.selector.ModelSelectorNames.{EstimatorType, ModelType}
 import com.salesforce.op.stages.impl.selector.{DefaultSelectorParams, ModelSelectorFactory, ModelSelector}
 import com.salesforce.op.stages.impl.tuning._
@@ -57,7 +57,7 @@ case object RegressionModelSelector extends ModelSelectorFactory {
      * Note: [[OpDecisionTreeRegressor]] and [[OpXGBoostRegressor]] are off by default
      */
     val modelTypesToUse: Seq[RegressionModelsToTry] = Seq(
-      RTT.OpLinearRegression, RTT.OpRandomForestRegressor, RTT.OpGBTRegressor, RTT.OpGeneralizedLinearRegression
+      MTT.OpLinearRegression, MTT.OpRandomForestRegressor, MTT.OpGBTRegressor, MTT.OpGeneralizedLinearRegression
     )
 
     /**
@@ -171,7 +171,7 @@ case object RegressionModelSelector extends ModelSelectorFactory {
       trainTestEvaluators = Seq(new OpRegressionEvaluator) ++ trainTestEvaluators,
       modelTypesToUse = modelTypesToUse,
       modelsAndParameters = modelsAndParameters,
-      defaults = Defaults
+      modelDefaults = Defaults
     )
   }
 
@@ -214,7 +214,7 @@ case object RegressionModelSelector extends ModelSelectorFactory {
       trainTestEvaluators = Seq(new OpRegressionEvaluator) ++ trainTestEvaluators,
       modelTypesToUse = modelTypesToUse,
       modelsAndParameters = modelsAndParameters,
-      defaults = Defaults
+      modelDefaults = Defaults
     )
   }
 

--- a/core/src/main/scala/com/salesforce/op/stages/impl/selector/ModelSelectorSummary.scala
+++ b/core/src/main/scala/com/salesforce/op/stages/impl/selector/ModelSelectorSummary.scala
@@ -73,25 +73,27 @@ case class ModelSelectorSummary
 ) extends MetadataLike {
 
   /**
-   * Convert to metadata instance
+   * Converts to [[Metadata]]
    *
-   * @return
+   * @param skipUnsupported skip unsupported values
+   * @throws RuntimeException in case of unsupported value type
+   * @return [[Metadata]] metadata
    */
-  def toMetadata(): Metadata = {
+  def toMetadata(skipUnsupported: Boolean): Metadata = {
     val meta = new MetadataBuilder()
       .putString(ValidationTypeName, validationType.entryName)
-      .putMetadata(ValidationParameters, validationParameters.toMetadata)
-      .putMetadata(DataPrepParameters, dataPrepParameters.toMetadata)
+      .putMetadata(ValidationParameters, validationParameters.toMetadata(skipUnsupported))
+      .putMetadata(DataPrepParameters, dataPrepParameters.toMetadata(skipUnsupported))
       .putString(EvaluationMetric, evaluationMetric.entryName)
       .putString(ProblemTypeName, problemType.entryName)
       .putString(BestModelUID, bestModelUID)
       .putString(BestModelName, bestModelName)
       .putString(BestModelType, bestModelType)
-      .putMetadataArray(ValidationResults, validationResults.map(_.toMetadata()).toArray)
+      .putMetadataArray(ValidationResults, validationResults.map(_.toMetadata(skipUnsupported)).toArray)
       .putStringArray(TrainEvaluation,
         Array(trainEvaluation.getClass.getName, trainEvaluation.toJson(pretty = false)))
 
-    dataPrepResults.map(dp => meta.putMetadata(DataPrepResults, dp.toMetadata()))
+    dataPrepResults.map(dp => meta.putMetadata(DataPrepResults, dp.toMetadata(skipUnsupported)))
     holdoutEvaluation.map(he => meta.putStringArray(HoldoutEvaluation,
       Array(he.getClass.getName, he.toJson(pretty = false))))
     meta.build()
@@ -117,17 +119,19 @@ case class ModelEvaluation
 ) extends MetadataLike {
 
   /**
-   * Convert to metadata instance
+   * Converts to [[Metadata]]
    *
-   * @return
+   * @param skipUnsupported skip unsupported values
+   * @throws RuntimeException in case of unsupported value type
+   * @return [[Metadata]] metadata
    */
-  def toMetadata(): Metadata = {
+  def toMetadata(skipUnsupported: Boolean): Metadata = {
     new MetadataBuilder()
       .putString(ModelUID, modelUID)
       .putString(ModelName, modelName)
       .putString(ModelTypeName, modelType)
       .putStringArray(MetricValues, Array(metricValues.getClass.getName, metricValues.toJson(pretty = false)))
-      .putMetadata(ModelParameters, modelParameters.toMetadata)
+      .putMetadata(ModelParameters, modelParameters.toMetadata(skipUnsupported))
       .build()
   }
 }

--- a/core/src/main/scala/com/salesforce/op/stages/impl/tuning/DataBalancer.scala
+++ b/core/src/main/scala/com/salesforce/op/stages/impl/tuning/DataBalancer.scala
@@ -409,7 +409,15 @@ case class DataBalancerSummary
   upSamplingFraction: Double,
   downSamplingFraction: Double
 ) extends SplitterSummary {
-  override def toMetadata(): Metadata = {
+
+  /**
+   * Converts to [[Metadata]]
+   *
+   * @param skipUnsupported skip unsupported values
+   * @throws RuntimeException in case of unsupported value type
+   * @return [[Metadata]] metadata
+   */
+  def toMetadata(skipUnsupported: Boolean): Metadata = {
     new MetadataBuilder()
       .putString(SplitterSummary.ClassName, this.getClass.getName)
       .putLong(ModelSelectorNames.Positive, positiveLabels)
@@ -419,4 +427,5 @@ case class DataBalancerSummary
       .putDouble(ModelSelectorNames.DownSample, downSamplingFraction)
       .build()
   }
+
 }

--- a/core/src/main/scala/com/salesforce/op/stages/impl/tuning/DataCutter.scala
+++ b/core/src/main/scala/com/salesforce/op/stages/impl/tuning/DataCutter.scala
@@ -180,7 +180,8 @@ private[impl] trait DataCutterParams extends Params {
 
 /**
  * Summary of results for data cutter
- * @param labelsKept labels retained
+ *
+ * @param labelsKept    labels retained
  * @param labelsDropped labels dropped by data cutter
  */
 case class DataCutterSummary
@@ -188,12 +189,20 @@ case class DataCutterSummary
   labelsKept: Seq[Double],
   labelsDropped: Seq[Double]
 ) extends SplitterSummary {
-  override def toMetadata(): Metadata = {
+
+  /**
+   * Converts to [[Metadata]]
+   *
+   * @param skipUnsupported skip unsupported values
+   * @throws RuntimeException in case of unsupported value type
+   * @return [[Metadata]] metadata
+   */
+  def toMetadata(skipUnsupported: Boolean): Metadata = {
     new MetadataBuilder()
       .putString(SplitterSummary.ClassName, this.getClass.getName)
       .putDoubleArray(ModelSelectorNames.LabelsKept, labelsKept.toArray)
       .putDoubleArray(ModelSelectorNames.LabelsDropped, labelsDropped.toArray)
       .build()
   }
-}
 
+}

--- a/core/src/main/scala/com/salesforce/op/stages/impl/tuning/DataSplitter.scala
+++ b/core/src/main/scala/com/salesforce/op/stages/impl/tuning/DataSplitter.scala
@@ -80,8 +80,18 @@ class DataSplitter(uid: String = UID[DataSplitter]) extends Splitter(uid = uid) 
  * Empty class because no summary information for a data splitter
  */
 case class DataSplitterSummary() extends SplitterSummary {
-  override def toMetadata(): Metadata = new MetadataBuilder()
-    .putString(SplitterSummary.ClassName, this.getClass.getName)
-    .build()
-}
 
+  /**
+   * Converts to [[Metadata]]
+   *
+   * @param skipUnsupported skip unsupported values
+   * @throws RuntimeException in case of unsupported value type
+   * @return [[Metadata]] metadata
+   */
+  def toMetadata(skipUnsupported: Boolean): Metadata = {
+    new MetadataBuilder()
+      .putString(SplitterSummary.ClassName, this.getClass.getName)
+      .build()
+  }
+
+}

--- a/core/src/main/scala/com/salesforce/op/stages/impl/tuning/Splitter.scala
+++ b/core/src/main/scala/com/salesforce/op/stages/impl/tuning/Splitter.scala
@@ -30,14 +30,12 @@
 
 package com.salesforce.op.stages.impl.tuning
 
-import org.apache.spark.ml.param._
-import org.apache.spark.sql.{Dataset, Row}
 import com.salesforce.op.stages.impl.MetadataLike
 import com.salesforce.op.stages.impl.selector.ModelSelectorNames
-import com.salesforce.op.utils.reflection.ReflectionUtils
-import org.apache.spark.sql.types.{Metadata, MetadataBuilder}
 import com.salesforce.op.utils.spark.RichMetadata._
+import org.apache.spark.ml.param._
 import org.apache.spark.sql.types.Metadata
+import org.apache.spark.sql.{Dataset, Row}
 
 import scala.util.Try
 

--- a/core/src/test/scala/com/salesforce/op/evaluators/OpRegressionEvaluatorTest.scala
+++ b/core/src/test/scala/com/salesforce/op/evaluators/OpRegressionEvaluatorTest.scala
@@ -86,7 +86,7 @@ class OpRegressionEvaluatorTest extends FlatSpec with TestSparkContext {
   it should "evaluate the metrics from a model selector" in {
     val model = testEstimator.fit(ds)
     val transformedData = model.setInput(label, features).transform(ds)
-    val metrics = testEvaluator.evaluateAll(transformedData).toMetadata
+    val metrics = testEvaluator.evaluateAll(transformedData).toMetadata()
 
     assert(metrics.getDouble(RegressionEvalMetrics.RootMeanSquaredError.toString) <= 1E-12, "rmse should be close to 0")
     assert(metrics.getDouble(RegressionEvalMetrics.MeanSquaredError.toString) <= 1E-24, "mse should be close to 0")
@@ -97,7 +97,7 @@ class OpRegressionEvaluatorTest extends FlatSpec with TestSparkContext {
   it should "evaluate the metrics from a single model" in {
     val model = testEstimator2.fit(ds)
     val transformedData = model.setInput(label, features).transform(ds)
-    val metrics = testEvaluator2.evaluateAll(transformedData).toMetadata
+    val metrics = testEvaluator2.evaluateAll(transformedData).toMetadata()
 
     assert(metrics.getDouble(RegressionEvalMetrics.RootMeanSquaredError.toString) <= 1E-12, "rmse should be close to 0")
     assert(metrics.getDouble(RegressionEvalMetrics.MeanSquaredError.toString) <= 1E-24, "mse should be close to 0")

--- a/core/src/test/scala/com/salesforce/op/stages/impl/classification/BinaryClassificationModelSelectorTest.scala
+++ b/core/src/test/scala/com/salesforce/op/stages/impl/classification/BinaryClassificationModelSelectorTest.scala
@@ -172,8 +172,9 @@ class BinaryClassificationModelSelectorTest extends FlatSpec with TestSparkConte
   }
 
   it should "fit and predict for default models" in {
-
-    val modelToTry = BinaryClassificationModelSelector.Defaults.modelTypesToUse(scala.util.Random.nextInt(4))
+    // Take one random model type each time
+    val defaultModels = BinaryClassificationModelSelector.Defaults.modelTypesToUse
+    val modelToTry = defaultModels(scala.util.Random.nextInt(defaultModels.size))
 
     val testEstimator =
       BinaryClassificationModelSelector

--- a/core/src/test/scala/com/salesforce/op/stages/impl/classification/BinaryClassificationModelSelectorTest.scala
+++ b/core/src/test/scala/com/salesforce/op/stages/impl/classification/BinaryClassificationModelSelectorTest.scala
@@ -173,7 +173,7 @@ class BinaryClassificationModelSelectorTest extends FlatSpec with TestSparkConte
 
   it should "fit and predict for default models" in {
 
-    val modelToTry = BinaryClassificationModelSelector.modelNames(scala.util.Random.nextInt(4))
+    val modelToTry = BinaryClassificationModelSelector.Defaults.modelTypesToUse(scala.util.Random.nextInt(4))
 
     val testEstimator =
       BinaryClassificationModelSelector

--- a/core/src/test/scala/com/salesforce/op/stages/impl/classification/MultiClassificationModelSelectorTest.scala
+++ b/core/src/test/scala/com/salesforce/op/stages/impl/classification/MultiClassificationModelSelectorTest.scala
@@ -178,7 +178,9 @@ class MultiClassificationModelSelectorTest extends FlatSpec with TestSparkContex
   }
 
   it should "fit and predict for default models" in {
-    val modelToTry = MultiClassificationModelSelector.Defaults.modelTypesToUse(scala.util.Random.nextInt(2))
+    // Take one random model type each time
+    val defaultModels = MultiClassificationModelSelector.Defaults.modelTypesToUse
+    val modelToTry = defaultModels(scala.util.Random.nextInt(defaultModels.size))
 
     val testEstimator =
       MultiClassificationModelSelector

--- a/core/src/test/scala/com/salesforce/op/stages/impl/classification/MultiClassificationModelSelectorTest.scala
+++ b/core/src/test/scala/com/salesforce/op/stages/impl/classification/MultiClassificationModelSelectorTest.scala
@@ -178,7 +178,7 @@ class MultiClassificationModelSelectorTest extends FlatSpec with TestSparkContex
   }
 
   it should "fit and predict for default models" in {
-    val modelToTry = MultiClassificationModelSelector.modelNames(scala.util.Random.nextInt(2))
+    val modelToTry = MultiClassificationModelSelector.Defaults.modelTypesToUse(scala.util.Random.nextInt(2))
 
     val testEstimator =
       MultiClassificationModelSelector

--- a/core/src/test/scala/com/salesforce/op/stages/impl/feature/TextMapNullEstimatorTest.scala
+++ b/core/src/test/scala/com/salesforce/op/stages/impl/feature/TextMapNullEstimatorTest.scala
@@ -61,10 +61,10 @@ class TextMapNullEstimatorTest
   val estimator = new TextMapNullEstimator[TextMap]().setInput(f1)
 
   val expectedResult = Seq(
-      Array(0.0, 0.0, 0.0, 0.0),
-      Array(1.0, 0.0, 1.0, 1.0),
-      Array(1.0, 1.0, 0.0, 1.0)
-    ).map(Vectors.dense(_).toOPVector)
+    Array(0.0, 0.0, 0.0, 0.0),
+    Array(1.0, 0.0, 1.0, 1.0),
+    Array(1.0, 1.0, 0.0, 1.0)
+  ).map(Vectors.dense(_).toOPVector)
 
   Spec[TextListNullTransformer[_]] should "take an array of features as input and return a single vector feature" in {
     val vector = estimator.getOutput()

--- a/core/src/test/scala/com/salesforce/op/stages/impl/regression/RegressionModelSelectorTest.scala
+++ b/core/src/test/scala/com/salesforce/op/stages/impl/regression/RegressionModelSelectorTest.scala
@@ -176,7 +176,7 @@ class RegressionModelSelectorTest extends FlatSpec with TestSparkContext
 
   it should "fit and predict for default models" in {
 
-    val modelToTry = RegressionModelSelector.modelNames(scala.util.Random.nextInt(4))
+    val modelToTry = RegressionModelSelector.Defaults.modelTypesToUse(scala.util.Random.nextInt(4))
 
     val testEstimator = RegressionModelSelector
       .withCrossValidation(

--- a/core/src/test/scala/com/salesforce/op/stages/impl/regression/RegressionModelSelectorTest.scala
+++ b/core/src/test/scala/com/salesforce/op/stages/impl/regression/RegressionModelSelectorTest.scala
@@ -175,8 +175,9 @@ class RegressionModelSelectorTest extends FlatSpec with TestSparkContext
   }
 
   it should "fit and predict for default models" in {
-
-    val modelToTry = RegressionModelSelector.Defaults.modelTypesToUse(scala.util.Random.nextInt(4))
+    // Take one random model type each time
+    val defaultModels = RegressionModelSelector.Defaults.modelTypesToUse
+    val modelToTry = defaultModels(scala.util.Random.nextInt(defaultModels.size))
 
     val testEstimator = RegressionModelSelector
       .withCrossValidation(

--- a/gradle/version-properties.gradle
+++ b/gradle/version-properties.gradle
@@ -2,12 +2,17 @@
  * Helper that calls a command and returns the output.
  */
 def cmdCaller = { commandln ->
-    def stdout = new ByteArrayOutputStream()
-    exec {
-        commandLine commandln
-        standardOutput = stdout
+    try {
+        def stdout = new ByteArrayOutputStream()
+        exec {
+            commandLine commandln
+            standardOutput = stdout
+        }
+        return stdout.toString().trim()
+    } catch (Exception ex) {
+        System.err.println("Command execution failed: '" + commandln.join(" ") + "'. Error: " + ex.message)
+        return ""
     }
-    return stdout.toString().trim()
 }
 
 

--- a/helloworld/src/main/scala/com/salesforce/hw/titanic/OpTitanic.scala
+++ b/helloworld/src/main/scala/com/salesforce/hw/titanic/OpTitanic.scala
@@ -32,8 +32,6 @@ package com.salesforce.hw.titanic
 
 import com.salesforce.op._
 import com.salesforce.op.evaluators.Evaluators
-import com.salesforce.op.features.FeatureLike
-import com.salesforce.op.features.types.Text
 import com.salesforce.op.readers.DataReaders
 import com.salesforce.op.stages.impl.classification._
 import com.salesforce.op.stages.impl.tuning.DataSplitter
@@ -57,15 +55,6 @@ object OpTitanic extends OpAppWithRunner with TitanicFeatures {
   ////////////////////////////////////////////////////////////////////////////////
   // WORKFLOW DEFINITION
   /////////////////////////////////////////////////////////////////////////////////
-
-  val familySize = (age + age).bucketize(trackNulls = true, trackInvalid = true)
-
-  val textIdfs = Seq(pClass, name, sex, age, sibSp, parch, ticket, cabin, embarked).collect {
-    case f if f.isSubtypeOf[Text] => f.asInstanceOf[FeatureLike[Text]]
-  }.map(_.tokenize(autoDetectLanguage = true).tf(numTerms = 100).idf()).combine()
-
-  name.tokenize(autoDetectLanguage = true).tf(numTerms = 100).idf()
-
 
   // Automated feature engineering
   val featureVector = Seq(pClass, name, sex, age, sibSp, parch, ticket, cabin, embarked).transmogrify()

--- a/helloworld/src/main/scala/com/salesforce/hw/titanic/OpTitanic.scala
+++ b/helloworld/src/main/scala/com/salesforce/hw/titanic/OpTitanic.scala
@@ -32,6 +32,8 @@ package com.salesforce.hw.titanic
 
 import com.salesforce.op._
 import com.salesforce.op.evaluators.Evaluators
+import com.salesforce.op.features.FeatureLike
+import com.salesforce.op.features.types.Text
 import com.salesforce.op.readers.DataReaders
 import com.salesforce.op.stages.impl.classification._
 import com.salesforce.op.stages.impl.tuning.DataSplitter
@@ -55,6 +57,15 @@ object OpTitanic extends OpAppWithRunner with TitanicFeatures {
   ////////////////////////////////////////////////////////////////////////////////
   // WORKFLOW DEFINITION
   /////////////////////////////////////////////////////////////////////////////////
+
+  val familySize = (age + age).bucketize(trackNulls = true, trackInvalid = true)
+
+  val textIdfs = Seq(pClass, name, sex, age, sibSp, parch, ticket, cabin, embarked).collect {
+    case f if f.isSubtypeOf[Text] => f.asInstanceOf[FeatureLike[Text]]
+  }.map(_.tokenize(autoDetectLanguage = true).tf(numTerms = 100).idf()).combine()
+
+  name.tokenize(autoDetectLanguage = true).tf(numTerms = 100).idf()
+
 
   // Automated feature engineering
   val featureVector = Seq(pClass, name, sex, age, sibSp, parch, ticket, cabin, embarked).transmogrify()


### PR DESCRIPTION
**Related issues**
1. It's impossible to reuse model selector default models & grids without copy pasting them from our code base.
2. Currently model selector fails to produce model selector summary metadata when one of the models contain a stage with unsupported params (example - #198). 

**Describe the proposed solution**
1. Expose model selector defaults on all model selectors (binary, multi, regression) to allow reuse.
2. Skip unsupported metadata values when producing model selector summary metadata.

**Describe alternatives you've considered**
N/A
