### PR TITLE
DataCutter-related fixes for multiclass

### DIFF
--- a/core/src/main/scala/com/salesforce/op/stages/impl/feature/OpStringIndexerNoFilter.scala
+++ b/core/src/main/scala/com/salesforce/op/stages/impl/feature/OpStringIndexerNoFilter.scala
@@ -56,7 +56,11 @@ class OpStringIndexerNoFilter[I <: Text]
   def fitFn(data: Dataset[I#Value]): UnaryModel[I, RealNN] = {
     val unseen = $(unseenName)
     val counts = data.rdd.countByValue()
-    val labels = counts.toSeq.sortBy(-_._2).map(_._1).toArray
+    val labels = counts.toSeq
+      .sortBy { case (label, count) => (-count, label) }
+      .map { case (label, _) => label }
+      .toArray
+
     val otherPos = labels.length
 
     val cleanedLabels = labels.map(_.getOrElse("null")) :+ unseen

--- a/core/src/main/scala/com/salesforce/op/stages/impl/selector/ModelSelector.scala
+++ b/core/src/main/scala/com/salesforce/op/stages/impl/selector/ModelSelector.scala
@@ -156,7 +156,6 @@ E <: Estimator[_] with OpPipelineStage2[RealNN, OPVector, Prediction]]
     }
 
     val preparedData = splitter.map(_.validationPrepare(datasetWithID)).getOrElse(datasetWithID)
-
     val bestModel = estimator.fit(preparedData).asInstanceOf[M]
     val bestEst = bestModel.parent
     log.info(s"Selected model : ${bestEst.getClass.getSimpleName}")

--- a/core/src/main/scala/com/salesforce/op/stages/impl/selector/ModelSelector.scala
+++ b/core/src/main/scala/com/salesforce/op/stages/impl/selector/ModelSelector.scala
@@ -202,9 +202,9 @@ E <: Estimator[_] with OpPipelineStage2[RealNN, OPVector, Prediction]]
     val labelColIdx = data.columns.indexOf(labelColName)
     val needColSwapForValidation = labelColIdx > 0
     val df = if (needColSwapForValidation) {
-      data
-    } else {
       data.select(labelColName, data.columns.drop(labelColIdx): _*)
+    } else {
+      data
     }
     df.show()
 

--- a/core/src/main/scala/com/salesforce/op/stages/impl/selector/ModelSelector.scala
+++ b/core/src/main/scala/com/salesforce/op/stages/impl/selector/ModelSelector.scala
@@ -148,6 +148,9 @@ E <: Estimator[_] with OpPipelineStage2[RealNN, OPVector, Prediction]]
 
     val splitterSummary = splitter.flatMap(_.preValidationPrepare(datasetWithIDPre))
     val datasetWithID = splitter.collect {
+      // TODO validate in best estimator below cannot defer label trimming to blanket
+      //  validationPrepare, redesign to accommodate for special case
+      //
       case dc: DataCutter => dc.validationPrepare(datasetWithIDPre)
     }.getOrElse(datasetWithIDPre)
     val BestEstimator(name, estimator, summary) = bestEstimator.getOrElse {
@@ -158,11 +161,7 @@ E <: Estimator[_] with OpPipelineStage2[RealNN, OPVector, Prediction]]
       best
     }
 
-    val preparedData = splitter.collect {
-      case _: DataCutter => datasetWithID
-      case sp => sp.validationPrepare(datasetWithID)
-    }.getOrElse(datasetWithID)
-
+    val preparedData = splitter.map(_.validationPrepare(datasetWithID)).getOrElse(datasetWithID)
     val bestModel = estimator.fit(preparedData).asInstanceOf[M]
     val bestEst = bestModel.parent
     log.info(s"Selected model : ${bestEst.getClass.getSimpleName}")

--- a/core/src/main/scala/com/salesforce/op/stages/impl/selector/ModelSelectorNames.scala
+++ b/core/src/main/scala/com/salesforce/op/stages/impl/selector/ModelSelectorNames.scala
@@ -55,6 +55,7 @@ case object ModelSelectorNames {
   val idColName = "rowId"
   val LabelsKept = "labelsKept"
   val LabelsDropped = "labelsDropped"
+  val LabelsDroppedTotal = "labelsDroppedTotal"
 
   type ModelType = Model[_ <: Model[_]] with OpTransformer2[RealNN, OPVector, Prediction]
   type EstimatorType = Estimator[_ <: Model[_]] with OpPipelineStage2[RealNN, OPVector, Prediction]

--- a/core/src/main/scala/com/salesforce/op/stages/impl/tuning/DataBalancer.scala
+++ b/core/src/main/scala/com/salesforce/op/stages/impl/tuning/DataBalancer.scala
@@ -37,6 +37,8 @@ import org.apache.spark.sql.types.{Metadata, MetadataBuilder}
 import org.apache.spark.sql.{DataFrame, Dataset, Row}
 import org.slf4j.LoggerFactory
 
+import scala.util.Try
+
 case object DataBalancer {
 
   /**
@@ -178,13 +180,12 @@ class DataBalancer(uid: String = UID[DataBalancer]) extends Splitter(uid = uid) 
     balanced.persist()
   }
 
-  private def splitNegativePositive(data: Dataset[Row]): Seq[DataFrame] = {
+  private def splitNegativePositive(data: DataFrame): Seq[DataFrame] = {
     val labelColOpt = if (isSet(labelColumnName)) {
-      Some(data($(labelColumnName)))
-    } else if (data.columns.length > 0) {
-      Some(data(data.columns(0)))
+      Option(data($(labelColumnName)))
     } else {
-      None
+      // empty dataframes in tests don't have schema
+      Try(data(data.columns(0))).toOption
     }
 
     Seq(0.0, 1.0).flatMap { labelVal =>

--- a/core/src/main/scala/com/salesforce/op/stages/impl/tuning/DataBalancer.scala
+++ b/core/src/main/scala/com/salesforce/op/stages/impl/tuning/DataBalancer.scala
@@ -35,7 +35,6 @@ import com.salesforce.op.stages.impl.selector.ModelSelectorNames
 import org.apache.spark.ml.param._
 import org.apache.spark.sql.types.{Metadata, MetadataBuilder}
 import org.apache.spark.sql.{DataFrame, Dataset, Row}
-import org.slf4j.LoggerFactory
 
 import scala.util.Try
 
@@ -72,8 +71,6 @@ case object DataBalancer {
  * @param uid
  */
 class DataBalancer(uid: String = UID[DataBalancer]) extends Splitter(uid = uid) with DataBalancerParams {
-
-  @transient private lazy val log = LoggerFactory.getLogger(this.getClass)
 
   /**
    * Computes the upSample and downSample proportions.

--- a/core/src/main/scala/com/salesforce/op/stages/impl/tuning/DataBalancer.scala
+++ b/core/src/main/scala/com/salesforce/op/stages/impl/tuning/DataBalancer.scala
@@ -191,7 +191,7 @@ class DataBalancer(uid: String = UID[DataBalancer]) extends Splitter(uid = uid) 
     Seq(0.0, 1.0).flatMap { labelVal =>
       labelColOpt
         .map(labelCol => data.filter(labelCol === labelVal))
-        .orElse(Some(data)) // empty data frame
+        .orElse(Option(data)) // empty data frame
     }
   }
 

--- a/core/src/main/scala/com/salesforce/op/stages/impl/tuning/DataCutter.scala
+++ b/core/src/main/scala/com/salesforce/op/stages/impl/tuning/DataCutter.scala
@@ -37,7 +37,6 @@ import org.apache.spark.ml.param._
 import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.types.{Metadata, MetadataBuilder}
-import org.slf4j.LoggerFactory
 
 import scala.util.Try
 
@@ -75,8 +74,6 @@ case object DataCutter {
  * @param uid
  */
 class DataCutter(uid: String = UID[DataCutter]) extends Splitter(uid = uid) with DataCutterParams {
-
-  @transient private lazy val log = LoggerFactory.getLogger(this.getClass)
 
   /**
    * Function to set parameters before passing into the validation step

--- a/core/src/main/scala/com/salesforce/op/stages/impl/tuning/DataCutter.scala
+++ b/core/src/main/scala/com/salesforce/op/stages/impl/tuning/DataCutter.scala
@@ -99,19 +99,6 @@ class DataCutter(uid: String = UID[DataCutter]) extends Splitter(uid = uid) with
     summary
   }
 
-
-  private def getNumValuesFromMetadata(data: DataFrame): Int = {
-    val labelSF: StructField = data.schema.head
-    val labelColMetadata = labelSF.metadata
-    log.info(s"Label column metadata ${labelSF.name} $labelColMetadata")
-    Try(labelColMetadata.getLong("num_vals").toInt)
-      .recover { case nonFatal =>
-        log.warn(s"Recovering non-fatal failure to extract num_vals with -1", nonFatal)
-        -1
-      }
-      .get
-  }
-
   /**
    * Removes labels that should not be used in modeling
    *
@@ -120,27 +107,41 @@ class DataCutter(uid: String = UID[DataCutter]) extends Splitter(uid = uid) with
    */
   override def validationPrepare(data: Dataset[Row]): Dataset[Row] = {
     val dataPrep = super.validationPrepare(data)
-    val labelSet = getLabelsToKeep.toSet
-    log.info(s"Dropping rows with columns not in $labelSet")
+    Try {
+      val labelSF: StructField = dataPrep.schema.head
+      val labelColMeta = labelSF.metadata
+      log.info(s"Label column metadata ${labelSF.name} $labelColMeta")
+      labelColMeta
+        .getMetadata("ml_attr")
+        .getStringArray("vals")
+        .map(_.toDouble)
+    }
+      .map(_.toSet)
+      .recover { case nonFatal =>
+        log.warn(s"Recovering non-fatal exception: $nonFatal", nonFatal)
+        Set.empty
+      }
+      .map { valSet =>
 
-    val labelColName = dataPrep.columns(0)
+        val labelSet = getLabelsToKeep.toSet
+        if (valSet == labelSet) {
+          log.info("Label sets identical in dataset metadata and datacutter, skipping label trim")
+          dataPrep
+        } else {
+          log.info(s"Dropping rows with columns not in $labelSet")
 
-    val metadata = NominalAttribute.defaultAttr
-      .withName(labelColName)
-      .withNumValues(labelSet.size)
-      .toMetadata()
-
-    val labelCol = dataPrep
-      .col(labelColName)
-      .as("_", metadata)
-
-    val res = dataPrep
-      .filter(r => labelSet.contains(r.getDouble(0)))
-      .withColumn(labelColName, labelCol)
-
-    assert(labelSet.size == getNumValuesFromMetadata(res))
-
-    res
+          val labelColName = dataPrep.columns(0)
+          val labelCol = dataPrep.col(labelColName)
+          val metadata = NominalAttribute.defaultAttr
+            .withName(labelColName)
+            .withValues(getLabelsToKeep.map(_.toString))
+            .toMetadata()
+          dataPrep
+            .filter(r => labelSet.contains(r.getDouble(0)))
+            .withColumn(labelColName, labelCol.as("_", metadata))
+        }
+    }
+      .get
   }
 
   /**

--- a/core/src/main/scala/com/salesforce/op/stages/impl/tuning/DataCutter.scala
+++ b/core/src/main/scala/com/salesforce/op/stages/impl/tuning/DataCutter.scala
@@ -124,9 +124,7 @@ class DataCutter(uid: String = UID[DataCutter]) extends Splitter(uid = uid) with
     //
     val dataPrep = data
       .filter(r => labelSet.contains(r.getDouble(labelColIdx)))
-      .withColumn(labelColName, data
-        .col(labelColName)
-        .as("_", metadataNA.toMetadata))
+      .withColumn(labelColName, data(labelColName).as("_", metadataNA.toMetadata))
 
     summary = Option(DataCutterSummary(
       labelsKept = getLabelsToKeep,

--- a/core/src/main/scala/com/salesforce/op/stages/impl/tuning/DataCutter.scala
+++ b/core/src/main/scala/com/salesforce/op/stages/impl/tuning/DataCutter.scala
@@ -35,7 +35,7 @@ import com.salesforce.op.stages.impl.selector.ModelSelectorNames
 import org.apache.spark.ml.attribute.NominalAttribute
 import org.apache.spark.ml.param._
 import org.apache.spark.sql.functions._
-import org.apache.spark.sql.types.{Metadata, MetadataBuilder}
+import org.apache.spark.sql.types.{Metadata, MetadataBuilder, StructField}
 import org.apache.spark.sql.{DataFrame, Dataset, Row}
 import org.slf4j.LoggerFactory
 
@@ -108,9 +108,10 @@ class DataCutter(uid: String = UID[DataCutter]) extends Splitter(uid = uid) with
   override def validationPrepare(data: Dataset[Row]): Dataset[Row] = {
     val dataPrep = super.validationPrepare(data)
     Try {
-      val labelColMeta = dataPrep.schema.head.metadata
-      log.info(s"Label column metadata $labelColMeta")
-      dataPrep.schema.head.metadata
+      val labelSF: StructField = dataPrep.schema.head
+      val labelColMeta = labelSF.metadata
+      log.info(s"Label column metadata ${labelSF.name} $labelColMeta")
+      labelColMeta
         .getMetadata("ml_attr")
         .getStringArray("vals")
         .map(_.toDouble)

--- a/core/src/main/scala/com/salesforce/op/stages/impl/tuning/DataCutter.scala
+++ b/core/src/main/scala/com/salesforce/op/stages/impl/tuning/DataCutter.scala
@@ -146,9 +146,11 @@ class DataCutter(uid: String = UID[DataCutter]) extends Splitter(uid = uid) with
         .getStringArray(MetadataHelper.attributeKeys.VALUES)
     }
     .recover { case nonFatal =>
-      log.warn(s"Cannot retrieve categories from metadata using " +
+      log.warn("Cannot retrieve categories from metadata using " +
         s"${MetadataHelper.attributeKeys.ML_ATTR}.${MetadataHelper.attributeKeys.VALUES}, " +
-        s"retrieving number of categories using ${MetadataHelper.attributeKeys.NUM_VALUES}", nonFatal)
+        "retrieving number of categories using " +
+        s"${MetadataHelper.attributeKeys.ML_ATTR}.${MetadataHelper.attributeKeys.NUM_VALUES}",
+        nonFatal)
       val numVals = labelColMetadata
         .getMetadata(MetadataHelper.attributeKeys.ML_ATTR)
         .getLong(MetadataHelper.attributeKeys.NUM_VALUES)

--- a/core/src/main/scala/com/salesforce/op/stages/impl/tuning/DataCutter.scala
+++ b/core/src/main/scala/com/salesforce/op/stages/impl/tuning/DataCutter.scala
@@ -78,8 +78,6 @@ class DataCutter(uid: String = UID[DataCutter]) extends Splitter(uid = uid) with
 
   @transient private lazy val log = LoggerFactory.getLogger(this.getClass)
 
-  var cachedDataFrameForTesting: Option[DataFrame] = None
-
   /**
    * Function to set parameters before passing into the validation step
    * eg - do data balancing or dropping based on the labels
@@ -131,11 +129,6 @@ class DataCutter(uid: String = UID[DataCutter]) extends Splitter(uid = uid) with
       labelsDropped = getLabelsToDrop,
       labelsDroppedTotal = getLabelsDroppedTotal
     ))
-
-    if (isSet(cacheValidatedDFForTesting) && $(cacheValidatedDFForTesting)) {
-      cachedDataFrameForTesting = Option(dataPrep)
-    }
-
     PrevalidationVal(summary, Option(dataPrep))
   }
 
@@ -267,14 +260,6 @@ private[impl] trait DataCutterParams extends SplitterParams {
   setDefault(maxLabelsDroppedForDiagnostics, 10)
 
   private[op] def getNumDroppedLabelsForLogging: Int = $(maxLabelsDroppedForDiagnostics)
-
-  final val cacheValidatedDFForTesting = new BooleanParam(this, "cacheValidatedDFForTesting",
-    doc = "parameter to verify label trimming")
-  setDefault(cacheValidatedDFForTesting, false)
-
-  def setCacheValidatedDFForTesting(value: Boolean): this.type = {
-    set(cacheValidatedDFForTesting, value)
-  }
 }
 
 /**

--- a/core/src/main/scala/com/salesforce/op/stages/impl/tuning/DataCutter.scala
+++ b/core/src/main/scala/com/salesforce/op/stages/impl/tuning/DataCutter.scala
@@ -141,23 +141,18 @@ class DataCutter(uid: String = UID[DataCutter]) extends Splitter(uid = uid) with
       log.info(s"Dropping rows with columns not in $labelSet")
       val labelColName = dataPrep.columns(0)
 
-      val newLabelCol = if (labelMetaArr.isEmpty) {
-        dataPrep
-          .col(labelColName)
+      val na = NominalAttribute.defaultAttr.withName(labelColName)
+      val metadataNA = if (labelMetaArr.isEmpty) {
+        na.withNumValues(labelSet.size)
       } else {
         // trim the metadata
-        val metadata = NominalAttribute.defaultAttr
-          .withName(labelColName)
-          .withValues(labelMetaArr.take(labelSet.size))
-          .toMetadata()
-        dataPrep.col(labelColName)
-          .as("_", metadata)
+        na.withValues(labelMetaArr.take(labelSet.size))
       }
 
       // trim dataframe
       dataPrep
         .filter(r => labelSet.contains(r.getDouble(0)))
-        .withColumn(labelColName, newLabelCol)
+        .withColumn(labelColName, dataPrep.col(labelColName).as("_", metadataNA.toMetadata))
     }
   }
 

--- a/core/src/main/scala/com/salesforce/op/stages/impl/tuning/DataCutter.scala
+++ b/core/src/main/scala/com/salesforce/op/stages/impl/tuning/DataCutter.scala
@@ -261,7 +261,7 @@ private[impl] trait DataCutterParams extends SplitterParams {
 
   final val maxNamesForDroppedLabels = new IntParam(this, "maxNamesForDroppedLabels",
     "maximum number of dropped label categories to retain for logging",
-    ParamValidators.inRange(lowerBound = 0, upperBound = 100, lowerInclusive = true, upperInclusive = true)
+    ParamValidators.inRange(lowerBound = 0, upperBound = 1000, lowerInclusive = true, upperInclusive = true)
   )
   setDefault(maxNamesForDroppedLabels, 10)
 

--- a/core/src/main/scala/com/salesforce/op/stages/impl/tuning/DataCutter.scala
+++ b/core/src/main/scala/com/salesforce/op/stages/impl/tuning/DataCutter.scala
@@ -174,25 +174,25 @@ class DataCutter(uid: String = UID[DataCutter]) extends Splitter(uid = uid) with
     val minLabelFract = getMinLabelFraction
     val maxLabels = getMaxLabelCategories
 
-    val labelCol = labelCounts.columns(0)
-    val countCol = labelCounts.columns(1)
+    val Seq(labelColIdx, countColIdx) = Seq(0, 1)
+    val Seq(labelCol, countCol) = Seq(labelColIdx, countColIdx).map(idx => labelCounts.columns(idx))
 
     val numLabels = labelCounts.count()
-    val totalValues = labelCounts.agg(sum(countCol)).first().getLong(0).toDouble
+    val totalValues = labelCounts.agg(sum(countCol)).first().getLong(labelColIdx).toDouble
 
     val labelsKept = labelCounts
-      .filter(r => r.getLong(1).toDouble / totalValues >= minLabelFract)
+      .filter(r => r.getLong(countColIdx).toDouble / totalValues >= minLabelFract)
       .sort(col(countCol).desc, col(labelCol))
       .take(maxLabels)
-      .map(_.getDouble(0))
+      .map(_.getDouble(labelColIdx))
 
     val labelsKeptSet = labelsKept.toSet
 
     val labelsDropped = labelCounts
-      .filter(r => !labelsKeptSet.contains(r.getDouble(0)))
+      .filter(r => !labelsKeptSet.contains(r.getDouble(labelColIdx)))
       .sort(col(countCol).desc, col(labelCol))
       .take(numDroppedToRecord)
-      .map(_.getDouble(0))
+      .map(_.getDouble(labelColIdx))
 
     val labelsDroppedTotal = numLabels - labelsKept.length
 

--- a/core/src/main/scala/com/salesforce/op/stages/impl/tuning/DataCutter.scala
+++ b/core/src/main/scala/com/salesforce/op/stages/impl/tuning/DataCutter.scala
@@ -116,7 +116,10 @@ class DataCutter(uid: String = UID[DataCutter]) extends Splitter(uid = uid) with
         .map(_.toDouble)
     }
       .map(_.toSet)
-      .recover { case _: NoSuchElementException => Set.empty }
+      .recover { case nonFatal =>
+        log.warn(s"Recovering non-fatal exception: $nonFatal", nonFatal)
+        Set.empty
+      }
       .map { valSet =>
 
         val labelSet = getLabelsToKeep.toSet

--- a/core/src/main/scala/com/salesforce/op/stages/impl/tuning/DataCutter.scala
+++ b/core/src/main/scala/com/salesforce/op/stages/impl/tuning/DataCutter.scala
@@ -187,7 +187,8 @@ class DataCutter(uid: String = UID[DataCutter]) extends Splitter(uid = uid) with
       .map(_.getDouble(0))
 
     if (labelSet.nonEmpty) {
-      log.info(s"DataCutter is keeping labels: $labelsKeep and dropping labels: $labelsDropped")
+      log.info(s"DataCutter is keeping labels: ${labelsKeep.mkString}" +
+        s" and dropping labels: ${labelsDropped.mkString}")
     } else {
       throw new RuntimeException(s"DataCutter dropped all labels with param settings:" +
         s" minLabelFraction = $minLabelFract, maxLabelCategories = $maxLabels. \n" +

--- a/core/src/main/scala/com/salesforce/op/stages/impl/tuning/DataCutter.scala
+++ b/core/src/main/scala/com/salesforce/op/stages/impl/tuning/DataCutter.scala
@@ -257,13 +257,13 @@ private[impl] trait DataCutterParams extends SplitterParams {
 
   private[op] def getLabelsDroppedTotal: Long = $(labelsDroppedTotal)
 
-  final val maxLabelsDroppedForDiagnostics = new IntParam(this, "maxLabelsDroppedForDiagnostics",
+  final val maxNamesForDroppedLabels = new IntParam(this, "maxNamesForDroppedLabels",
     "maximum number of dropped label categories to retain for logging",
     ParamValidators.inRange(lowerBound = 0, upperBound = 100, lowerInclusive = true, upperInclusive = true)
   )
-  setDefault(maxLabelsDroppedForDiagnostics, 10)
+  setDefault(maxNamesForDroppedLabels, 10)
 
-  private[op] def getNumDroppedLabelsForLogging: Int = $(maxLabelsDroppedForDiagnostics)
+  private[op] def getNumDroppedLabelsForLogging: Int = $(maxNamesForDroppedLabels)
 }
 
 /**

--- a/core/src/main/scala/com/salesforce/op/stages/impl/tuning/DataCutter.scala
+++ b/core/src/main/scala/com/salesforce/op/stages/impl/tuning/DataCutter.scala
@@ -104,22 +104,14 @@ class DataCutter(uid: String = UID[DataCutter]) extends Splitter(uid = uid) with
         val labelMetaArr = getLabelsFromMetadata(data)
         val labelSet = getLabelsToKeep.toSet
 
-        // discount unseen label
-        val integralLabelSet = 0.until(labelMetaArr.length - 1)
-          .map(_.toDouble)
-          .toSet
-
-        val dataPrep = if (integralLabelSet == labelSet) {
-          log.info("Label sets identical in dataset metadata and datacutter, skipping label trim")
-          data
-        } else {
+        val dataPrep = {
           log.info(s"Dropping rows with columns not in $labelSet")
 
           // Update metadata that spark.ml Classifier is using tp determine the number of classes
           //
           val na = NominalAttribute.defaultAttr.withName(labelColName)
           val metadataNA = if (labelMetaArr.isEmpty) {
-            na.withNumValues(labelSet.size)
+            na
           } else {
             na.withValues(labelMetaArr.take(labelSet.size))
           }

--- a/core/src/main/scala/com/salesforce/op/stages/impl/tuning/DataSplitter.scala
+++ b/core/src/main/scala/com/salesforce/op/stages/impl/tuning/DataSplitter.scala
@@ -68,9 +68,9 @@ class DataSplitter(uid: String = UID[DataSplitter]) extends Splitter(uid = uid) 
    * @param data
    * @return Parameters set in examining data
    */
-  override def preValidationPrepare(data: Dataset[Row], labelColNameOpt: Option[String]): Option[SplitterSummary] = {
+  override def preValidationPrepare(data: Dataset[Row]): PrevalidationVal = {
     summary = Option(DataSplitterSummary())
-    summary
+    PrevalidationVal(summary, None)
   }
 
   override def copy(extra: ParamMap): DataSplitter = {

--- a/core/src/main/scala/com/salesforce/op/stages/impl/tuning/DataSplitter.scala
+++ b/core/src/main/scala/com/salesforce/op/stages/impl/tuning/DataSplitter.scala
@@ -68,7 +68,7 @@ class DataSplitter(uid: String = UID[DataSplitter]) extends Splitter(uid = uid) 
    * @param data
    * @return Parameters set in examining data
    */
-  override def preValidationPrepare(data: Dataset[Row]): Option[SplitterSummary] = {
+  override def preValidationPrepare(data: Dataset[Row], labelColNameOpt: Option[String]): Option[SplitterSummary] = {
     summary = Option(DataSplitterSummary())
     summary
   }

--- a/core/src/main/scala/com/salesforce/op/stages/impl/tuning/Splitter.scala
+++ b/core/src/main/scala/com/salesforce/op/stages/impl/tuning/Splitter.scala
@@ -146,7 +146,8 @@ private[op] object SplitterSummary {
       )
       case s if s == classOf[DataCutterSummary].getName => DataCutterSummary(
         labelsKept = metadata.getDoubleArray(ModelSelectorNames.LabelsKept),
-        labelsDropped = metadata.getDoubleArray(ModelSelectorNames.LabelsDropped)
+        labelsDropped = metadata.getDoubleArray(ModelSelectorNames.LabelsDropped),
+        labelsDroppedTotal = metadata.getLong(ModelSelectorNames.LabelsDroppedTotal)
       )
       case s =>
         throw new RuntimeException(s"Unknown splitter summary class '$s'")

--- a/core/src/main/scala/com/salesforce/op/stages/impl/tuning/Splitter.scala
+++ b/core/src/main/scala/com/salesforce/op/stages/impl/tuning/Splitter.scala
@@ -32,7 +32,6 @@ package com.salesforce.op.stages.impl.tuning
 
 import com.salesforce.op.stages.impl.MetadataLike
 import com.salesforce.op.stages.impl.selector.ModelSelectorNames
-import com.salesforce.op.utils.spark.RichMetadata._
 import org.apache.spark.ml.param._
 import org.apache.spark.sql.types.Metadata
 import org.apache.spark.sql.{Dataset, Row}
@@ -69,7 +68,7 @@ abstract class Splitter(val uid: String) extends SplitterParams {
    * @param data
    * @return Training set test set
    */
-  def validationPrepare(data: Dataset[Row]): Dataset[Row] = {
+  def validationPrepare(data: Dataset[Row], labelColNameOpt: Option[String] = None): Dataset[Row] = {
     checkPreconditions()
     data
   }
@@ -82,7 +81,7 @@ abstract class Splitter(val uid: String) extends SplitterParams {
    * @param data
    * @return Parameters set in examining data
    */
-  def preValidationPrepare(data: Dataset[Row]): Option[SplitterSummary]
+  def preValidationPrepare(data: Dataset[Row], labelColNameOpt: Option[String] = None): Option[SplitterSummary]
 
 
   protected def checkPreconditions(): Unit =

--- a/core/src/main/scala/com/salesforce/op/stages/impl/tuning/Splitter.scala
+++ b/core/src/main/scala/com/salesforce/op/stages/impl/tuning/Splitter.scala
@@ -35,6 +35,7 @@ import com.salesforce.op.stages.impl.selector.ModelSelectorNames
 import org.apache.spark.ml.param._
 import org.apache.spark.sql.types.Metadata
 import org.apache.spark.sql.{DataFrame, Dataset, Row}
+import org.slf4j.LoggerFactory
 
 import scala.util.Try
 
@@ -44,6 +45,7 @@ case class PrevalidationVal(summaryOpt: Option[SplitterSummary], dataFrame: Opti
  * Abstract class that will carry on the creation of training set + test set
  */
 abstract class Splitter(val uid: String) extends SplitterParams {
+  @transient private[tuning] lazy val log = LoggerFactory.getLogger(this.getClass)
 
   @transient private[op] var summary: Option[SplitterSummary] = None
 
@@ -93,6 +95,7 @@ abstract class Splitter(val uid: String) extends SplitterParams {
     if (!isSet(labelColumnName)) {
       set(labelColumnName, label)
     } else {
+      log.warn(s"$labelColumnName on an existing Splitter instance can be set only once")
       this
     }
   }

--- a/core/src/main/scala/org/apache/spark/ml/attribute/MetadataHelper.scala
+++ b/core/src/main/scala/org/apache/spark/ml/attribute/MetadataHelper.scala
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2017, Salesforce.com, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.apache.spark.ml.attribute
+
+import org.apache.spark.ml.util.MetadataUtils
+
+object MetadataHelper {
+  val attributeKeys = AttributeKeys
+  val metadtaUtils = MetadataUtils
+}

--- a/core/src/test/resources/log4j.properties
+++ b/core/src/test/resources/log4j.properties
@@ -18,7 +18,7 @@ log4j.logger.com.databricks.spark.avro=WARN
 log4j.logger.org.apache.avro.mapreduce.AvroKeyInputFormat=ERROR
 
 # TransmogrifAI logging
-log4j.logger.com.salesforce.op=INFO
+log4j.logger.com.salesforce.op=ERROR
 log4j.logger.com.salesforce.op.utils.spark.OpSparkListener=OFF
 
 # Breeze

--- a/core/src/test/resources/log4j.properties
+++ b/core/src/test/resources/log4j.properties
@@ -18,7 +18,7 @@ log4j.logger.com.databricks.spark.avro=WARN
 log4j.logger.org.apache.avro.mapreduce.AvroKeyInputFormat=ERROR
 
 # TransmogrifAI logging
-log4j.logger.com.salesforce.op=ERROR
+log4j.logger.com.salesforce.op=INFO
 log4j.logger.com.salesforce.op.utils.spark.OpSparkListener=OFF
 
 # Breeze

--- a/core/src/test/resources/log4j.properties
+++ b/core/src/test/resources/log4j.properties
@@ -26,5 +26,3 @@ log4j.logger.breeze.optimize=ERROR
 
 # BLAS & LAPACK
 log4j.logger.com.github.fommil.netlib=ERROR
-
-log4j.logger.com.salesforce.op.stages.impl.classification.MultiClassificationModelSelectorTest=DEBUG

--- a/core/src/test/resources/log4j.properties
+++ b/core/src/test/resources/log4j.properties
@@ -26,3 +26,5 @@ log4j.logger.breeze.optimize=ERROR
 
 # BLAS & LAPACK
 log4j.logger.com.github.fommil.netlib=ERROR
+
+log4j.logger.com.salesforce.op.stages.impl.classification.MultiClassificationModelSelectorTest=DEBUG

--- a/core/src/test/scala/com/salesforce/op/stages/impl/classification/MultiClassificationModelSelectorTest.scala
+++ b/core/src/test/scala/com/salesforce/op/stages/impl/classification/MultiClassificationModelSelectorTest.scala
@@ -334,8 +334,8 @@ class MultiClassificationModelSelectorTest extends FlatSpec with TestSparkContex
 
   it should "trim low-cardinality labels during cross validation" in {
     val nunLabeledRecords = 1000
-    val numLabels = 10
-    val topLabelsToPick = 3
+    val numLabels = 500
+    val topLabelsToPick = 100
     val labelColName = "label"
 
     val rnd = scala.util.Random
@@ -360,7 +360,10 @@ class MultiClassificationModelSelectorTest extends FlatSpec with TestSparkContex
     val (label, Array(features: Feature[OPVector]@unchecked)) = FeatureBuilder.fromDataFrame[RealNN](
       bigData, response = labelColName, nonNullable = Set("features"))
 
-    assert(bigData.select(labelColName).distinct().count() === numLabels)
+    val bigDataUniqs = bigData.select(labelColName).distinct().count()
+
+    withClue("Pseudo-random generation should produce labels within 25% from " + numLabels)(
+      assert(bigDataUniqs >= numLabels * 0.75 && bigDataUniqs <= numLabels))
 
     val cutter = DataCutter(seed = 42L, maxLabelCategories = topLabelsToPick)
     val testEstimator =

--- a/core/src/test/scala/com/salesforce/op/stages/impl/classification/MultiClassificationModelSelectorTest.scala
+++ b/core/src/test/scala/com/salesforce/op/stages/impl/classification/MultiClassificationModelSelectorTest.scala
@@ -124,218 +124,218 @@ class MultiClassificationModelSelectorTest extends FlatSpec with TestSparkContex
   val models = Seq(lr -> lrParams, rf -> rfParams)
 
 
-//  Spec(MultiClassificationModelSelector.getClass) should "properly select models to try" in {
-//    val modelSelector = MultiClassificationModelSelector
-//      .withCrossValidation(modelTypesToUse = Seq(MTT.OpLogisticRegression, MTT.OpNaiveBayes, MTT.OpXGBoostClassifier))
-//      .setInput(label.asInstanceOf[Feature[RealNN]], features)
-//
-//    modelSelector.models.size shouldBe 3
-//    modelSelector.models.exists(_._1.getClass.getSimpleName == MTT.OpLogisticRegression.entryName) shouldBe true
-//    modelSelector.models.exists(_._1.getClass.getSimpleName == MTT.OpRandomForestClassifier.entryName) shouldBe false
-//    modelSelector.models.exists(_._1.getClass.getSimpleName == MTT.OpNaiveBayes.entryName) shouldBe true
-//    modelSelector.models.exists(_._1.getClass.getSimpleName == MTT.OpXGBoostClassifier.entryName) shouldBe true
-//  }
-//
-//  it should "split into training and test" in {
-//    implicit val vectorEncoder: org.apache.spark.sql.Encoder[Vector] = ExpressionEncoder()
-//    implicit val e1 = Encoders.tuple(Encoders.scalaDouble, vectorEncoder)
-//
-//    val testFraction = 0.2
-//
-//    val (train, test) = DataSplitter(reserveTestFraction = testFraction)
-//      .split(data.withColumn(ModelSelectorNames.idColName, monotonically_increasing_id())
-//        .as[(Double, Vector, Double)])
-//
-//
-//    val trainCount = train.count()
-//    val testCount = test.count()
-//    val totalCount = label0Count + label1Count + label2Count
-//
-//    assert(math.abs(testCount - testFraction * totalCount) <= 20)
-//    assert(math.abs(trainCount - (1.0 - testFraction) * totalCount) <= 20)
-//
-//    trainCount + testCount shouldBe totalCount
-//  }
-//
-//  ignore should "fit and predict all models on by default" in {
-//    val testEstimator =
-//      MultiClassificationModelSelector
-//        .withCrossValidation(
-//          Option(DataCutter(seed = 42, maxLabelCategories = 1000000, minLabelFraction = 0.0)),
-//          numFolds = 4,
-//          validationMetric = Evaluators.MultiClassification.precision(),
-//          seed = 10L
-//        )
-//        .setInput(label, features)
-//
-//    val model = testEstimator.fit(data)
-//
-//    log.info(model.getMetadata().prettyJson)
-//
-//    // evaluation metrics from test set should be in metadata
-//    val metaData = ModelSelectorSummary.fromMetadata(model.getMetadata().getSummaryMetadata())
-//    MultiClassEvalMetrics.values.foreach(metric =>
-//      assert(metaData.trainEvaluation.toJson(false).contains(s"${metric.entryName}"),
-//        s"Metric ${metric.entryName} is not present in metadata: " + metaData.trainEvaluation)
-//    )
-//
-//    metaData.validationResults.length shouldEqual 26
-//
-//    // evaluation metrics from test set should be in metadata after eval run
-//    model.evaluateModel(data)
-//    val metaData2 = ModelSelectorSummary.fromMetadata(model.getMetadata().getSummaryMetadata())
-//    MultiClassEvalMetrics.values.foreach(metric =>
-//      assert(metaData2.holdoutEvaluation.get.toJson(false).contains(s"${metric.entryName}"),
-//        s"Metric ${metric.entryName} is not present in metadata: " + metaData2.holdoutEvaluation)
-//    )
-//
-//    val transformedData = model.transform(data)
-//    val pred = model.getOutput()
-//    val justScores = transformedData.collect(pred).map(_.prediction)
-//    justScores shouldEqual transformedData.collect(label).map(_.v.get)
-//  }
-//
-//  it should "fit and predict for default models" in {
-//    // Take one random model type each time
-//    val defaultModels = MultiClassificationModelSelector.Defaults.modelTypesToUse
-//    val modelToTry = defaultModels(scala.util.Random.nextInt(defaultModels.size))
-//
-//    val testEstimator =
-//      MultiClassificationModelSelector
-//        .withCrossValidation(
-//          Option(DataCutter(seed = 42, maxLabelCategories = 1000000, minLabelFraction = 0.0)),
-//          numFolds = 4,
-//          validationMetric = Evaluators.MultiClassification.precision(),
-//          seed = 10L,
-//          modelTypesToUse = Seq(modelToTry)
-//        )
-//        .setInput(label, features)
-//
-//    val model = testEstimator.fit(data)
-//
-//    log.info(model.getMetadata().prettyJson)
-//
-//    // evaluation metrics from test set should be in metadata
-//    val metaData = ModelSelectorSummary.fromMetadata(model.getMetadata().getSummaryMetadata())
-//    MultiClassEvalMetrics.values.foreach(metric =>
-//      assert(metaData.trainEvaluation.toJson(false).contains(s"${metric.entryName}"),
-//        s"Metric ${metric.entryName} is not present in metadata: " + metaData.trainEvaluation)
-//    )
-//
-//    // evaluation metrics from test set should be in metadata after eval run
-//    model.evaluateModel(data)
-//    val metaData2 = ModelSelectorSummary.fromMetadata(model.getMetadata().getSummaryMetadata())
-//    MultiClassEvalMetrics.values.foreach(metric =>
-//      assert(metaData2.holdoutEvaluation.get.toJson(false).contains(s"${metric.entryName}"),
-//        s"Metric ${metric.entryName} is not present in metadata: " + metaData2.holdoutEvaluation)
-//    )
-//
-//    val transformedData = model.transform(data)
-//    val pred = model.getOutput()
-//    val justScores = transformedData.collect(pred).map(_.prediction)
-//    justScores.length shouldEqual transformedData.count()
-//  }
-//
-//  it should "fit and predict with a train validation split, even if there is no split + custom evaluator" in {
-//
-//    val crossEntropy = Evaluators.MultiClassification.custom(
-//      metricName = "cross entropy",
-//      isLargerBetter = false,
-//      evaluateFn = crossEntropyFun
-//    )
-//
-//    val testEstimator =
-//      MultiClassificationModelSelector
-//        .withTrainValidationSplit(None, trainRatio = 0.8, validationMetric = crossEntropy, seed = 10L,
-//          modelsAndParameters = models)
-//        .setInput(label, features)
-//
-//    val model = testEstimator.fit(data)
-//
-//    val sparkStage = model.modelStageIn
-//    sparkStage.isInstanceOf[OpLogisticRegressionModel] shouldBe true
-//    sparkStage.parent.extractParamMap()(sparkStage.parent.getParam("maxIter")) shouldBe 10
-//    sparkStage.parent.extractParamMap()(sparkStage.parent.getParam("regParam")) shouldBe 0.1
-//
-//    val transformedData = model.transform(data)
-//    val pred = testEstimator.getOutput()
-//    val justScores = transformedData.collect(pred)
-//    val missed = justScores.zip(transformedData.collect(label))
-//      .map{ case (p, l) => math.abs(p.prediction - l.v.get) }.sum
-//    missed < 10 shouldBe true
-//  }
-//
-//  it should "fit and predict with a cross validation and compute correct metrics from evaluators" in {
-//
-//    val crossEntropy = Evaluators.MultiClassification.custom(
-//      metricName = "cross entropy",
-//      isLargerBetter = false,
-//      evaluateFn = crossEntropyFun
-//    )
-//
-//    val testEstimator =
-//      MultiClassificationModelSelector
-//        .withCrossValidation(
-//          Option(DataCutter(42, reserveTestFraction = 0.2, maxLabelCategories = 1000000, minLabelFraction = 0.0)),
-//          numFolds = 4,
-//          validationMetric = Evaluators.MultiClassification.precision(),
-//          trainTestEvaluators = Seq(crossEntropy),
-//          seed = 10L,
-//          modelsAndParameters = models
-//        )
-//        .setInput(label, features)
-//
-//    val model = testEstimator.fit(data)
-//    model.evaluateModel(data)
-//
-//    // checking the holdOut Evaluators
-//    assert(testEstimator.evaluators.contains(crossEntropy), "Cross entropy evaluator not present in estimator")
-//
-//    // checking trainingEval & holdOutEval metrics
-//    val metaData = ModelSelectorSummary.fromMetadata(model.getMetadata().getSummaryMetadata())
-//    val trainMetaData = metaData.trainEvaluation.toJson(false)
-//    val holdOutMetaData = metaData.holdoutEvaluation.get.toJson(false)
-//
-//    testEstimator.evaluators.foreach {
-//      case evaluator: OpMultiClassificationEvaluator => {
-//        MultiClassEvalMetrics.values.foreach(metric =>
-//          Seq(trainMetaData, holdOutMetaData).foreach(
-//            metadata => assert(metadata.contains(s"${metric.entryName}"),
-//              s"Metric ${metric.entryName} is not present in metadata: " + metadata)
-//          )
-//        )
-//      }
-//      case evaluator: OpMultiClassificationEvaluatorBase[_] => {
-//        Seq(trainMetaData, holdOutMetaData).foreach(
-//          metadata => assert(metadata.contains(s"${evaluator.name.humanFriendlyName}"),
-//            s"Single Metric evaluator ${evaluator.name} is not present in metadata: " + metadata)
-//        )
-//      }
-//    }
-//  }
-//
-//  it should "fit and predict a model specified in the var bestEstimator" in {
-//    val modelSelector = MultiClassificationModelSelector().setInput(label, features)
-//    val myParam = "entropy"
-//    val myMetaName = "myMeta"
-//    val myMetaValue = 0.5
-//    val myMetadata = ModelEvaluation(myMetaName, myMetaName, myMetaName, SingleMetric(myMetaName, myMetaValue),
-//      Map.empty)
-//    val myEstimatorName = "myEstimatorIsAwesome"
-//    val myEstimator = new OpDecisionTreeClassifier().setImpurity(myParam).setInput(label, features)
-//
-//    val bestEstimator = new BestEstimator(myEstimatorName, myEstimator.asInstanceOf[EstimatorType], Seq(myMetadata))
-//    modelSelector.bestEstimator = Option(bestEstimator)
-//    val fitted = modelSelector.fit(data)
-//
-//    fitted.modelStageIn.parent.extractParamMap().toSeq
-//      .collect{ case p: ParamPair[_] if p.param.name == "impurity" => p.value }.head shouldBe myParam
-//
-//    val meta = ModelSelectorSummary.fromMetadata(fitted.getMetadata().getSummaryMetadata())
-//    meta.validationResults.head shouldBe myMetadata
-//  }
+  Spec(MultiClassificationModelSelector.getClass) should "properly select models to try" in {
+    val modelSelector = MultiClassificationModelSelector
+      .withCrossValidation(modelTypesToUse = Seq(MTT.OpLogisticRegression, MTT.OpNaiveBayes, MTT.OpXGBoostClassifier))
+      .setInput(label.asInstanceOf[Feature[RealNN]], features)
 
-  Spec(MultiClassificationModelSelector.getClass) should "trim low-cardinality labels during cross validation" in {
+    modelSelector.models.size shouldBe 3
+    modelSelector.models.exists(_._1.getClass.getSimpleName == MTT.OpLogisticRegression.entryName) shouldBe true
+    modelSelector.models.exists(_._1.getClass.getSimpleName == MTT.OpRandomForestClassifier.entryName) shouldBe false
+    modelSelector.models.exists(_._1.getClass.getSimpleName == MTT.OpNaiveBayes.entryName) shouldBe true
+    modelSelector.models.exists(_._1.getClass.getSimpleName == MTT.OpXGBoostClassifier.entryName) shouldBe true
+  }
+
+  it should "split into training and test" in {
+    implicit val vectorEncoder: org.apache.spark.sql.Encoder[Vector] = ExpressionEncoder()
+    implicit val e1 = Encoders.tuple(Encoders.scalaDouble, vectorEncoder)
+
+    val testFraction = 0.2
+
+    val (train, test) = DataSplitter(reserveTestFraction = testFraction)
+      .split(data.withColumn(ModelSelectorNames.idColName, monotonically_increasing_id())
+        .as[(Double, Vector, Double)])
+
+
+    val trainCount = train.count()
+    val testCount = test.count()
+    val totalCount = label0Count + label1Count + label2Count
+
+    assert(math.abs(testCount - testFraction * totalCount) <= 20)
+    assert(math.abs(trainCount - (1.0 - testFraction) * totalCount) <= 20)
+
+    trainCount + testCount shouldBe totalCount
+  }
+
+  ignore should "fit and predict all models on by default" in {
+    val testEstimator =
+      MultiClassificationModelSelector
+        .withCrossValidation(
+          Option(DataCutter(seed = 42, maxLabelCategories = 1000000, minLabelFraction = 0.0)),
+          numFolds = 4,
+          validationMetric = Evaluators.MultiClassification.precision(),
+          seed = 10L
+        )
+        .setInput(label, features)
+
+    val model = testEstimator.fit(data)
+
+    log.info(model.getMetadata().prettyJson)
+
+    // evaluation metrics from test set should be in metadata
+    val metaData = ModelSelectorSummary.fromMetadata(model.getMetadata().getSummaryMetadata())
+    MultiClassEvalMetrics.values.foreach(metric =>
+      assert(metaData.trainEvaluation.toJson(false).contains(s"${metric.entryName}"),
+        s"Metric ${metric.entryName} is not present in metadata: " + metaData.trainEvaluation)
+    )
+
+    metaData.validationResults.length shouldEqual 26
+
+    // evaluation metrics from test set should be in metadata after eval run
+    model.evaluateModel(data)
+    val metaData2 = ModelSelectorSummary.fromMetadata(model.getMetadata().getSummaryMetadata())
+    MultiClassEvalMetrics.values.foreach(metric =>
+      assert(metaData2.holdoutEvaluation.get.toJson(false).contains(s"${metric.entryName}"),
+        s"Metric ${metric.entryName} is not present in metadata: " + metaData2.holdoutEvaluation)
+    )
+
+    val transformedData = model.transform(data)
+    val pred = model.getOutput()
+    val justScores = transformedData.collect(pred).map(_.prediction)
+    justScores shouldEqual transformedData.collect(label).map(_.v.get)
+  }
+
+  it should "fit and predict for default models" in {
+    // Take one random model type each time
+    val defaultModels = MultiClassificationModelSelector.Defaults.modelTypesToUse
+    val modelToTry = defaultModels(scala.util.Random.nextInt(defaultModels.size))
+
+    val testEstimator =
+      MultiClassificationModelSelector
+        .withCrossValidation(
+          Option(DataCutter(seed = 42, maxLabelCategories = 1000000, minLabelFraction = 0.0)),
+          numFolds = 4,
+          validationMetric = Evaluators.MultiClassification.precision(),
+          seed = 10L,
+          modelTypesToUse = Seq(modelToTry)
+        )
+        .setInput(label, features)
+
+    val model = testEstimator.fit(data)
+
+    log.info(model.getMetadata().prettyJson)
+
+    // evaluation metrics from test set should be in metadata
+    val metaData = ModelSelectorSummary.fromMetadata(model.getMetadata().getSummaryMetadata())
+    MultiClassEvalMetrics.values.foreach(metric =>
+      assert(metaData.trainEvaluation.toJson(false).contains(s"${metric.entryName}"),
+        s"Metric ${metric.entryName} is not present in metadata: " + metaData.trainEvaluation)
+    )
+
+    // evaluation metrics from test set should be in metadata after eval run
+    model.evaluateModel(data)
+    val metaData2 = ModelSelectorSummary.fromMetadata(model.getMetadata().getSummaryMetadata())
+    MultiClassEvalMetrics.values.foreach(metric =>
+      assert(metaData2.holdoutEvaluation.get.toJson(false).contains(s"${metric.entryName}"),
+        s"Metric ${metric.entryName} is not present in metadata: " + metaData2.holdoutEvaluation)
+    )
+
+    val transformedData = model.transform(data)
+    val pred = model.getOutput()
+    val justScores = transformedData.collect(pred).map(_.prediction)
+    justScores.length shouldEqual transformedData.count()
+  }
+
+  it should "fit and predict with a train validation split, even if there is no split + custom evaluator" in {
+
+    val crossEntropy = Evaluators.MultiClassification.custom(
+      metricName = "cross entropy",
+      isLargerBetter = false,
+      evaluateFn = crossEntropyFun
+    )
+
+    val testEstimator =
+      MultiClassificationModelSelector
+        .withTrainValidationSplit(None, trainRatio = 0.8, validationMetric = crossEntropy, seed = 10L,
+          modelsAndParameters = models)
+        .setInput(label, features)
+
+    val model = testEstimator.fit(data)
+
+    val sparkStage = model.modelStageIn
+    sparkStage.isInstanceOf[OpLogisticRegressionModel] shouldBe true
+    sparkStage.parent.extractParamMap()(sparkStage.parent.getParam("maxIter")) shouldBe 10
+    sparkStage.parent.extractParamMap()(sparkStage.parent.getParam("regParam")) shouldBe 0.1
+
+    val transformedData = model.transform(data)
+    val pred = testEstimator.getOutput()
+    val justScores = transformedData.collect(pred)
+    val missed = justScores.zip(transformedData.collect(label))
+      .map{ case (p, l) => math.abs(p.prediction - l.v.get) }.sum
+    missed < 10 shouldBe true
+  }
+
+  it should "fit and predict with a cross validation and compute correct metrics from evaluators" in {
+
+    val crossEntropy = Evaluators.MultiClassification.custom(
+      metricName = "cross entropy",
+      isLargerBetter = false,
+      evaluateFn = crossEntropyFun
+    )
+
+    val testEstimator =
+      MultiClassificationModelSelector
+        .withCrossValidation(
+          Option(DataCutter(42, reserveTestFraction = 0.2, maxLabelCategories = 1000000, minLabelFraction = 0.0)),
+          numFolds = 4,
+          validationMetric = Evaluators.MultiClassification.precision(),
+          trainTestEvaluators = Seq(crossEntropy),
+          seed = 10L,
+          modelsAndParameters = models
+        )
+        .setInput(label, features)
+
+    val model = testEstimator.fit(data)
+    model.evaluateModel(data)
+
+    // checking the holdOut Evaluators
+    assert(testEstimator.evaluators.contains(crossEntropy), "Cross entropy evaluator not present in estimator")
+
+    // checking trainingEval & holdOutEval metrics
+    val metaData = ModelSelectorSummary.fromMetadata(model.getMetadata().getSummaryMetadata())
+    val trainMetaData = metaData.trainEvaluation.toJson(false)
+    val holdOutMetaData = metaData.holdoutEvaluation.get.toJson(false)
+
+    testEstimator.evaluators.foreach {
+      case evaluator: OpMultiClassificationEvaluator => {
+        MultiClassEvalMetrics.values.foreach(metric =>
+          Seq(trainMetaData, holdOutMetaData).foreach(
+            metadata => assert(metadata.contains(s"${metric.entryName}"),
+              s"Metric ${metric.entryName} is not present in metadata: " + metadata)
+          )
+        )
+      }
+      case evaluator: OpMultiClassificationEvaluatorBase[_] => {
+        Seq(trainMetaData, holdOutMetaData).foreach(
+          metadata => assert(metadata.contains(s"${evaluator.name.humanFriendlyName}"),
+            s"Single Metric evaluator ${evaluator.name} is not present in metadata: " + metadata)
+        )
+      }
+    }
+  }
+
+  it should "fit and predict a model specified in the var bestEstimator" in {
+    val modelSelector = MultiClassificationModelSelector().setInput(label, features)
+    val myParam = "entropy"
+    val myMetaName = "myMeta"
+    val myMetaValue = 0.5
+    val myMetadata = ModelEvaluation(myMetaName, myMetaName, myMetaName, SingleMetric(myMetaName, myMetaValue),
+      Map.empty)
+    val myEstimatorName = "myEstimatorIsAwesome"
+    val myEstimator = new OpDecisionTreeClassifier().setImpurity(myParam).setInput(label, features)
+
+    val bestEstimator = new BestEstimator(myEstimatorName, myEstimator.asInstanceOf[EstimatorType], Seq(myMetadata))
+    modelSelector.bestEstimator = Option(bestEstimator)
+    val fitted = modelSelector.fit(data)
+
+    fitted.modelStageIn.parent.extractParamMap().toSeq
+      .collect{ case p: ParamPair[_] if p.param.name == "impurity" => p.value }.head shouldBe myParam
+
+    val meta = ModelSelectorSummary.fromMetadata(fitted.getMetadata().getSummaryMetadata())
+    meta.validationResults.head shouldBe myMetadata
+  }
+
+  it should "trim low-cardinality labels during cross validation" in {
     val bigLabelCount = 1000
     val rand = scala.util.Random
     rand.setSeed(seed)

--- a/core/src/test/scala/com/salesforce/op/stages/impl/classification/MultiClassificationModelSelectorTest.scala
+++ b/core/src/test/scala/com/salesforce/op/stages/impl/classification/MultiClassificationModelSelectorTest.scala
@@ -295,7 +295,7 @@ class MultiClassificationModelSelectorTest extends FlatSpec with TestSparkContex
     val holdOutMetaData = metaData.holdoutEvaluation.get.toJson(false)
 
     testEstimator.evaluators.foreach {
-      case evaluator: OpMultiClassificationEvaluator => {
+      case _: OpMultiClassificationEvaluator => {
         MultiClassEvalMetrics.values.foreach(metric =>
           Seq(trainMetaData, holdOutMetaData).foreach(
             metadata => assert(metadata.contains(s"${metric.entryName}"),
@@ -339,12 +339,11 @@ class MultiClassificationModelSelectorTest extends FlatSpec with TestSparkContex
     val labelColName = "label"
     val testTable = Table(
       ("nunLabeledRecords", "numLabels", "topLabelsToPick"),
-//      (1000, 10, 100),
-//      (1000, 100, 100),
-      (2000, 1000, 100)
-//      ,
-//      (200, 101, 100),
-//      (200, 101, 50)
+      (1000, 10, 100),
+      (1000, 100, 100),
+      (2000, 1000, 100),
+      (200, 101, 100),
+      (200, 101, 50)
     )
 
     forAll(testTable) { (numLabeledRecords: Int, numLabels: Int, topLabelsToPick: Int) =>

--- a/core/src/test/scala/com/salesforce/op/stages/impl/classification/MultiClassificationModelSelectorTest.scala
+++ b/core/src/test/scala/com/salesforce/op/stages/impl/classification/MultiClassificationModelSelectorTest.scala
@@ -422,7 +422,6 @@ class MultiClassificationModelSelectorTest extends FlatSpec with TestSparkContex
 
         bigData.unpersist()
         bigNoneIndexedData.unpersist()
-
       }
     }
   }

--- a/core/src/test/scala/com/salesforce/op/stages/impl/classification/MultiClassificationModelSelectorTest.scala
+++ b/core/src/test/scala/com/salesforce/op/stages/impl/classification/MultiClassificationModelSelectorTest.scala
@@ -386,6 +386,8 @@ class MultiClassificationModelSelectorTest extends FlatSpec with TestSparkContex
           bigDataWithMeta, response = labelColName, nonNullable = Set("features"))
 
         val cutter = DataCutter(seed = 42L, maxLabelCategories = topLabelsToPick)
+        cutter.setCacheValidatedDFForTesting(true)
+
         val testEstimator =
           MultiClassificationModelSelector
             .withCrossValidation(
@@ -398,8 +400,7 @@ class MultiClassificationModelSelectorTest extends FlatSpec with TestSparkContex
             .setInput(label, features)
         testEstimator.fit(bigDataWithMeta)
 
-        val numLabelsInCutter = cutter.summary
-          .flatMap(_.asInstanceOf[DataCutterSummary].preparedDF)
+        val numLabelsInCutter = cutter.cachedDataFrameForTesting
           .map(_.select(labelColName).distinct().count())
 
         bigData.unpersist()

--- a/core/src/test/scala/com/salesforce/op/stages/impl/classification/MultiClassificationModelSelectorTest.scala
+++ b/core/src/test/scala/com/salesforce/op/stages/impl/classification/MultiClassificationModelSelectorTest.scala
@@ -412,7 +412,7 @@ class MultiClassificationModelSelectorTest extends FlatSpec with TestSparkContex
             .getOrElse(spark.emptyDataFrame)
 
           (df.select(labelColName).distinct().count(),
-            MetadataHelper.metadtaUtils.getNumClasses(df.schema.head).getOrElse(-1)))
+            MetadataHelper.metadtaUtils.getNumClasses(df.schema.head).getOrElse(-1))
         }
 
         val maxUniqs = math.min(numLabels, topLabelsToPick)

--- a/core/src/test/scala/com/salesforce/op/stages/impl/classification/MultiClassificationModelSelectorTest.scala
+++ b/core/src/test/scala/com/salesforce/op/stages/impl/classification/MultiClassificationModelSelectorTest.scala
@@ -333,8 +333,8 @@ class MultiClassificationModelSelectorTest extends FlatSpec with TestSparkContex
   }
 
   it should "trim low-cardinality labels during cross validation" in {
-    val nunLabeledRecords = 1000
-    val numLabels = 500
+    val nunLabeledRecords = 10000
+    val numLabels = 1000
     val topLabelsToPick = 100
     val labelColName = "label"
 

--- a/core/src/test/scala/com/salesforce/op/stages/impl/feature/VectorsCombinerTest.scala
+++ b/core/src/test/scala/com/salesforce/op/stages/impl/feature/VectorsCombinerTest.scala
@@ -35,10 +35,11 @@ import com.salesforce.op.features.TransientFeature
 import com.salesforce.op.features.types.{Text, _}
 import com.salesforce.op.stages.base.sequence.SequenceModel
 import com.salesforce.op.test.{OpEstimatorSpec, PassengerSparkFixtureTest, TestFeatureBuilder}
-import com.salesforce.op.testkit.{RandomReal, RandomVector}
 import com.salesforce.op.utils.spark.OpVectorMetadata
 import com.salesforce.op.utils.spark.RichMetadata._
+import org.apache.spark.ml.attribute.MetadataHelper
 import org.apache.spark.ml.linalg.Vectors
+import org.apache.spark.sql.types.Metadata
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 
@@ -92,7 +93,9 @@ class VectorsCombinerTest
     val outputData = new OpWorkflow().setReader(dataReader)
       .setResultFeatures(vector, inputs1, inputs2, inputs3)
       .train().score()
-    outputData.schema(inputs1.name).metadata.wrapped.getAny("ml_attr").toString shouldBe "Some({\"num_attrs\":5})"
+    outputData.schema(inputs1.name).metadata.wrapped
+      .get[Metadata](MetadataHelper.attributeKeys.ML_ATTR)
+      .getLong(MetadataHelper.attributeKeys.NUM_ATTRIBUTES) shouldBe 5
 
     val inputMetadata = OpVectorMetadata.flatten(vector.name,
       Array(TransientFeature(inputs1).toVectorMetaData(5, Option(inputs1.name)),

--- a/core/src/test/scala/com/salesforce/op/stages/impl/tuning/DataBalancerTest.scala
+++ b/core/src/test/scala/com/salesforce/op/stages/impl/tuning/DataBalancerTest.scala
@@ -113,7 +113,7 @@ class DataBalancerTest extends FlatSpec with TestSparkContext with SplitterSumma
     balancer.getUpSampleFraction shouldBe upSample
     balancer.getDownSampleFraction shouldBe downSample
     balancer.getIsPositiveSmall shouldBe false
-    checkRecurringPrepare(balancer, res1, s1, DataBalancerSummary(800, 200, 0.4, 2.0, 0.75))
+    checkRecurringPrepare(balancer, res1, s1.summaryOpt, DataBalancerSummary(800, 200, 0.4, 2.0, 0.75))
   }
 
   it should "throw an error if you try to prepare before examining" in {
@@ -130,7 +130,7 @@ class DataBalancerTest extends FlatSpec with TestSparkContext with SplitterSumma
     val res1 = balancer.validationPrepare(data)
 
     balancer.getAlreadyBalancedFraction shouldBe 1.0
-    checkRecurringPrepare(balancer, res1, s1, DataBalancerSummary(800, 200, 0.01, 0.0, 1.0))
+    checkRecurringPrepare(balancer, res1, s1.summaryOpt, DataBalancerSummary(800, 200, 0.01, 0.0, 1.0))
   }
 
   it should "remember that data is already balanced, but needs to be sample because too big" in {
@@ -141,7 +141,7 @@ class DataBalancerTest extends FlatSpec with TestSparkContext with SplitterSumma
     val res1 = balancer.validationPrepare(data)
 
     balancer.getAlreadyBalancedFraction shouldBe maxSize.toDouble / (smallCount + bigCount)
-    checkRecurringPrepare(balancer, res1, s1, DataBalancerSummary(800, 200, 0.01, 0.0, 0.1))
+    checkRecurringPrepare(balancer, res1, s1.summaryOpt, DataBalancerSummary(800, 200, 0.01, 0.0, 0.1))
   }
 
   private def checkRecurringPrepare(
@@ -166,7 +166,7 @@ class DataBalancerTest extends FlatSpec with TestSparkContext with SplitterSumma
     val s2 = balancer.preValidationPrepare(data)
     val res2 = balancer.validationPrepare(data)
     res2.collect() shouldBe previousResult.collect()
-    s2 shouldBe summary
+    s2.summaryOpt shouldBe summary
     balancer.summary shouldBe Some(expectedSummary)
   }
 

--- a/core/src/test/scala/com/salesforce/op/stages/impl/tuning/DataCutterTest.scala
+++ b/core/src/test/scala/com/salesforce/op/stages/impl/tuning/DataCutterTest.scala
@@ -175,7 +175,7 @@ class DataCutterTest extends FlatSpec with TestSparkContext with SplitterSummary
   it should "filter out using labels to keep/drop params" in {
     val keep = Seq(0.0, 1.0)
     val drop = Seq(5.0, 7.0)
-    val dc = DataCutter(seed = seed).setLabels(keep = keep, dropTop10 = drop, labelsDropped = 2)
+    val dc = DataCutter(seed = seed).setLabels(keep = keep, dropTopK = drop, labelsDropped = 2)
     dc.preValidationPrepare(randDF)
     val split = dc.validationPrepare(randDF)
 

--- a/core/src/test/scala/com/salesforce/op/stages/impl/tuning/DataCutterTest.scala
+++ b/core/src/test/scala/com/salesforce/op/stages/impl/tuning/DataCutterTest.scala
@@ -61,14 +61,13 @@ class DataCutterTest extends FlatSpec with TestSparkContext with SplitterSummary
     val split1 = dc1.validationPrepare(randDF)
 
     split1.count() shouldBe dataSize
-    assertDataCutterSummary(s1) { s =>
+    assertDataCutterSummary(s1.summaryOpt) { s =>
       s.labelsKept.length shouldBe 1000
       s.labelsDropped.length shouldBe 0
       s shouldBe DataCutterSummary(
         dc1.getLabelsToKeep,
         dc1.getLabelsToDrop,
-        dc1.getLabelsDroppedTotal,
-        Option(split1)
+        dc1.getLabelsDroppedTotal
       )
     }
 
@@ -77,14 +76,13 @@ class DataCutterTest extends FlatSpec with TestSparkContext with SplitterSummary
     val split2 = dc2.validationPrepare(biasDF)
 
     split2.count() shouldBe dataSize
-    assertDataCutterSummary(s2) { s =>
+    assertDataCutterSummary(s2.summaryOpt) { s =>
       s.labelsKept.length shouldBe 1000
       s.labelsDropped.length shouldBe 0
       s shouldBe DataCutterSummary(
         dc2.getLabelsToKeep,
         dc2.getLabelsToDrop,
-        dc2.getLabelsDroppedTotal,
-        Option(split2)
+        dc2.getLabelsDroppedTotal
       )
     }
   }
@@ -103,35 +101,33 @@ class DataCutterTest extends FlatSpec with TestSparkContext with SplitterSummary
   it should "filter out all but the top N label categories" in {
     val dc1 = DataCutter(seed = seed, minLabelFraction = 0.0, maxLabelCategories = 100, reserveTestFraction = 0.5)
     val s1 = dc1.preValidationPrepare(randDF)
-    val split1 = dc1.validationPrepare(randDF)
+    val split1 = dc1.validationPrepare(s1.dataFrame.get)
 
     findDistinct(split1).count() shouldBe 100
-    assertDataCutterSummary(s1) { s =>
+    assertDataCutterSummary(s1.summaryOpt) { s =>
       s.labelsKept.length shouldBe 100
       s.labelsDropped.length shouldBe 10
       s.labelsDroppedTotal shouldBe 900
       s shouldBe DataCutterSummary(
         dc1.getLabelsToKeep,
         dc1.getLabelsToDrop,
-        dc1.getLabelsDroppedTotal,
-        Option(split1)
+        dc1.getLabelsDroppedTotal
       )
     }
 
     val dc2 = DataCutter(seed = seed).setMaxLabelCategories(3)
     val s2 = dc2.preValidationPrepare(biasDF)
-    val split2 = dc2.validationPrepare(biasDF)
+    val split2 = dc2.validationPrepare(s2.dataFrame.get)
 
     findDistinct(split2).collect().toSet shouldEqual Set(0.0, 1.0, 2.0)
-    assertDataCutterSummary(s2) { s =>
+    assertDataCutterSummary(s2.summaryOpt) { s =>
       s.labelsKept.length shouldBe 3
       s.labelsDropped.length shouldBe 10
       s.labelsDroppedTotal shouldBe 997
       s shouldBe DataCutterSummary(
         dc2.getLabelsToKeep,
         dc2.getLabelsToDrop,
-        dc2.getLabelsDroppedTotal,
-        Option(split2)
+        dc2.getLabelsDroppedTotal
       )
     }
   }
@@ -139,35 +135,33 @@ class DataCutterTest extends FlatSpec with TestSparkContext with SplitterSummary
   it should "filter out anything that does not have at least the specified data fraction" in {
     val dc1 = DataCutter(seed = seed, minLabelFraction = 0.0012, maxLabelCategories = 100000, reserveTestFraction = 0.5)
     val s1 = dc1.preValidationPrepare(randDF)
-    val split1 = dc1.validationPrepare(randDF)
+    val split1 = dc1.validationPrepare(s1.dataFrame.get)
 
     val distinct = findDistinct(randDF).count()
     val distTrain = findDistinct(split1)
     distTrain.count() < distinct shouldBe true
     distTrain.count() > 0 shouldBe true
-    assertDataCutterSummary(s1) { s =>
+    assertDataCutterSummary(s1.summaryOpt) { s =>
       s.labelsKept.length + s.labelsDroppedTotal shouldBe distinct
       s shouldBe DataCutterSummary(
         dc1.getLabelsToKeep,
         dc1.getLabelsToDrop,
-        dc1.getLabelsDroppedTotal,
-        Option(split1)
+        dc1.getLabelsDroppedTotal
       )
     }
 
     val dc2 = DataCutter(seed = seed, minLabelFraction = 0.2, reserveTestFraction = 0.5)
     val s2 = dc2.preValidationPrepare(biasDF)
-    val split2 = dc2.validationPrepare(biasDF)
+    val split2 = dc2.validationPrepare(s2.dataFrame.get)
     findDistinct(split2).count() shouldBe 3
-    assertDataCutterSummary(s2) { s =>
+    assertDataCutterSummary(s2.summaryOpt) { s =>
       s.labelsKept.length shouldBe 3
       s.labelsDroppedTotal shouldBe 997
       s.labelsDropped.length shouldBe 10
       s shouldBe DataCutterSummary(
         dc2.getLabelsToKeep,
         dc2.getLabelsToDrop,
-        dc2.getLabelsDroppedTotal,
-        Option(split2)
+        dc2.getLabelsDroppedTotal
       )
     }
   }
@@ -176,8 +170,8 @@ class DataCutterTest extends FlatSpec with TestSparkContext with SplitterSummary
     val keep = Seq(0.0, 1.0)
     val drop = Seq(5.0, 7.0)
     val dc = DataCutter(seed = seed).setLabels(keep = keep, dropTopK = drop, labelsDropped = 2)
-    dc.preValidationPrepare(randDF)
-    val split = dc.validationPrepare(randDF)
+    val s1 = dc.preValidationPrepare(randDF)
+    val split = dc.validationPrepare(s1.dataFrame.get)
 
     findDistinct(split).collect().sorted shouldBe Array(0.0, 1.0)
     dc.getLabelsToKeep shouldBe keep.toArray

--- a/core/src/test/scala/com/salesforce/op/stages/impl/tuning/DataCutterTest.scala
+++ b/core/src/test/scala/com/salesforce/op/stages/impl/tuning/DataCutterTest.scala
@@ -64,7 +64,12 @@ class DataCutterTest extends FlatSpec with TestSparkContext with SplitterSummary
     assertDataCutterSummary(s1) { s =>
       s.labelsKept.length shouldBe 1000
       s.labelsDropped.length shouldBe 0
-      s shouldBe DataCutterSummary(dc1.getLabelsToKeep, dc1.getLabelsToDrop, dc1.getLabelsDroppedTotal)
+      s shouldBe DataCutterSummary(
+        dc1.getLabelsToKeep,
+        dc1.getLabelsToDrop,
+        dc1.getLabelsDroppedTotal,
+        Option(split1)
+      )
     }
 
     val dc2 = DataCutter(seed = seed, minLabelFraction = 0.0, maxLabelCategories = 100000)
@@ -75,7 +80,12 @@ class DataCutterTest extends FlatSpec with TestSparkContext with SplitterSummary
     assertDataCutterSummary(s2) { s =>
       s.labelsKept.length shouldBe 1000
       s.labelsDropped.length shouldBe 0
-      s shouldBe DataCutterSummary(dc2.getLabelsToKeep, dc2.getLabelsToDrop, dc2.getLabelsDroppedTotal)
+      s shouldBe DataCutterSummary(
+        dc2.getLabelsToKeep,
+        dc2.getLabelsToDrop,
+        dc2.getLabelsDroppedTotal,
+        Option(split2)
+      )
     }
   }
 
@@ -100,7 +110,12 @@ class DataCutterTest extends FlatSpec with TestSparkContext with SplitterSummary
       s.labelsKept.length shouldBe 100
       s.labelsDropped.length shouldBe 10
       s.labelsDroppedTotal shouldBe 900
-      s shouldBe DataCutterSummary(dc1.getLabelsToKeep, dc1.getLabelsToDrop, dc1.getLabelsDroppedTotal)
+      s shouldBe DataCutterSummary(
+        dc1.getLabelsToKeep,
+        dc1.getLabelsToDrop,
+        dc1.getLabelsDroppedTotal,
+        Option(split1)
+      )
     }
 
     val dc2 = DataCutter(seed = seed).setMaxLabelCategories(3)
@@ -112,7 +127,12 @@ class DataCutterTest extends FlatSpec with TestSparkContext with SplitterSummary
       s.labelsKept.length shouldBe 3
       s.labelsDropped.length shouldBe 10
       s.labelsDroppedTotal shouldBe 997
-      s shouldBe DataCutterSummary(dc2.getLabelsToKeep, dc2.getLabelsToDrop, dc2.getLabelsDroppedTotal)
+      s shouldBe DataCutterSummary(
+        dc2.getLabelsToKeep,
+        dc2.getLabelsToDrop,
+        dc2.getLabelsDroppedTotal,
+        Option(split2)
+      )
     }
   }
 
@@ -127,7 +147,12 @@ class DataCutterTest extends FlatSpec with TestSparkContext with SplitterSummary
     distTrain.count() > 0 shouldBe true
     assertDataCutterSummary(s1) { s =>
       s.labelsKept.length + s.labelsDroppedTotal shouldBe distinct
-      s shouldBe DataCutterSummary(dc1.getLabelsToKeep, dc1.getLabelsToDrop, dc1.getLabelsDroppedTotal)
+      s shouldBe DataCutterSummary(
+        dc1.getLabelsToKeep,
+        dc1.getLabelsToDrop,
+        dc1.getLabelsDroppedTotal,
+        Option(split1)
+      )
     }
 
     val dc2 = DataCutter(seed = seed, minLabelFraction = 0.2, reserveTestFraction = 0.5)
@@ -138,19 +163,20 @@ class DataCutterTest extends FlatSpec with TestSparkContext with SplitterSummary
       s.labelsKept.length shouldBe 3
       s.labelsDroppedTotal shouldBe 997
       s.labelsDropped.length shouldBe 10
-      s shouldBe DataCutterSummary(dc2.getLabelsToKeep, dc2.getLabelsToDrop, dc2.getLabelsDroppedTotal)
+      s shouldBe DataCutterSummary(
+        dc2.getLabelsToKeep,
+        dc2.getLabelsToDrop,
+        dc2.getLabelsDroppedTotal,
+        Option(split2)
+      )
     }
   }
 
   it should "filter out using labels to keep/drop params" in {
-    val keep = Set(0.0, 1.0)
-    val drop = Set(5.0, 7.0)
+    val keep = Seq(0.0, 1.0)
+    val drop = Seq(5.0, 7.0)
     val dc = DataCutter(seed = seed).setLabels(keep = keep, dropTop10 = drop, labelsDropped = 2)
-    dc.summary = Option(DataCutterSummary(
-      labelsKept = dc.getLabelsToKeep,
-      labelsDropped = dc.getLabelsToDrop,
-      labelsDroppedTotal = dc.getLabelsDroppedTotal
-    ))
+    dc.preValidationPrepare(randDF)
     val split = dc.validationPrepare(randDF)
 
     findDistinct(split).collect().sorted shouldBe Array(0.0, 1.0)

--- a/core/src/test/scala/com/salesforce/op/stages/impl/tuning/DataCutterTest.scala
+++ b/core/src/test/scala/com/salesforce/op/stages/impl/tuning/DataCutterTest.scala
@@ -42,10 +42,11 @@ import org.scalatest.junit.JUnitRunner
 class DataCutterTest extends FlatSpec with TestSparkContext with SplitterSummaryAsserts {
   import spark.implicits._
 
-  val labels = RandomIntegral.integrals(0, 1000).withProbabilityOfEmpty(0).limit(100000)
+  private val numIntLabels = 1000
+  val labels = RandomIntegral.integrals(0, numIntLabels).withProbabilityOfEmpty(0).limit(100000)
   val labelsBiased = {
     RandomIntegral.integrals(0, 3).withProbabilityOfEmpty(0).limit(80000) ++
-      RandomIntegral.integrals(3, 1000).withProbabilityOfEmpty(0).limit(20000)
+      RandomIntegral.integrals(3, numIntLabels).withProbabilityOfEmpty(0).limit(20000)
   }
   val vectors = RandomVector.sparse(RandomReal.poisson(2), 10).limit(100000)
 
@@ -62,7 +63,7 @@ class DataCutterTest extends FlatSpec with TestSparkContext with SplitterSummary
 
     split1.count() shouldBe dataSize
     assertDataCutterSummary(s1) { s =>
-      s.labelsKept.length shouldBe 1000
+      s.labelsKept.length shouldBe numIntLabels
       s.labelsDropped.length shouldBe 0
       s shouldBe DataCutterSummary(dc1.getLabelsToKeep, dc1.getLabelsToDrop)
     }
@@ -73,7 +74,7 @@ class DataCutterTest extends FlatSpec with TestSparkContext with SplitterSummary
 
     split2.count() shouldBe dataSize
     assertDataCutterSummary(s2) { s =>
-      s.labelsKept.length shouldBe 1000
+      s.labelsKept.length shouldBe numIntLabels
       s.labelsDropped.length shouldBe 0
       s shouldBe DataCutterSummary(dc2.getLabelsToKeep, dc2.getLabelsToDrop)
     }
@@ -98,7 +99,7 @@ class DataCutterTest extends FlatSpec with TestSparkContext with SplitterSummary
     findDistinct(split1).count() shouldBe 100
     assertDataCutterSummary(s1) { s =>
       s.labelsKept.length shouldBe 100
-      s.labelsDropped.length shouldBe 900
+      s.labelsDropped.length shouldBe 100
       s shouldBe DataCutterSummary(dc1.getLabelsToKeep, dc1.getLabelsToDrop)
     }
 
@@ -109,7 +110,7 @@ class DataCutterTest extends FlatSpec with TestSparkContext with SplitterSummary
     findDistinct(split2).collect().toSet shouldEqual Set(0.0, 1.0, 2.0)
     assertDataCutterSummary(s2) { s =>
       s.labelsKept.length shouldBe 3
-      s.labelsDropped.length shouldBe 997
+      s.labelsDropped.length shouldBe 100
       s shouldBe DataCutterSummary(dc2.getLabelsToKeep, dc2.getLabelsToDrop)
     }
   }
@@ -124,7 +125,6 @@ class DataCutterTest extends FlatSpec with TestSparkContext with SplitterSummary
     distTrain.count() < distinct shouldBe true
     distTrain.count() > 0 shouldBe true
     assertDataCutterSummary(s1) { s =>
-      s.labelsKept.length + s.labelsDropped.length shouldBe distinct
       s shouldBe DataCutterSummary(dc1.getLabelsToKeep, dc1.getLabelsToDrop)
     }
 
@@ -134,7 +134,7 @@ class DataCutterTest extends FlatSpec with TestSparkContext with SplitterSummary
     findDistinct(split2).count() shouldBe 3
     assertDataCutterSummary(s2) { s =>
       s.labelsKept.length shouldBe 3
-      s.labelsDropped.length shouldBe 997
+      s.labelsDropped.length shouldBe 100
       s shouldBe DataCutterSummary(dc2.getLabelsToKeep, dc2.getLabelsToDrop)
     }
   }

--- a/core/src/test/scala/com/salesforce/op/stages/impl/tuning/DataSplitterTest.scala
+++ b/core/src/test/scala/com/salesforce/op/stages/impl/tuning/DataSplitterTest.scala
@@ -72,7 +72,7 @@ class DataSplitterTest extends FlatSpec with TestSparkContext with SplitterSumma
     val summary = dataSplitter.preValidationPrepare(data)
     val train = dataSplitter.validationPrepare(data)
     train.collect().zip(data.collect()).foreach { case (a, b) => a shouldBe b }
-    assertDataSplitterSummary(summary) { s => s shouldBe DataSplitterSummary() }
+    assertDataSplitterSummary(summary.summaryOpt) { s => s shouldBe DataSplitterSummary() }
   }
 
 }

--- a/core/src/test/scala/com/salesforce/op/stages/impl/tuning/OpValidatorTest.scala
+++ b/core/src/test/scala/com/salesforce/op/stages/impl/tuning/OpValidatorTest.scala
@@ -99,7 +99,7 @@ class OpValidatorTest extends FlatSpec with TestSparkContext with SplitterSummar
       assertFractions(multiClassProbabilities, train)
       assertFractions(multiClassProbabilities, validate)
     }
-    assertDataCutterSummary(new DataCutter().preValidationPrepare(multiDS))(_ => succeed)
+    assertDataCutterSummary(new DataCutter().preValidationPrepare(multiDS).summaryOpt)(_ => succeed)
   }
 
   Spec[OpTrainValidationSplit[_, _]] should "stratify binary class data" in {
@@ -123,7 +123,7 @@ class OpValidatorTest extends FlatSpec with TestSparkContext with SplitterSummar
       assertFractions(multiClassProbabilities, train)
       assertFractions(multiClassProbabilities, validate)
     }
-    assertDataCutterSummary(new DataCutter().preValidationPrepare(multiDS))(_ => succeed)
+    assertDataCutterSummary(new DataCutter().preValidationPrepare(multiDS).summaryOpt)(_ => succeed)
   }
 
   /**

--- a/core/src/test/scala/com/salesforce/op/stages/impl/tuning/OpValidatorTest.scala
+++ b/core/src/test/scala/com/salesforce/op/stages/impl/tuning/OpValidatorTest.scala
@@ -86,7 +86,7 @@ class OpValidatorTest extends FlatSpec with TestSparkContext with SplitterSummar
       assertFractions(Array(1 - p, p), validate)
     }
     assertDataBalancerSummary(balancer.summary) { s =>
-      Some(s) shouldBe new DataBalancer().preValidationPrepare(binaryDS)
+      Some(s) shouldBe new DataBalancer().preValidationPrepare(binaryDS).summaryOpt
     }
   }
 
@@ -111,7 +111,7 @@ class OpValidatorTest extends FlatSpec with TestSparkContext with SplitterSummar
       assertFractions(Array(1 - p, p), validate)
     }
     assertDataBalancerSummary(balancer.summary) { s =>
-      Some(s) shouldBe new DataBalancer().preValidationPrepare(binaryDS)
+      Some(s) shouldBe new DataBalancer().preValidationPrepare(binaryDS).summaryOpt
     }
   }
 

--- a/core/src/test/scala/com/salesforce/op/stages/impl/tuning/SplitterSummaryAsserts.scala
+++ b/core/src/test/scala/com/salesforce/op/stages/impl/tuning/SplitterSummaryAsserts.scala
@@ -63,6 +63,7 @@ trait SplitterSummaryAsserts {
       meta.getString(SplitterSummary.ClassName) shouldBe classOf[DataCutterSummary].getName
       meta.getDoubleArray(ModelSelectorNames.LabelsKept).foreach(_ should be >= 0.0)
       meta.getDoubleArray(ModelSelectorNames.LabelsDropped).foreach(_ should be >= 0.0)
+      meta.getLong(ModelSelectorNames.LabelsDroppedTotal) should be >= 0L
       assert(s)
     case x =>
       fail(s"Unexpected data cutter summary: $x")


### PR DESCRIPTION
**Related issues**
Fixes #245

- label sort by count is nondeterministic for labels with the same count
- data cutter label trimming in validation is not called prior to bestEstimator
- column  metadata is not updated after trimming
- in `DataCutter.estimate` whereas `filter` before `sort` is good for performance it may not drop labels non-deterministically unlike filtering over a stable order. 
  
**Describe the proposed solution**
Remove non-determinism 