### PR TITLE
Scaler and descaler transformers

### DIFF
--- a/core/src/main/scala/com/salesforce/op/dsl/RichMapFeature.scala
+++ b/core/src/main/scala/com/salesforce/op/dsl/RichMapFeature.scala
@@ -1093,7 +1093,7 @@ trait RichMapFeature {
      * @param scaledFeature Feature containing the metadata to reconstruct the inverse scaling function
      * @tparam I feature type of the input feature: scaledFeature
      * @tparam O Output Feature type
-     * @return
+     * @return the scaled prediction value cast to type O.
      */
     def descale[I <: Real : TypeTag, O <: Real: TypeTag](scaledFeature: FeatureLike[I]): FeatureLike[O] = {
       new PredictionDescaler[I, O]().setInput(f, scaledFeature).getOutput()

--- a/core/src/main/scala/com/salesforce/op/dsl/RichNumericFeature.scala
+++ b/core/src/main/scala/com/salesforce/op/dsl/RichNumericFeature.scala
@@ -352,7 +352,7 @@ trait RichNumericFeature {
      * @param scalingType type of scaling function
      * @param scalingArgs arguments to define the scaling function
      * @tparam O Output feature type
-     * @return
+     * @return the descaled input cast to type O
      */
     def scale[O <: Real : TypeTag](
       scalingType: ScalingType,
@@ -367,7 +367,7 @@ trait RichNumericFeature {
      * @param scaledFeature the feature containing metadata for constructing the scaling used to make this column
      * @tparam I feature type of the input feature: scaledFeature
      * @tparam O output feature type
-     * @return
+     * @return the scaled input cast to type O
      */
     def descale[I <: Real : TypeTag, O <: Real : TypeTag](scaledFeature: FeatureLike[I]): FeatureLike[O] = {
       new DescalerTransformer[T, I, O]().setInput(f, scaledFeature).getOutput()

--- a/core/src/main/scala/com/salesforce/op/dsl/RichNumericFeature.scala
+++ b/core/src/main/scala/com/salesforce/op/dsl/RichNumericFeature.scala
@@ -346,6 +346,32 @@ trait RichNumericFeature {
           new VectorsCombiner().setInput(filledValues +: bucketized).getOutput()
       }
     }
+
+    /**
+     * Apply ScalerTransformer shortcut.  Applies the scaling function defined by the scalingType and scalingArg params
+     * @param scalingType type of scaling function
+     * @param scalingArgs arguments to define the scaling function
+     * @tparam O Output feature type
+     * @return
+     */
+    def scale[O <: Real : TypeTag](
+      scalingType: ScalingType,
+      scalingArgs: ScalingArgs
+    ): FeatureLike[O] = {
+      new ScalerTransformer[T, O](scalingType = scalingType, scalingArgs = scalingArgs).setInput(f).getOutput()
+    }
+
+    /**
+     * Apply DescalerTransformer shortcut.  Applies the inverse of the scaling function found in
+     * the metadata of the the input feature: scaledFeature
+     * @param scaledFeature the feature containing metadata for constructing the scaling used to make this column
+     * @tparam I feature type of the input feature: scaledFeature
+     * @tparam O output feature type
+     * @return
+     */
+    def descale[I <: Real : TypeTag, O <: Real : TypeTag](scaledFeature: FeatureLike[I]): FeatureLike[O] = {
+      new DescalerTransformer[T, I, O]().setInput(f, scaledFeature).getOutput()
+    }
   }
 
 

--- a/core/src/main/scala/com/salesforce/op/stages/impl/feature/DescalerTransformer.scala
+++ b/core/src/main/scala/com/salesforce/op/stages/impl/feature/DescalerTransformer.scala
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2017, Salesforce.com, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.salesforce.op.stages.impl.feature
+
+import com.salesforce.op.UID
+import com.salesforce.op.features.types.{FeatureTypeFactory, Prediction, Real}
+import com.salesforce.op.stages.base.binary.BinaryTransformer
+
+import scala.reflect.runtime.universe.TypeTag
+import scala.util.{Failure, Success}
+
+/**
+ * A transformer that takes as inputs a feature to descale and (potentially different) scaled feature which contains the
+ * metadata for reconstructing the inverse scaling function.  Transforms the 2nd input feature by applying the inverse
+ * of the scaling function found in the metadata
+ * - 1st input feature the feature to descale
+ * - 2nd input feature the scaled feature containing metadata for constructing the scaling used to make this column
+ *
+ * @param uid  uid for instance
+ * @param tti1 type tag for first input
+ * @param tti2 type tag for second input
+ * @param tto  type tag for output
+ * @param ttov type tag for output value
+ * @tparam I1 feature type for first input
+ * @tparam I2 feature type for the second input
+ * @tparam O  output feature type
+ */
+final class DescalerTransformer[I1 <: Real, I2 <: Real, O <: Real]
+(
+  uid: String = UID[DescalerTransformer[_, _, _]]
+)(implicit tti1: TypeTag[I1], tti2: TypeTag[I2], tto: TypeTag[O], ttov: TypeTag[O#Value])
+  extends BinaryTransformer[I1, I2, O](operationName = "descaler", uid = uid) {
+
+  private val ftFactory = FeatureTypeFactory[O]()
+
+  @transient private lazy val meta = getInputSchema()(in2.name).metadata
+  @transient private lazy val scalerMeta: ScalerMetadata = ScalerMetadata(meta) match {
+    case Success(sm) => sm
+    case Failure(error) =>
+      throw new RuntimeException(s"Failed to extract scaler metadata for input feature '${in2.name}'", error)
+  }
+  @transient private lazy val scaler = Scaler(scalerMeta.scalingType, scalerMeta.scalingArgs)
+
+  def transformFn: (I1, I2) => O = (v, _) => {
+    val descaled = v.toDouble.map(scaler.descale)
+    ftFactory.newInstance(descaled)
+  }
+
+}
+
+/**
+ * Applies to the input column the inverse of the scaling function defined in the Prediction feature metadata.
+ * - 1st input feature is the Prediction feature to descale
+ * - 2nd input feature is scaled Prediction feature containing the metadata for constructing
+ * the scaling used to make this column
+ *
+ * @param uid  uid for instance
+ * @param tti2 type tag for second input
+ * @param tto  type tag for output
+ * @param ttov type tag for output value
+ * @tparam I input feature type
+ * @tparam O output feature type
+ */
+final class PredictionDescaler[I <: Real, O <: Real]
+(
+  uid: String = UID[PredictionDescaler[_, _]]
+)(implicit tti2: TypeTag[I], tto: TypeTag[O], ttov: TypeTag[O#Value])
+  extends BinaryTransformer[Prediction, I, O](operationName = "descaler", uid = uid) {
+
+  private val ftFactory = FeatureTypeFactory[O]()
+
+  @transient private lazy val meta = getInputSchema()(in2.name).metadata
+  @transient private lazy val scalerMeta: ScalerMetadata = ScalerMetadata(meta) match {
+    case Success(sm) => sm
+    case Failure(error) =>
+      throw new RuntimeException(s"Failed to extract scaler metadata for input feature '${in2.name}'", error)
+  }
+  @transient private lazy val scaler = Scaler(scalerMeta.scalingType, scalerMeta.scalingArgs)
+
+  def transformFn: (Prediction, I) => O = (v, _) => {
+    val descaled = Some(scaler.descale(v.prediction))
+    ftFactory.newInstance(descaled)
+  }
+}

--- a/core/src/main/scala/com/salesforce/op/stages/impl/feature/ScalerTransformer.scala
+++ b/core/src/main/scala/com/salesforce/op/stages/impl/feature/ScalerTransformer.scala
@@ -111,9 +111,7 @@ case class LogScaler() extends Scaler {
 case class LinearScaler(args: LinearScalerArgs) extends Scaler {
   require(args.slope != 0.0, "LinearScaler must have a non-zero slope to be invertible")
   val scalingType: ScalingType = ScalingType.Linear
-
   def scale(v: Double): Double = args.slope * v + args.intercept
-
   def descale(v: Double): Double = (v - args.intercept) / args.slope
 }
 

--- a/core/src/main/scala/com/salesforce/op/stages/impl/feature/ScalerTransformer.scala
+++ b/core/src/main/scala/com/salesforce/op/stages/impl/feature/ScalerTransformer.scala
@@ -1,0 +1,188 @@
+/*
+ * Copyright (c) 2017, Salesforce.com, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.salesforce.op.stages.impl.feature
+
+import com.salesforce.op.UID
+import com.salesforce.op.features.types._
+import com.salesforce.op.stages.base.unary.UnaryTransformer
+import com.salesforce.op.utils.json.{JsonLike, JsonUtils}
+import org.apache.spark.sql.types.{Metadata, MetadataBuilder}
+
+import scala.reflect.runtime.universe.TypeTag
+import scala.util.{Failure, Try}
+
+
+/**
+ * A trait to be extended by a case class containing the args needed to define a family of scaling & descaling functions
+ */
+trait ScalingArgs extends JsonLike
+
+/**
+ * Case class for Scaling families that take no parameters
+ */
+case class EmptyArgs() extends ScalingArgs
+
+/**
+ * Parameters need to uniquely define a linear scaling function
+ *
+ * @param slope     the slope of the linear scaler
+ * @param intercept the x axis intercept of the linear scaler
+ */
+case class LinearScalerArgs(slope: Double, intercept: Double) extends ScalingArgs
+
+/**
+ * A trait for defining a new family of scaling functions
+ * scalingType: a ScalingType Enum for the scaling name
+ * args: A case class containing the args needed to define scaling and inverse scaling functions
+ * scale: The scaling function
+ * descale: The inverse scaling function
+ *
+ * To add a new family of scaling functions: Add an entry to the scalingType enum, define a Case class extending Scaler,
+ * and add a case statement to both the Scaler and ScalerMetaData case classes
+ */
+trait Scaler extends Serializable {
+  def scalingType: ScalingType
+  def args: ScalingArgs
+  def scale(v: Double): Double
+  def descale(v: Double): Double
+}
+
+/**
+ * [[Scaler]] instance factory
+ */
+object Scaler {
+  /**
+   * Creates a new instance of a [[Scaler]] based on specified [[ScalingType]] and [[ScalingArgs]]
+   * @param scalingType desired scaling type
+   * @param args specific scaling args
+   * @return
+   */
+  def apply(scalingType: ScalingType, args: ScalingArgs): Scaler = (scalingType, args) match {
+    case (ScalingType.Linear, l: LinearScalerArgs) => LinearScaler(l)
+    case (ScalingType.Logarithmic, _) => LogScaler()
+    case (t, args) => throw new IllegalArgumentException(
+      s"Invalid combination of scaling type '$t' and args type '${args.getClass.getSimpleName}'")
+  }
+}
+
+/**
+ * A case class representing a logarithmic scaling function
+ */
+case class LogScaler() extends Scaler {
+  val scalingType: ScalingType = ScalingType.Logarithmic
+  val args: ScalingArgs = EmptyArgs()
+  def scale(v: Double): Double = math.log(v)
+  def descale(v: Double): Double = math.exp(v)
+}
+
+/**
+ * A case class representing a linear scaling function
+ *
+ * @param args case class containing the slope and intercept of the scaling function
+ */
+case class LinearScaler(args: LinearScalerArgs) extends Scaler {
+  require(args.slope != 0.0, "LinearScaler must have a non-zero slope to be invertible")
+  val scalingType: ScalingType = ScalingType.Linear
+
+  def scale(v: Double): Double = args.slope * v + args.intercept
+
+  def descale(v: Double): Double = (v - args.intercept) / args.slope
+}
+
+/**
+ * Metadata containing the info needed to reconstruct a Scaler instance
+ *
+ * @param scalingType the family of functions containing the scaler
+ * @param scalingArgs the args uniquely defining a function in the scaling family
+ */
+case class ScalerMetadata(scalingType: ScalingType, scalingArgs: ScalingArgs) {
+  def toMetadata(): Metadata = new MetadataBuilder()
+    .putString(ScalerMetadata.scalingTypeName, scalingType.entryName)
+    .putString(ScalerMetadata.scalingArgsName, scalingArgs.toJson(pretty = false))
+    .build()
+}
+
+object ScalerMetadata extends {
+
+  val scalingTypeName = "scalingType"
+  val scalingArgsName = "scalingArgs"
+
+  def apply(meta: Metadata): Try[ScalerMetadata] = for {
+    scalingType <- Try(ScalingType.withName(meta.getString(scalingTypeName)))
+    args <- Try(meta.getString(scalingArgsName))
+    meta <- scalingType match {
+      case t@ScalingType.Linear =>
+        JsonUtils.fromString[LinearScalerArgs](args).map(ScalerMetadata(t, _))
+      case t@ScalingType.Logarithmic =>
+        JsonUtils.fromString[EmptyArgs](args).map(ScalerMetadata(t, _))
+      case t =>
+        Failure(new IllegalArgumentException(s"Unsupported scaling type $t"))
+    }
+  } yield meta
+
+}
+
+/**
+ * Scaling transformer that applies a scaling function to a numerical feature
+ *
+ * @param uid         uid for instance
+ * @param scalingType type of scaling function
+ * @param scalingArgs arguments to define the scaling function
+ * @param tti         type tag for input
+ * @param tto         type tag for output
+ * @param ttov        type tag for output value
+ * @tparam I input feature type
+ * @tparam O output feature type
+ */
+final class ScalerTransformer[I <: Real, O <: Real]
+(
+  uid: String = UID[ScalerTransformer[_, _]],
+  val scalingType: ScalingType,
+  val scalingArgs: ScalingArgs
+)(implicit tti: TypeTag[I], tto: TypeTag[O], ttov: TypeTag[O#Value])
+  extends UnaryTransformer[I, O](operationName = "scaler", uid = uid) {
+
+  private val ftFactory = FeatureTypeFactory[O]()
+  private val scaler = Scaler(scalingType, scalingArgs)
+
+  def transformFn: I => O = v => {
+    val scaled = v.toDouble.map(scaler.scale)
+    ftFactory.newInstance(scaled)
+  }
+
+  override def onGetMetadata(): Unit = {
+    super.onGetMetadata()
+    val meta = ScalerMetadata(scalingType, scalingArgs).toMetadata()
+    setMetadata(meta)
+  }
+}
+
+

--- a/core/src/test/scala/com/salesforce/op/stages/impl/feature/DescalerTransformerTest.scala
+++ b/core/src/test/scala/com/salesforce/op/stages/impl/feature/DescalerTransformerTest.scala
@@ -60,7 +60,7 @@ class DescalerTransformerTest extends OpTransformerSpec[Real, DescalerTransforme
     error.getCause.getMessage shouldBe s"Failed to extract scaler metadata for input feature '${f1.name}'"
   }
 
-  it should "descale and serialize log-scaling workflow" in {
+  it should "descale and work in log-scaling workflow" in {
     val logScaler = new ScalerTransformer[Real, Real](
       scalingType = ScalingType.Logarithmic,
       scalingArgs = EmptyArgs()

--- a/core/src/test/scala/com/salesforce/op/stages/impl/feature/DescalerTransformerTest.scala
+++ b/core/src/test/scala/com/salesforce/op/stages/impl/feature/DescalerTransformerTest.scala
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2017, Salesforce.com, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.salesforce.op.stages.impl.feature
+
+import com.salesforce.op.OpWorkflow
+import com.salesforce.op.features.types._
+import com.salesforce.op.test.{OpTransformerSpec, TestFeatureBuilder}
+import com.salesforce.op.utils.spark.RichDataset._
+import org.apache.spark.SparkException
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+
+import scala.util.{Failure, Success}
+
+@RunWith(classOf[JUnitRunner])
+class DescalerTransformerTest extends OpTransformerSpec[Real, DescalerTransformer[Real, Real, Real]] {
+  val (testData, f1) = TestFeatureBuilder(Seq(4.0, 1.0, 0.0).map(_.toReal))
+  val scalerMetadata = ScalerMetadata(ScalingType.Linear, LinearScalerArgs(slope = 2.0, intercept = 3.0)).toMetadata()
+  val colWithMetadata = testData.col(f1.name).as(f1.name, scalerMetadata)
+  val inputData = testData.withColumn(f1.name, colWithMetadata)
+
+  val transformer = new DescalerTransformer[Real, Real, Real]().setInput(f1, f1)
+  val expectedResult: Seq[Real] = Seq(0.5, -1.0, -1.5).map(_.toReal)
+
+  it should "error on missing scaler metadata" in {
+    val (df, f) = TestFeatureBuilder(Seq(4.0, 1.0, 0.0).map(_.toReal))
+    val error = intercept[SparkException](
+      new DescalerTransformer[Real, Real, Real]().setInput(f, f).transform(df).collect()
+    )
+    error.getCause should not be null
+    error.getCause shouldBe a[RuntimeException]
+    error.getCause.getMessage shouldBe s"Failed to extract scaler metadata for input feature '${f1.name}'"
+  }
+
+  it should "descale and serialize log-scaling workflow" in {
+    val logScaler = new ScalerTransformer[Real, Real](
+      scalingType = ScalingType.Logarithmic,
+      scalingArgs = EmptyArgs()
+    ).setInput(f1)
+    val scaledResponse = logScaler.getOutput()
+    val metadata = logScaler.transform(inputData).schema(scaledResponse.name).metadata
+    ScalerMetadata(metadata) match {
+      case Failure(err) => fail(err)
+      case Success(meta) =>
+        meta shouldBe ScalerMetadata(ScalingType.Logarithmic, EmptyArgs())
+    }
+
+    val shifted = scaledResponse.map[Real](v => v.value.map(_ + 1).toReal, operationName = "shift")
+    val descaledResponse = new DescalerTransformer[Real, Real, Real]().setInput(shifted, scaledResponse).getOutput()
+    val workflow = new OpWorkflow().setResultFeatures(descaledResponse)
+    val wfModel = workflow.setInputDataset(inputData).train()
+    val transformed = wfModel.score()
+
+    val actual = transformed.collect().map(_.getAs[Double](1))
+    val expected = Array(4.0, 1.0, 0.0).map(_ * math.E)
+    all(actual.zip(expected).map(x => math.abs(x._2 - x._1))) should be < 0.0001
+  }
+
+  it should "work with its shortcut" in {
+    val descaled = f1.descale[Real, Real](f1)
+    val transformed = descaled.originStage.asInstanceOf[DescalerTransformer[Real, Real, Real]].transform(inputData)
+    val actual = transformed.collect(descaled)
+    actual shouldEqual expectedResult.toArray
+  }
+}

--- a/core/src/test/scala/com/salesforce/op/stages/impl/feature/LinearScalerTest.scala
+++ b/core/src/test/scala/com/salesforce/op/stages/impl/feature/LinearScalerTest.scala
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2017, Salesforce.com, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.salesforce.op.stages.impl.feature
+
+import com.salesforce.op.test.TestSparkContext
+import org.junit.runner.RunWith
+import org.scalatest.FlatSpec
+import org.scalatest.junit.JUnitRunner
+
+@RunWith(classOf[JUnitRunner])
+class LinearScalerTest extends FlatSpec with TestSparkContext{
+
+  Spec[LinearScaler] should "Error on construction of a non-invertible transformation" in {
+    val error = intercept[java.lang.IllegalArgumentException](
+      LinearScaler(LinearScalerArgs(slope = 0.0, intercept = 1.0))
+    )
+    error.getMessage shouldBe "requirement failed: LinearScaler must have a non-zero slope to be invertible"
+  }
+
+  it should "correctly construct the linear scaling and inverse scaling function" in {
+    val sampleData = Seq(0.0, 1.0, 2.0, 3.0, 4.0)
+    val scaler = LinearScaler(LinearScalerArgs(slope = 2.0, intercept = 1.0))
+    sampleData.map(x => scaler.scale(x)) shouldEqual sampleData.map(x => 2.0*x + 1.0)
+    sampleData.map(x => scaler.descale(x)) shouldEqual sampleData.map(x => 0.5*x - 0.5)
+  }
+}

--- a/core/src/test/scala/com/salesforce/op/stages/impl/feature/LinearScalerTest.scala
+++ b/core/src/test/scala/com/salesforce/op/stages/impl/feature/LinearScalerTest.scala
@@ -36,7 +36,7 @@ import org.scalatest.FlatSpec
 import org.scalatest.junit.JUnitRunner
 
 @RunWith(classOf[JUnitRunner])
-class LinearScalerTest extends FlatSpec with TestSparkContext{
+class LinearScalerTest extends FlatSpec with TestSparkContext {
 
   Spec[LinearScaler] should "Error on construction of a non-invertible transformation" in {
     val error = intercept[java.lang.IllegalArgumentException](

--- a/core/src/test/scala/com/salesforce/op/stages/impl/feature/PredictionDescalerTransformerTest.scala
+++ b/core/src/test/scala/com/salesforce/op/stages/impl/feature/PredictionDescalerTransformerTest.scala
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2017, Salesforce.com, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.salesforce.op.stages.impl.feature
+
+import com.salesforce.op.OpWorkflow
+import com.salesforce.op.features.types._
+import com.salesforce.op.test.{OpTransformerSpec, TestFeatureBuilder}
+import com.salesforce.op.utils.spark.RichDataset._
+import org.apache.spark.SparkException
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+
+import scala.util.{Failure, Success}
+
+@RunWith(classOf[JUnitRunner])
+class PredictionDescalerTransformerTest extends OpTransformerSpec[Real, PredictionDescaler[Real, Real]] {
+  val predictionData = Seq(-1.0, 0.0, 1.0, 2.0).map(Prediction(_))
+  val featureData = Seq(0.0, 1.0, 2.0, 3.0).map(_.toReal)
+  val (testData, p, f1) = TestFeatureBuilder[Prediction, Real](predictionData zip featureData)
+
+  val scalerMetadata = ScalerMetadata(ScalingType.Linear, LinearScalerArgs(slope = 4.0, intercept = 1.0)).toMetadata()
+  val colWithMetadata = testData.col(f1.name).as(f1.name, scalerMetadata)
+  val inputData = testData.withColumn(f1.name, colWithMetadata)
+
+  val transformer = new PredictionDescaler[Real, Real]().setInput(p, f1)
+
+  val expectedResult: Seq[Real] = Seq(-0.5, -0.25, 0.0, 0.25).map(_.toReal)
+
+  it should "error on missing scaler metadata" in {
+    val (df, p, f1) = TestFeatureBuilder(Seq(4.0, 1.0, 0.0).map(Prediction(_)) zip Seq(0.0, 0.0, 0.0).map(Real(_)))
+    val error = intercept[SparkException](
+      new PredictionDescaler[Real, Real]().setInput(p, f1).transform(df).collect()
+    )
+    error.getCause should not be null
+    error.getCause shouldBe a[RuntimeException]
+    error.getCause.getMessage shouldBe s"Failed to extract scaler metadata for input feature '${f1.name}'"
+  }
+
+  it should "descale and serialize log-scaling workflow" in {
+    val logScaler = new ScalerTransformer[Real, Real](
+      scalingType = ScalingType.Logarithmic,
+      scalingArgs = EmptyArgs()
+    ).setInput(f1)
+    val scaledResponse = logScaler.getOutput()
+    val metadata = logScaler.transform(inputData).schema(scaledResponse.name).metadata
+    ScalerMetadata(metadata) match {
+      case Failure(err) => fail(err)
+      case Success(meta) =>
+        meta shouldBe ScalerMetadata(ScalingType.Logarithmic, EmptyArgs())
+    }
+    val shifted = scaledResponse.map[Prediction](v => Prediction(v.value.getOrElse(Double.NaN) + 1),
+      operationName = "shift")
+    val descaledPrediction = new PredictionDescaler[Real, Real]().setInput(shifted, scaledResponse).getOutput()
+    val workflow = new OpWorkflow().setResultFeatures(descaledPrediction)
+    val wfModel = workflow.setInputDataset(inputData).train()
+    val transformed = wfModel.score()
+    val actual = transformed.collect().map(_.getAs[Double](1))
+    val expected = Array(0.0, 1.0, 2.0, 3.0).map(_ * math.E)
+    all(actual.zip(expected).map(x => math.abs(x._2 - x._1))) should be < 0.0001
+  }
+
+  it should "descale and serialize linear-scaling workflow" in {
+    val scalingArgs = LinearScalerArgs(slope = 2.0, intercept = 0.0)
+    val linearScaler = new ScalerTransformer[Real, Real](
+      scalingType = ScalingType.Linear,
+      scalingArgs = scalingArgs
+    ).setInput(f1)
+    val scaledResponse = linearScaler.getOutput()
+    val metadata = linearScaler.transform(inputData).schema(scaledResponse.name).metadata
+    ScalerMetadata(metadata) match {
+      case Failure(err) => fail(err)
+      case Success(meta) =>
+        meta shouldBe ScalerMetadata(ScalingType.Linear, scalingArgs)
+    }
+    val shifted = scaledResponse.map[Prediction](v => Prediction(v.value.getOrElse(Double.NaN) + 1),
+      operationName = "shift")
+    val descaledPrediction = new PredictionDescaler[Real, Real]().setInput(shifted, scaledResponse).getOutput()
+    val workflow = new OpWorkflow().setResultFeatures(descaledPrediction)
+    val wfModel = workflow.setInputDataset(inputData).train()
+    val transformed = wfModel.score()
+    val actual = transformed.collect().map(_.getAs[Double](1))
+    val expected = Array(0.5, 1.5, 2.5, 3.5)
+    actual shouldBe expected
+  }
+
+  it should "work with its shortcut" in {
+    val descaled = p.descale[Real, Real](f1)
+    val transformed = descaled.originStage.asInstanceOf[PredictionDescaler[Real, Real]].transform(inputData)
+    val actual = transformed.collect(descaled)
+    actual shouldEqual expectedResult.toArray
+  }
+
+}

--- a/core/src/test/scala/com/salesforce/op/stages/impl/feature/ScalerMetadataTest.scala
+++ b/core/src/test/scala/com/salesforce/op/stages/impl/feature/ScalerMetadataTest.scala
@@ -40,7 +40,7 @@ import org.apache.spark.sql.types.MetadataBuilder
 import scala.util.{Failure, Success}
 
 @RunWith(classOf[JUnitRunner])
-class ScalerMetadataTest extends FlatSpec with TestSparkContext{
+class ScalerMetadataTest extends FlatSpec with TestSparkContext {
   val linearArgs = LinearScalerArgs(slope = 2.0, intercept = 1.0)
 
   Spec[ScalerMetadata] should "properly construct ScalerMetadata for a LinearScaler" in {

--- a/core/src/test/scala/com/salesforce/op/stages/impl/feature/ScalerMetadataTest.scala
+++ b/core/src/test/scala/com/salesforce/op/stages/impl/feature/ScalerMetadataTest.scala
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2017, Salesforce.com, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.salesforce.op.stages.impl.feature
+
+import com.salesforce.op.test.TestSparkContext
+import org.junit.runner.RunWith
+import org.scalatest.FlatSpec
+import org.scalatest.junit.JUnitRunner
+import com.salesforce.op.utils.json.JsonUtils
+import org.apache.spark.sql.types.MetadataBuilder
+
+import scala.util.{Failure, Success}
+
+@RunWith(classOf[JUnitRunner])
+class ScalerMetadataTest extends FlatSpec with TestSparkContext{
+  val linearArgs = LinearScalerArgs(slope = 2.0, intercept = 1.0)
+
+  Spec[ScalerMetadata] should "properly construct ScalerMetadata for a LinearScaler" in {
+    val metadata = ScalerMetadata(scalingType = ScalingType.Linear,
+      scalingArgs = linearArgs).toMetadata()
+    metadata.getString(ScalerMetadata.scalingTypeName) shouldBe ScalingType.Linear.entryName
+    val args = JsonUtils.fromString[LinearScalerArgs](metadata.getString(ScalerMetadata.scalingArgsName))
+    args match {
+      case Failure(err) => fail(err)
+      case Success(x) => x shouldBe linearArgs
+    }
+  }
+
+  it should "properly construct ScalerMetaData for a LogScaler" in {
+    val metadata = ScalerMetadata(scalingType = ScalingType.Logarithmic, scalingArgs = EmptyArgs()).toMetadata()
+    metadata.getString(ScalerMetadata.scalingTypeName) shouldBe ScalingType.Logarithmic.entryName
+    metadata.getString(ScalerMetadata.scalingArgsName) shouldBe "{}"
+  }
+
+  it should "use apply to properly convert metadata to ScalerMetadata" in {
+    val metadata = new MetadataBuilder().putString(ScalerMetadata.scalingTypeName, ScalingType.Linear.entryName)
+      .putString(ScalerMetadata.scalingArgsName, linearArgs.toJson(pretty = false)).build()
+    ScalerMetadata.apply(metadata) match {
+      case Failure(err) => fail(err)
+      case Success(x) => x shouldBe ScalerMetadata(ScalingType.Linear, linearArgs)
+    }
+  }
+
+  it should "error when apply is given an invalid scaling type" in {
+    val invalidMetaData = new MetadataBuilder().putString(ScalerMetadata.scalingTypeName, "unsupportedScaling")
+      .putString(ScalerMetadata.scalingArgsName, linearArgs.toJson(pretty = false)).build()
+
+    val err =  intercept[NoSuchElementException] (
+      ScalerMetadata.apply(invalidMetaData).get
+    )
+    err.getMessage shouldBe "unsupportedScaling is not a member of Enum (Linear, Logarithmic)"
+  }
+}

--- a/core/src/test/scala/com/salesforce/op/stages/impl/feature/ScalerMetadataTest.scala
+++ b/core/src/test/scala/com/salesforce/op/stages/impl/feature/ScalerMetadataTest.scala
@@ -73,7 +73,7 @@ class ScalerMetadataTest extends FlatSpec with TestSparkContext{
     val invalidMetaData = new MetadataBuilder().putString(ScalerMetadata.scalingTypeName, "unsupportedScaling")
       .putString(ScalerMetadata.scalingArgsName, linearArgs.toJson(pretty = false)).build()
 
-    val err =  intercept[NoSuchElementException] (
+    val err = intercept[NoSuchElementException] (
       ScalerMetadata.apply(invalidMetaData).get
     )
     err.getMessage shouldBe "unsupportedScaling is not a member of Enum (Linear, Logarithmic)"

--- a/core/src/test/scala/com/salesforce/op/stages/impl/feature/ScalerTest.scala
+++ b/core/src/test/scala/com/salesforce/op/stages/impl/feature/ScalerTest.scala
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2017, Salesforce.com, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.salesforce.op.stages.impl.feature
+
+import com.salesforce.op.test.TestSparkContext
+import org.junit.runner.RunWith
+import org.scalatest.FlatSpec
+import org.scalatest.junit.JUnitRunner
+
+@RunWith(classOf[JUnitRunner])
+class ScalerTest extends FlatSpec with TestSparkContext{
+
+  Spec[Scaler] should "error on invalid data" in {
+    val error = intercept[IllegalArgumentException](
+      Scaler.apply(scalingType = ScalingType.Linear, args = EmptyArgs())
+    )
+    error.getMessage shouldBe "Invalid combination of scaling type 'Linear' and args type 'EmptyArgs'"
+  }
+
+  it should "correctly build construct a LinearScaler" in {
+    val linearScaler = Scaler.apply(scalingType = ScalingType.Linear,
+      args = LinearScalerArgs(slope = 1.0, intercept = 2.0))
+    linearScaler shouldBe a [LinearScaler]
+    linearScaler.scalingType shouldBe ScalingType.Linear
+  }
+
+  it should "correctly build construct a LogScaler" in {
+    val linearScaler = Scaler.apply(scalingType = ScalingType.Logarithmic, args = EmptyArgs())
+    linearScaler shouldBe a [LogScaler]
+    linearScaler.scalingType shouldBe ScalingType.Logarithmic
+  }
+}
+

--- a/core/src/test/scala/com/salesforce/op/stages/impl/feature/ScalerTest.scala
+++ b/core/src/test/scala/com/salesforce/op/stages/impl/feature/ScalerTest.scala
@@ -36,7 +36,7 @@ import org.scalatest.FlatSpec
 import org.scalatest.junit.JUnitRunner
 
 @RunWith(classOf[JUnitRunner])
-class ScalerTest extends FlatSpec with TestSparkContext{
+class ScalerTest extends FlatSpec with TestSparkContext {
 
   Spec[Scaler] should "error on invalid data" in {
     val error = intercept[IllegalArgumentException](

--- a/core/src/test/scala/com/salesforce/op/stages/impl/feature/ScalerTest.scala
+++ b/core/src/test/scala/com/salesforce/op/stages/impl/feature/ScalerTest.scala
@@ -48,13 +48,13 @@ class ScalerTest extends FlatSpec with TestSparkContext{
   it should "correctly build construct a LinearScaler" in {
     val linearScaler = Scaler.apply(scalingType = ScalingType.Linear,
       args = LinearScalerArgs(slope = 1.0, intercept = 2.0))
-    linearScaler shouldBe a [LinearScaler]
+    linearScaler shouldBe a[LinearScaler]
     linearScaler.scalingType shouldBe ScalingType.Linear
   }
 
   it should "correctly build construct a LogScaler" in {
     val linearScaler = Scaler.apply(scalingType = ScalingType.Logarithmic, args = EmptyArgs())
-    linearScaler shouldBe a [LogScaler]
+    linearScaler shouldBe a[LogScaler]
     linearScaler.scalingType shouldBe ScalingType.Logarithmic
   }
 }

--- a/core/src/test/scala/com/salesforce/op/stages/impl/feature/ScalerTransformerTest.scala
+++ b/core/src/test/scala/com/salesforce/op/stages/impl/feature/ScalerTransformerTest.scala
@@ -84,7 +84,7 @@ class  ScalerTransformerTest extends OpTransformerSpec[Real, ScalerTransformer[R
 
   it should "work with its shortcut" in {
     val scaled = f1.scale[Real](scalingType = ScalingType.Linear,
-      scalingArgs= LinearScalerArgs(slope = 10.0, intercept = 0.5)
+      scalingArgs = LinearScalerArgs(slope = 10.0, intercept = 0.5)
     )
     val transformed = scaled.originStage.asInstanceOf[ScalerTransformer[RealNN, RealNN]].transform(inputData)
     val actual = transformed.collect(scaled)

--- a/core/src/test/scala/com/salesforce/op/stages/impl/feature/ScalerTransformerTest.scala
+++ b/core/src/test/scala/com/salesforce/op/stages/impl/feature/ScalerTransformerTest.scala
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2017, Salesforce.com, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.salesforce.op.stages.impl.feature
+
+import com.salesforce.op.features.FeatureLike
+import com.salesforce.op.features.types._
+import com.salesforce.op.test.{OpTransformerSpec, TestFeatureBuilder}
+import com.salesforce.op.utils.spark.RichDataset._
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+
+import scala.util.{Failure, Success}
+
+@RunWith(classOf[JUnitRunner])
+class  ScalerTransformerTest extends OpTransformerSpec[Real, ScalerTransformer[Real, Real]] {
+  val (inputData, f1) = TestFeatureBuilder(Seq(4.0, 1.0, 0.0).toReal)
+
+  val transformer = new ScalerTransformer[Real, Real](
+    scalingType = ScalingType.Linear,
+    scalingArgs = LinearScalerArgs(slope = 2.0, intercept = 1.0)
+  ).setInput(f1)
+
+  val expectedResult: Seq[Real] = Seq(9.0, 3.0, 1.0).map(_.toReal)
+
+  it should "linearly scale numeric fields and produce correct metadata" in {
+    val scaled: FeatureLike[Real] = transformer.getOutput()
+    val transformed = transformer.transform(inputData)
+
+    val actual = transformed.collect(scaled)
+    actual shouldEqual expectedResult
+
+    ScalerMetadata(transformed.schema(scaled.name).metadata) match {
+      case Failure(err) => fail(err)
+      case Success(meta) =>
+        meta shouldBe ScalerMetadata(ScalingType.Linear, LinearScalerArgs(slope = 2.0, intercept = 1.0))
+    }
+  }
+
+  it should "log scale numeric fields and produce correct metadata" in {
+    val logScaler = new ScalerTransformer[Real, Real](
+      scalingType = ScalingType.Logarithmic, scalingArgs = EmptyArgs()
+    ).setInput(f1)
+
+    val scaled: FeatureLike[Real] = logScaler.getOutput()
+    val transformed = logScaler.transform(inputData)
+
+    val actual = transformed.collect(scaled)
+    actual shouldEqual Array(4.0, 1.0, 0.0).map(math.log).map(_.toReal)
+
+    ScalerMetadata(transformed.schema(scaled.name).metadata) match {
+      case Failure(err) => fail(err)
+      case Success(meta) =>
+        meta shouldBe ScalerMetadata(ScalingType.Logarithmic, EmptyArgs())
+    }
+  }
+
+  it should "work with its shortcut" in {
+    val scaled = f1.scale[Real](scalingType = ScalingType.Linear,
+      scalingArgs= LinearScalerArgs(slope = 10.0, intercept = 0.5)
+    )
+    val transformed = scaled.originStage.asInstanceOf[ScalerTransformer[RealNN, RealNN]].transform(inputData)
+    val actual = transformed.collect(scaled)
+    actual shouldEqual Array(40.5, 10.5, 0.5).map(_.toRealNN)
+  }
+}

--- a/features/src/main/scala/com/salesforce/op/stages/OpPipelineStageReadWriteShared.scala
+++ b/features/src/main/scala/com/salesforce/op/stages/OpPipelineStageReadWriteShared.scala
@@ -31,7 +31,7 @@
 package com.salesforce.op.stages
 
 import com.salesforce.op.features.FeatureDistributionType
-import com.salesforce.op.stages.impl.feature.{HashAlgorithm, HashSpaceStrategy, TimePeriod}
+import com.salesforce.op.stages.impl.feature.{HashAlgorithm, HashSpaceStrategy, ScalingType, TimePeriod}
 import com.salesforce.op.utils.json.{EnumEntrySerializer, SpecialDoubleSerializer}
 import enumeratum._
 import org.json4s.ext.JodaTimeSerializers
@@ -83,6 +83,7 @@ object OpPipelineStageReadWriteShared {
       EnumEntrySerializer.json4s[AnyValueTypes](AnyValueTypes) +
       EnumEntrySerializer.json4s[HashAlgorithm](HashAlgorithm) +
       EnumEntrySerializer.json4s[HashSpaceStrategy](HashSpaceStrategy) +
+      EnumEntrySerializer.json4s[ScalingType](ScalingType) +
       EnumEntrySerializer.json4s[TimePeriod](TimePeriod) +
       EnumEntrySerializer.json4s[FeatureDistributionType](FeatureDistributionType) +
       new SpecialDoubleSerializer

--- a/features/src/main/scala/com/salesforce/op/stages/impl/feature/ScalingType.scala
+++ b/features/src/main/scala/com/salesforce/op/stages/impl/feature/ScalingType.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2017, Salesforce.com, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.salesforce.op.stages.impl.feature
+
+import enumeratum.{Enum, EnumEntry}
+
+sealed trait ScalingType extends EnumEntry with Serializable
+
+object ScalingType extends Enum[ScalingType] {
+  val values = findValues
+  case object Linear extends ScalingType
+  case object Logarithmic extends ScalingType
+}


### PR DESCRIPTION
**Related Issues**
Often in regression use cases the response variable is not normally distributed. As a data scientist training regression models I'd like generic transformers to easily scale the response variable during training time, but to also descale the predictions (at scoring time) so predictions are returned in the original scale.

**Proposed Solution**
A general framework for scaling and descaling the response feature that allows developers to easily add support for new feature scaling functions with minimal boiler plate code and without having to write new code to handle reading and writing metadata.

Each family of scaling functions is represented by a case class which extends the `Scaler` case class.
All supported families of scaling functions are stored in the `ScalingType` enum.

The `ScalerTransformer` constructs a transformer that scales features from `scalingType` and `scalingArgs`. The `scalingType` and `scalingArgs` are stored in the metadata of this feature.

The `DescalerTransformer` takes in a feature for descaling and a scaled feature containing the metadata for constructing the scaling inverse. This allows for predictions (in the scaled domain) to be descaled at scoring time.