### PR TITLE
Use ParamGridBuilder in model selector grids to allow modifications

### DIFF
--- a/core/src/main/scala/com/salesforce/op/stages/impl/classification/BinaryClassificationModelSelector.scala
+++ b/core/src/main/scala/com/salesforce/op/stages/impl/classification/BinaryClassificationModelSelector.scala
@@ -65,7 +65,7 @@ case object BinaryClassificationModelSelector extends ModelSelectorFactory {
      *
      * @return defaults for problem type
      */
-    def modelsAndParams: Seq[(EstimatorType, Array[ParamMap])] = {
+    def modelsAndParams: Seq[(EstimatorType, ParamGridBuilder)] = {
       val lr = new OpLogisticRegression()
       val lrParams = new ParamGridBuilder()
         .addGrid(lr.fitIntercept, DefaultSelectorParams.FitIntercept)
@@ -74,7 +74,6 @@ case object BinaryClassificationModelSelector extends ModelSelectorFactory {
         .addGrid(lr.regParam, DefaultSelectorParams.Regularization)
         .addGrid(lr.standardization, DefaultSelectorParams.Standardized)
         .addGrid(lr.tol, DefaultSelectorParams.Tol)
-        .build()
 
       val rf = new OpRandomForestClassifier()
       val rfParams = new ParamGridBuilder()
@@ -85,7 +84,6 @@ case object BinaryClassificationModelSelector extends ModelSelectorFactory {
         .addGrid(rf.minInstancesPerNode, DefaultSelectorParams.MinInstancesPerNode)
         .addGrid(rf.numTrees, DefaultSelectorParams.MaxTrees)
         .addGrid(rf.subsamplingRate, DefaultSelectorParams.SubsampleRate)
-        .build()
 
       val gbt = new OpGBTClassifier()
       val gbtParams = new ParamGridBuilder()
@@ -97,7 +95,6 @@ case object BinaryClassificationModelSelector extends ModelSelectorFactory {
         .addGrid(gbt.maxIter, DefaultSelectorParams.MaxIterTree)
         .addGrid(gbt.subsamplingRate, DefaultSelectorParams.SubsampleRate)
         .addGrid(gbt.stepSize, DefaultSelectorParams.StepSize)
-        .build()
 
       val svc = new OpLinearSVC()
       val svcParams = new ParamGridBuilder()
@@ -106,12 +103,10 @@ case object BinaryClassificationModelSelector extends ModelSelectorFactory {
         .addGrid(svc.fitIntercept, DefaultSelectorParams.FitIntercept)
         .addGrid(svc.tol, DefaultSelectorParams.Tol)
         .addGrid(svc.standardization, DefaultSelectorParams.Standardized)
-        .build()
 
       val nb = new OpNaiveBayes()
       val nbParams = new ParamGridBuilder()
         .addGrid(nb.smoothing, DefaultSelectorParams.NbSmoothing)
-        .build()
 
       val dt = new OpDecisionTreeClassifier()
       val dtParams = new ParamGridBuilder()
@@ -120,7 +115,6 @@ case object BinaryClassificationModelSelector extends ModelSelectorFactory {
         .addGrid(dt.maxBins, DefaultSelectorParams.MaxBin)
         .addGrid(dt.minInfoGain, DefaultSelectorParams.MinInfoGain)
         .addGrid(dt.minInstancesPerNode, DefaultSelectorParams.MinInstancesPerNode)
-        .build()
 
       val xgb = new OpXGBoostClassifier()
       val xgbParams = new ParamGridBuilder()
@@ -128,7 +122,6 @@ case object BinaryClassificationModelSelector extends ModelSelectorFactory {
         .addGrid(xgb.eta, DefaultSelectorParams.Eta)
         .addGrid(xgb.maxDepth, DefaultSelectorParams.MaxDepth)
         .addGrid(xgb.minChildWeight, DefaultSelectorParams.MinChildWeight)
-        .build()
 
       Seq(lr -> lrParams, rf -> rfParams, gbt -> gbtParams, svc -> svcParams,
         nb -> nbParams, dt -> dtParams, xgb -> xgbParams)

--- a/core/src/main/scala/com/salesforce/op/stages/impl/classification/MultiClassificationModelSelector.scala
+++ b/core/src/main/scala/com/salesforce/op/stages/impl/classification/MultiClassificationModelSelector.scala
@@ -65,7 +65,7 @@ case object MultiClassificationModelSelector extends ModelSelectorFactory {
      *
      * @return defaults for problem type
      */
-    def modelsAndParams: Seq[(EstimatorType, Array[ParamMap])] = {
+    def modelsAndParams: Seq[(EstimatorType, ParamGridBuilder)] = {
       val lr = new OpLogisticRegression()
       val lrParams = new ParamGridBuilder()
         .addGrid(lr.fitIntercept, DefaultSelectorParams.FitIntercept)
@@ -74,7 +74,6 @@ case object MultiClassificationModelSelector extends ModelSelectorFactory {
         .addGrid(lr.elasticNetParam, DefaultSelectorParams.ElasticNet)
         .addGrid(lr.standardization, DefaultSelectorParams.Standardized)
         .addGrid(lr.tol, DefaultSelectorParams.Tol)
-        .build()
 
       val rf = new OpRandomForestClassifier()
       val rfParams = new ParamGridBuilder()
@@ -85,12 +84,10 @@ case object MultiClassificationModelSelector extends ModelSelectorFactory {
         .addGrid(rf.minInstancesPerNode, DefaultSelectorParams.MinInstancesPerNode)
         .addGrid(rf.numTrees, DefaultSelectorParams.MaxTrees)
         .addGrid(rf.subsamplingRate, DefaultSelectorParams.SubsampleRate)
-        .build()
 
       val nb = new OpNaiveBayes()
       val nbParams = new ParamGridBuilder()
         .addGrid(nb.smoothing, DefaultSelectorParams.NbSmoothing)
-        .build()
 
       val dt = new OpDecisionTreeClassifier()
       val dtParams = new ParamGridBuilder()
@@ -99,7 +96,6 @@ case object MultiClassificationModelSelector extends ModelSelectorFactory {
         .addGrid(dt.maxBins, DefaultSelectorParams.MaxBin)
         .addGrid(dt.minInfoGain, DefaultSelectorParams.MinInfoGain)
         .addGrid(dt.minInstancesPerNode, DefaultSelectorParams.MinInstancesPerNode)
-        .build()
 
       val xgb = new OpXGBoostClassifier()
       val xgbParams = new ParamGridBuilder()
@@ -107,7 +103,6 @@ case object MultiClassificationModelSelector extends ModelSelectorFactory {
         .addGrid(xgb.eta, DefaultSelectorParams.Eta)
         .addGrid(xgb.maxDepth, DefaultSelectorParams.MaxDepth)
         .addGrid(xgb.minChildWeight, DefaultSelectorParams.MinChildWeight)
-        .build()
 
       Seq(lr -> lrParams, rf -> rfParams, nb -> nbParams, dt -> dtParams, xgb -> xgbParams)
     }

--- a/core/src/main/scala/com/salesforce/op/stages/impl/regression/RegressionModelSelector.scala
+++ b/core/src/main/scala/com/salesforce/op/stages/impl/regression/RegressionModelSelector.scala
@@ -65,7 +65,7 @@ case object RegressionModelSelector extends ModelSelectorFactory {
      *
      * @return defaults for problem type
      */
-    def modelsAndParams: Seq[(EstimatorType, Array[ParamMap])] = {
+    def modelsAndParams: Seq[(EstimatorType, ParamGridBuilder)] = {
       val lr = new OpLinearRegression()
       val lrParams = new ParamGridBuilder()
         .addGrid(lr.fitIntercept, DefaultSelectorParams.FitIntercept)
@@ -75,7 +75,6 @@ case object RegressionModelSelector extends ModelSelectorFactory {
         .addGrid(lr.solver, DefaultSelectorParams.RegSolver)
         .addGrid(lr.standardization, DefaultSelectorParams.Standardized)
         .addGrid(lr.tol, DefaultSelectorParams.Tol)
-        .build()
 
       val rf = new OpRandomForestRegressor()
       val rfParams = new ParamGridBuilder()
@@ -85,7 +84,6 @@ case object RegressionModelSelector extends ModelSelectorFactory {
         .addGrid(rf.minInstancesPerNode, DefaultSelectorParams.MinInstancesPerNode)
         .addGrid(rf.numTrees, DefaultSelectorParams.MaxTrees)
         .addGrid(rf.subsamplingRate, DefaultSelectorParams.SubsampleRate)
-        .build()
 
       val gbt = new OpGBTRegressor()
       val gbtParams = new ParamGridBuilder()
@@ -97,7 +95,6 @@ case object RegressionModelSelector extends ModelSelectorFactory {
         .addGrid(gbt.maxIter, DefaultSelectorParams.MaxIterTree)
         .addGrid(gbt.subsamplingRate, DefaultSelectorParams.SubsampleRate)
         .addGrid(gbt.stepSize, DefaultSelectorParams.StepSize)
-        .build()
 
       val dt = new OpDecisionTreeRegressor()
       val dtParams = new ParamGridBuilder()
@@ -105,7 +102,6 @@ case object RegressionModelSelector extends ModelSelectorFactory {
         .addGrid(dt.maxBins, DefaultSelectorParams.MaxBin)
         .addGrid(dt.minInfoGain, DefaultSelectorParams.MinInfoGain)
         .addGrid(dt.minInstancesPerNode, DefaultSelectorParams.MinInstancesPerNode)
-        .build()
 
       val glr = new OpGeneralizedLinearRegression()
       val glrParams = new ParamGridBuilder()
@@ -114,7 +110,6 @@ case object RegressionModelSelector extends ModelSelectorFactory {
         .addGrid(glr.maxIter, DefaultSelectorParams.MaxIterLin)
         .addGrid(glr.regParam, DefaultSelectorParams.Regularization)
         .addGrid(glr.tol, DefaultSelectorParams.Tol)
-        .build()
 
       val xgb = new OpXGBoostRegressor()
       val xgbParams = new ParamGridBuilder()
@@ -122,7 +117,6 @@ case object RegressionModelSelector extends ModelSelectorFactory {
         .addGrid(xgb.eta, DefaultSelectorParams.Eta)
         .addGrid(xgb.maxDepth, DefaultSelectorParams.MaxDepth)
         .addGrid(xgb.minChildWeight, DefaultSelectorParams.MinChildWeight)
-        .build()
 
       Seq(lr -> lrParams, rf -> rfParams, gbt -> gbtParams, dt -> dtParams, glr -> glrParams, xgb -> xgbParams)
     }


### PR DESCRIPTION
**Related issues**
It's difficult to reuse the model selector default grids, especially if one only wants to change a single param value.

**Describe the proposed solution**
We replace `Array[ParamMap]` with `ParamGridBuilder` to ease on that. For example user can now modify a single parameter `maxBins` like this and keep the rest of the grid the same:
```scala
val modelsAndParams = BinaryClassificationModelSelector.Defaults.modelsAndParams.map {
    case (e: OpRandomForestClassifier, grid) => e -> grid.addGrid(e.maxBins, Array(1, 2, 3)).build()
    case (e, grid) => e -> grid.build()
  }
val modelSelector = BinaryClassificationModelSelector.withCrossValidation(modelsAndParameters = modelsAndParams)
```

**Describe alternatives you've considered**
Many many others.

**Additional context**
This is still not over...
