### PR TITLE
Allow copying model instances

### DIFF
--- a/core/src/main/scala/com/salesforce/op/OpWorkflowCore.scala
+++ b/core/src/main/scala/com/salesforce/op/OpWorkflowCore.scala
@@ -88,11 +88,6 @@ private[op] trait OpWorkflowCore {
     this
   }
 
-  private[op] final def setRawFeatures(features: Array[OPFeature]): this.type = {
-    rawFeatures = features
-    this
-  }
-
   private[op] final def setRawFeatureFilterResults(results: RawFeatureFilterResults): this.type = {
     rawFeatureFilterResults = results
     this

--- a/core/src/main/scala/com/salesforce/op/OpWorkflowModel.scala
+++ b/core/src/main/scala/com/salesforce/op/OpWorkflowModel.scala
@@ -32,12 +32,13 @@ package com.salesforce.op
 
 import com.salesforce.op.evaluators.{EvaluationMetrics, OpEvaluatorBase}
 import com.salesforce.op.features.types.FeatureType
-import com.salesforce.op.features.{FeatureLike, OPFeature}
+import com.salesforce.op.features.{Feature, FeatureLike, OPFeature}
 import com.salesforce.op.readers.DataFrameFieldNames._
 import com.salesforce.op.stages.{OPStage, OpPipelineStage, OpTransformer}
 import com.salesforce.op.utils.spark.RichDataset._
 import com.salesforce.op.utils.spark.RichMetadata._
 import com.salesforce.op.utils.stages.FitStagesUtil
+import org.apache.spark.ml.param.ParamMap
 import org.apache.spark.sql.types.Metadata
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.{DataFrame, SparkSession}
@@ -417,6 +418,31 @@ class OpWorkflowModel(val uid: String = UID[OpWorkflowModel], val trainingParams
     path.foreach(scores.saveAvro(_))
 
     scores -> metrics
+  }
+
+  /**
+   * Creates a copy of [[OpWorkflowModel]]
+   *
+   * @return copy of [[OpWorkflowModel]]
+   */
+  def copy(): OpWorkflowModel = {
+    def copyFeatures(features: Array[OPFeature]): Array[OPFeature] = features.collect { case f: Feature[_] =>
+      implicit val tt = f.wtt
+      f.copy()
+    }
+    val copy =
+      new OpWorkflowModel(uid = uid, trainingParams = trainingParams.copy())
+        .setFeatures(copyFeatures(resultFeatures))
+        .setRawFeatures(copyFeatures(rawFeatures))
+        .setBlacklist(copyFeatures(blacklistedFeatures))
+        .setBlacklistMapKeys(blacklistedMapKeys)
+        .setRawFeatureFilterResults(rawFeatureFilterResults.copy())
+        .setStages(stages.map(_.copy(ParamMap.empty)))
+        .setParameters(parameters.copy())
+
+    reader.foreach(copy.setReader)
+
+    if (isWorkflowCV) copy.withWorkflowCV else copy
   }
 
 }

--- a/core/src/main/scala/com/salesforce/op/OpWorkflowModel.scala
+++ b/core/src/main/scala/com/salesforce/op/OpWorkflowModel.scala
@@ -421,9 +421,9 @@ class OpWorkflowModel(val uid: String = UID[OpWorkflowModel], val trainingParams
   }
 
   /**
-   * Creates a copy of [[OpWorkflowModel]]
+   * Creates a copy of this [[OpWorkflowModel]] instance
    *
-   * @return copy of [[OpWorkflowModel]]
+   * @return copy of this [[OpWorkflowModel]] instance
    */
   def copy(): OpWorkflowModel = {
     def copyFeatures(features: Array[OPFeature]): Array[OPFeature] = features.collect { case f: Feature[_] =>

--- a/core/src/main/scala/com/salesforce/op/OpWorkflowModel.scala
+++ b/core/src/main/scala/com/salesforce/op/OpWorkflowModel.scala
@@ -433,7 +433,6 @@ class OpWorkflowModel(val uid: String = UID[OpWorkflowModel], val trainingParams
     val copy =
       new OpWorkflowModel(uid = uid, trainingParams = trainingParams.copy())
         .setFeatures(copyFeatures(resultFeatures))
-        .setRawFeatures(copyFeatures(rawFeatures))
         .setBlacklist(copyFeatures(blacklistedFeatures))
         .setBlacklistMapKeys(blacklistedMapKeys)
         .setRawFeatureFilterResults(rawFeatureFilterResults.copy())

--- a/core/src/test/scala/com/salesforce/op/OpWorkflowModelReaderWriterTest.scala
+++ b/core/src/test/scala/com/salesforce/op/OpWorkflowModelReaderWriterTest.scala
@@ -286,6 +286,22 @@ class OpWorkflowModelReaderWriterTest
     wfM.getBlacklist().map(_.name) should contain theSameElementsAs Array("age", "description")
   }
 
+  it should "load model and allow copying it" in new VectorizedFlow {
+    val wfM = wf.loadModel(saveFlowPathStable)
+    val copy = wfM.copy()
+    copy.uid shouldBe wfM.uid
+    copy.trainingParams.toString shouldBe wfM.trainingParams.toString
+    copy.isWorkflowCV shouldBe wfM.isWorkflowCV
+    copy.reader shouldBe wfM.reader
+    copy.resultFeatures shouldBe wfM.resultFeatures
+    copy.rawFeatures shouldBe wfM.rawFeatures
+    copy.blacklistedFeatures shouldBe wfM.blacklistedFeatures
+    copy.blacklistedMapKeys shouldBe wfM.blacklistedMapKeys
+    copy.rawFeatureFilterResults shouldBe wfM.rawFeatureFilterResults
+    copy.stages.map(_.uid) shouldBe wfM.stages.map(_.uid)
+    copy.parameters.toString shouldBe wfM.parameters.toString
+  }
+
   it should "be able to load a old version of a saved model" in new VectorizedFlow {
     val wfM = wf.loadModel("src/test/resources/OldModelVersion")
     wfM.getBlacklist().isEmpty shouldBe true


### PR DESCRIPTION
**Related issues**
Currently once the model is loaded it's impossible to reuse the same instance across multiple threads.

**Describe the proposed solution**
Added `model.copy()` to allow deep copy of model instance so each thread would get it's own instance.