### PR TITLE
Changes to allow passing reader as optional param to be able to  gene…

### DIFF
--- a/core/src/main/scala/com/salesforce/op/OpWorkflow.scala
+++ b/core/src/main/scala/com/salesforce/op/OpWorkflow.scala
@@ -219,8 +219,14 @@ class OpWorkflow(val uid: String = UID[OpWorkflow]) extends OpWorkflowCore {
    *
    * @return Dataframe with all the features generated + persisted
    */
-  protected def generateRawData()(implicit spark: SparkSession): DataFrame = {
-    (reader, rawFeatureFilter) match {
+  protected def generateRawData(readerAlt: Option[Reader[_]] = None)(implicit spark: SparkSession): DataFrame = {
+    val finalreader =
+      readerAlt match {
+        case Some(_) => readerAlt
+        case None => reader
+    }
+
+    (finalreader, rawFeatureFilter) match {
       case (None, None) => throw new IllegalArgumentException(
         "Data reader must be set either directly on the workflow or through the RawFeatureFilter")
       case (Some(r), None) =>

--- a/core/src/main/scala/com/salesforce/op/OpWorkflowCore.scala
+++ b/core/src/main/scala/com/salesforce/op/OpWorkflowCore.scala
@@ -261,7 +261,7 @@ private[op] trait OpWorkflowCore {
    *
    * @return Dataframe with all the features generated + persisted
    */
-  protected def generateRawData()(implicit spark: SparkSession): DataFrame
+  protected def generateRawData(readerAlt: Option[Reader[_]] = None)(implicit spark: SparkSession): DataFrame
 
   /**
    * Returns a dataframe containing all the columns generated up to the feature input

--- a/core/src/main/scala/com/salesforce/op/test/TestOpWorkflowBuilder.scala
+++ b/core/src/main/scala/com/salesforce/op/test/TestOpWorkflowBuilder.scala
@@ -32,6 +32,7 @@ package com.salesforce.op.test
 
 import com.salesforce.op.OpWorkflow
 import com.salesforce.op.features.OPFeature
+import com.salesforce.op.readers.Reader
 import org.apache.spark.sql.{DataFrame, SparkSession}
 
 /**
@@ -47,7 +48,8 @@ object TestOpWorkflowBuilder {
    */
   def apply(dataFrame: DataFrame, features: OPFeature*): OpWorkflow = {
     new OpWorkflow() {
-      override def generateRawData()(implicit spark: SparkSession): DataFrame = dataFrame
+      override def generateRawData(readerAlt: Option[Reader[_]] = None)
+        (implicit spark: SparkSession): DataFrame = dataFrame
     }.setResultFeatures(features: _*)
   }
 


### PR DESCRIPTION
…rateDataFrame based on the outside reader

versus reader set on the workflowmodel, as latter one can be cached

**Related issues**
Refer to issue(s) addressed in this pull request from [Issues](https://github.com/salesforce/TransmogrifAI/issues) page.

**Describe the proposed solution**
A clear and concise description of what the changes are.

**Describe alternatives you've considered**
A clear and concise description of any alternative solutions or features you've considered.

**Additional context**
Add any other context about the changes here.
