### PR TITLE
Release 0.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,30 +3,31 @@
 ## 0.5.2
 
 Bug fixes:
-- Fixed local scoring with multipicklist features #243
-- Fixed error messages in `DataCutter` and `DataBalancer` #256
-- Fixed bug in in model selector fit method #251
-- Fixed some Transmogrifier defaults to be modifiable / exposed #232
-- Fixed bug in `OpXGBoostClassificationModel` #229
-- Minor fixes / cleanup on notebooks, Helloworld examples, and developer guide #226, #230, #240, #259
+Bug fixes:
+- Fixed local scoring with multipicklist features [#243](https://github.com/salesforce/TransmogrifAI/pull/243)
+- Fixed error messages in `DataCutter` and `DataBalancer` [#256](https://github.com/salesforce/TransmogrifAI/pull/256)
+- Fixed bug in in model selector fit method [#251](https://github.com/salesforce/TransmogrifAI/pull/251)
+- Fixed some Transmogrifier defaults to be modifiable / exposed [#232](https://github.com/salesforce/TransmogrifAI/pull/232)
+- Fixed bug in `OpXGBoostClassificationModel` [#229](https://github.com/salesforce/TransmogrifAI/pull/229)
+- Minor fixes / cleanup on notebooks, Helloworld examples, and developer guide [#226](https://github.com/salesforce/TransmogrifAI/pull/226), [#230](https://github.com/salesforce/TransmogrifAI/pull/230), [#240](https://github.com/salesforce/TransmogrifAI/pull/240), [#259](https://github.com/salesforce/TransmogrifAI/pull/259)
 
 New features / updates:
-- Added transformer classes for common math operations #255, #257
-- Added string transformers for substring search and valid email #265
-- Added scaler and descaler transformers #223
-- Added Raw Feature Filter results e.g., metrics, exclusion reasons to serialization and to `ModelInsights` #237, #252, #258, #276
-- Changed OpBinScoreEvaluator to allow for lift analysis #233
-- Added random param builder for random hyperparameter search in model selectors #238
-- Added possibility to return top K positives and top K negatives improvement for LOCO #264
-- Added a max cardinality percentage that can be set for pivot #241
-- Added minimum rows for scoring set in RawFeatureFilter #250
-- Allowed copying model instances across multiple threads #270
-- Added stub to allow loading models without workflow #269, #272
-- Made decision tree numeric bucketizer tests less flaky #225
-- Added Jupyter notebooks for samples #231
+- Added transformer classes for common math operations [#255](https://github.com/salesforce/TransmogrifAI/pull/255), [#257](https://github.com/salesforce/TransmogrifAI/pull/257)
+- Added string transformers for substring search and valid email [#265](https://github.com/salesforce/TransmogrifAI/pull/265)
+- Added scaler and descaler transformers [#223](https://github.com/salesforce/TransmogrifAI/pull/223)
+- Added Raw Feature Filter results e.g., metrics, exclusion reasons to serialization and to `ModelInsights` [#237](https://github.com/salesforce/TransmogrifAI/pull/237), [#252](https://github.com/salesforce/TransmogrifAI/pull/252), [#258](https://github.com/salesforce/TransmogrifAI/pull/258), [#276](https://github.com/salesforce/TransmogrifAI/pull/276)
+- Changed OpBinScoreEvaluator to allow for lift analysis [#233](https://github.com/salesforce/TransmogrifAI/pull/233)
+- Added random param builder for random hyperparameter search in model selectors [#238](https://github.com/salesforce/TransmogrifAI/pull/238)
+- Added possibility to return top K positives and top K negatives improvement for LOCO [#264](https://github.com/salesforce/TransmogrifAI/pull/264)
+- Added a max cardinality percentage that can be set for pivot [#241](https://github.com/salesforce/TransmogrifAI/pull/241)
+- Added minimum rows for scoring set in RawFeatureFilter [#250](https://github.com/salesforce/TransmogrifAI/pull/250)
+- Allowed copying model instances across multiple threads [#270](https://github.com/salesforce/TransmogrifAI/pull/270)
+- Added stub to allow loading models without workflow [#269](https://github.com/salesforce/TransmogrifAI/pull/269), [#272](https://github.com/salesforce/TransmogrifAI/pull/272)
+- Made decision tree numeric bucketizer tests less flaky [#225](https://github.com/salesforce/TransmogrifAI/pull/225)
+- Added Jupyter notebooks for samples [#231](https://github.com/salesforce/TransmogrifAI/pull/231)
 
 Dependency updates:
-- Switched to MLeap runtime from Aardpfark for local scoring #249, #261
+- Switched to MLeap runtime from Aardpfark for local scoring [#249](https://github.com/salesforce/TransmogrifAI/pull/249), [#261](https://github.com/salesforce/TransmogrifAI/pull/261)
 
 ## 0.5.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,6 @@
 ## 0.5.2
 
 Bug fixes:
-Bug fixes:
 - Fixed local scoring with multipicklist features [#243](https://github.com/salesforce/TransmogrifAI/pull/243)
 - Fixed error messages in `DataCutter` and `DataBalancer` [#256](https://github.com/salesforce/TransmogrifAI/pull/256)
 - Fixed bug in in model selector fit method [#251](https://github.com/salesforce/TransmogrifAI/pull/251)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ New features / updates:
 - Added Jupyter notebooks for samples #231
 
 Dependency updates:
-- Switched to MLeap runtime from Aardpfark #249, #261
+- Switched to MLeap runtime from Aardpfark for local scoring #249, #261
 
 ## 0.5.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Changelog
 
+## 0.5.2
+
+Bug fixes:
+- Fixed local scoring with multipicklist features #243
+- Fixed error messages in `DataCutter` and `DataBalancer` #256
+- Fixed bug in in model selector fit method #251
+- Fixed some Transmogrifier defaults to be modifiable / exposed #232
+- Fixed bug in `OpXGBoostClassificationModel` #229
+- Minor fixes / cleanup on notebooks, Helloworld examples, and developer guide #226, #230, #240, #259
+
+New features / updates:
+- Added transformer classes for common math operations #255, #257
+- Added string transformers for substring search and valid email #265
+- Added scaler and descaler transformers #223
+- Added Raw Feature Filter results e.g., metrics, exclusion reasons to serialization and to `ModelInsights` #237, #252, #258, #276
+- Changed OpBinScoreEvaluator to allow for lift analysis #233
+- Added random param builder for random hyperparameter search in model selectors #238
+- Added possibility to return top K positives and top K negatives improvement for LOCO #264
+- Added a max cardinality percentage that can be set for pivot #241
+- Added minimum rows for scoring set in RawFeatureFilter #250
+- Allowed copying model instances across multiple threads #270
+- Added stub to allow loading models without workflow #269, #272
+- Made decision tree numeric bucketizer tests less flaky #225
+- Added Jupyter notebooks for samples #231
+
+Dependency updates:
+- Switched to MLeap runtime from Aardpfark #249, #261
+
 ## 0.5.1
 
 Bug fixes:

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
-version=0.6.0-SNAPSHOT
+version=0.5.2
 group=com.salesforce.transmogrifai
 org.gradle.caching=true

--- a/helloworld/README.md
+++ b/helloworld/README.md
@@ -59,7 +59,7 @@ First, build project with `./gradlew shadowJar`.
 #### Train
 ```shell
 $SPARK_HOME/bin/spark-submit --class com.salesforce.hw.titanic.OpTitanic \
-  build/libs/transmogrifai-helloworld-0.0.1-all.jar \
+  build/libs/transmogrifai-helloworld-0.0.1.jar \
   --run-type train \
   --model-location /tmp/titanic-model \
   --read-location Passenger=`pwd`/src/main/resources/TitanicDataset/TitanicPassengersTrainData.csv
@@ -67,7 +67,7 @@ $SPARK_HOME/bin/spark-submit --class com.salesforce.hw.titanic.OpTitanic \
 #### Score
 ```shell
 $SPARK_HOME/bin/spark-submit --class com.salesforce.hw.titanic.OpTitanic \
-  build/libs/transmogrifai-helloworld-0.0.1-all.jar \
+  build/libs/transmogrifai-helloworld-0.0.1.jar \
   --run-type score \
   --model-location /tmp/titanic-model \
   --read-location Passenger=`pwd`/src/main/resources/TitanicDataset/TitanicPassengersTrainData.csv \
@@ -76,7 +76,7 @@ $SPARK_HOME/bin/spark-submit --class com.salesforce.hw.titanic.OpTitanic \
 #### Evaluate
 ```shell
 $SPARK_HOME/bin/spark-submit --class com.salesforce.hw.titanic.OpTitanic \
-  build/libs/transmogrifai-helloworld-0.0.1-all.jar \
+  build/libs/transmogrifai-helloworld-0.0.1.jar \
   --run-type evaluate \
   --model-location /tmp/titanic-model \
   --read-location Passenger=`pwd`/src/main/resources/TitanicDataset/TitanicPassengersTrainData.csv \


### PR DESCRIPTION
Bug fixes:
- Fixed local scoring with multipicklist features [#243](https://github.com/salesforce/TransmogrifAI/pull/243)
- Fixed error messages in `DataCutter` and `DataBalancer` [#256](https://github.com/salesforce/TransmogrifAI/pull/256)
- Fixed bug in in model selector fit method [#251](https://github.com/salesforce/TransmogrifAI/pull/251)
- Fixed some Transmogrifier defaults to be modifiable / exposed [#232](https://github.com/salesforce/TransmogrifAI/pull/232)
- Fixed bug in `OpXGBoostClassificationModel` [#229](https://github.com/salesforce/TransmogrifAI/pull/229)
- Minor fixes / cleanup on notebooks, Helloworld examples, and developer guide [#226](https://github.com/salesforce/TransmogrifAI/pull/226), [#230](https://github.com/salesforce/TransmogrifAI/pull/230), [#240](https://github.com/salesforce/TransmogrifAI/pull/240), [#259](https://github.com/salesforce/TransmogrifAI/pull/259)

New features / updates:
- Added transformer classes for common math operations [#255](https://github.com/salesforce/TransmogrifAI/pull/255), [#257](https://github.com/salesforce/TransmogrifAI/pull/257)
- Added string transformers for substring search and valid email [#265](https://github.com/salesforce/TransmogrifAI/pull/265)
- Added scaler and descaler transformers [#223](https://github.com/salesforce/TransmogrifAI/pull/223)
- Added Raw Feature Filter results e.g., metrics, exclusion reasons to serialization and to `ModelInsights` [#237](https://github.com/salesforce/TransmogrifAI/pull/237), [#252](https://github.com/salesforce/TransmogrifAI/pull/252), [#258](https://github.com/salesforce/TransmogrifAI/pull/258), [#276](https://github.com/salesforce/TransmogrifAI/pull/276)
- Changed OpBinScoreEvaluator to allow for lift analysis [#233](https://github.com/salesforce/TransmogrifAI/pull/233)
- Added random param builder for random hyperparameter search in model selectors [#238](https://github.com/salesforce/TransmogrifAI/pull/238)
- Added possibility to return top K positives and top K negatives improvement for LOCO [#264](https://github.com/salesforce/TransmogrifAI/pull/264)
- Added a max cardinality percentage that can be set for pivot [#241](https://github.com/salesforce/TransmogrifAI/pull/241)
- Added minimum rows for scoring set in RawFeatureFilter [#250](https://github.com/salesforce/TransmogrifAI/pull/250)
- Allowed copying model instances across multiple threads [#270](https://github.com/salesforce/TransmogrifAI/pull/270)
- Added stub to allow loading models without workflow [#269](https://github.com/salesforce/TransmogrifAI/pull/269), [#272](https://github.com/salesforce/TransmogrifAI/pull/272)
- Made decision tree numeric bucketizer tests less flaky [#225](https://github.com/salesforce/TransmogrifAI/pull/225)
- Added Jupyter notebooks for samples [#231](https://github.com/salesforce/TransmogrifAI/pull/231)

Dependency updates:
- Switched to MLeap runtime from Aardpfark for local scoring [#249](https://github.com/salesforce/TransmogrifAI/pull/249), [#261](https://github.com/salesforce/TransmogrifAI/pull/261)
