### PR TITLE
Skip serializing estimators + fix test + added empty data transform test

### DIFF
--- a/core/src/test/scala/com/salesforce/op/ModelInsightsTest.scala
+++ b/core/src/test/scala/com/salesforce/op/ModelInsightsTest.scala
@@ -404,7 +404,7 @@ class ModelInsightsTest extends FlatSpec with PassengerSparkFixtureTest with Dou
 
         def getRawFeatureFilterConfig(modelInsights: ModelInsights): Map[String, String] = {
           modelInsights.stageInfo(RawFeatureFilter.stageName) match {
-            case configInfo: Map[String, Map[String, String]] =>
+            case configInfo: Map[String, Map[String, String]]@unchecked =>
               configInfo.getOrElse("params", Map.empty[String, String])
             case _ => Map.empty[String, String]
           }

--- a/core/src/test/scala/com/salesforce/op/OpWorkflowModelReaderWriterTest.scala
+++ b/core/src/test/scala/com/salesforce/op/OpWorkflowModelReaderWriterTest.scala
@@ -33,14 +33,16 @@ package com.salesforce.op
 import java.io.File
 
 import com.salesforce.op.OpWorkflowModelReadWriteShared.FieldNames._
-import com.salesforce.op.features.OPFeature
-import com.salesforce.op.features.types.{Real, RealNN}
+import com.salesforce.op.features.types.{OPVector, Real}
+import com.salesforce.op.features.{FeatureBuilder, FeatureSparkTypes, OPFeature}
 import com.salesforce.op.filters._
 import com.salesforce.op.readers.{AggregateAvroReader, DataReaders}
 import com.salesforce.op.stages.OPStage
-import com.salesforce.op.stages.sparkwrappers.generic.SwUnaryEstimator
+import com.salesforce.op.stages.sparkwrappers.specific.OpEstimatorWrapper
 import com.salesforce.op.test.{Passenger, PassengerSparkFixtureTest}
 import org.apache.spark.ml.feature.{StandardScaler, StandardScalerModel}
+import org.apache.spark.ml.linalg.Vectors
+import org.apache.spark.sql.Row
 import org.joda.time.DateTime
 import org.json4s.jackson.JsonMethods._
 import org.json4s.{DefaultFormats, Formats, JArray, JValue}
@@ -48,6 +50,8 @@ import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 import org.scalatest.{BeforeAndAfterEach, FlatSpec}
 import org.slf4j.LoggerFactory
+
+import scala.collection.JavaConverters._
 
 
 @RunWith(classOf[JUnitRunner])
@@ -141,14 +145,13 @@ class OpWorkflowModelReaderWriterTest
   }
 
   trait SwSingleStageFlow {
+    val vec = FeatureBuilder.OPVector[Passenger].extract(_ => OPVector.empty).asPredictor
     val scaler = new StandardScaler().setWithStd(false).setWithMean(false)
-    val swEstimator = new SwUnaryEstimator[RealNN, RealNN, StandardScalerModel, StandardScaler](
-      inputParamName = "foo",
-      outputParamName = "foo2",
-      operationName = "foo3",
-      sparkMlStageIn = Some(scaler)
-    )
-    val scaled = height.transformWith(swEstimator)
+    val schema = FeatureSparkTypes.toStructType(vec)
+    val data = spark.createDataFrame(List(Row(Vectors.dense(1.0))).asJava, schema)
+    val swEstimatorModel = new OpEstimatorWrapper[OPVector, OPVector, StandardScaler, StandardScalerModel](scaler)
+      .setInput(vec).fit(data)
+    val scaled = vec.transformWith(swEstimatorModel)
     val wf = new OpWorkflow()
       .setParameters(workflowParams)
       .setReader(dummyReader)

--- a/core/src/test/scala/com/salesforce/op/stages/OpCalibratorReaderWriterTest.scala
+++ b/core/src/test/scala/com/salesforce/op/stages/OpCalibratorReaderWriterTest.scala
@@ -40,7 +40,7 @@ import org.scalatest.junit.JUnitRunner
 class OpCalibratorReaderWriterTest extends OpPipelineStageReaderWriterTest {
   private val calibrator = new PercentileCalibrator().setInput(height)
 
-  lazy val stage: OpPipelineStageBase = calibrator.fit(passengersDataSet)
+  lazy val stage = calibrator.fit(passengersDataSet)
 
   val expected = Array(99.0.toReal, 25.0.toReal, 25.0.toReal, 25.0.toReal, 74.0.toReal, 50.0.toReal)
 }

--- a/core/src/test/scala/com/salesforce/op/stages/OpMinMaxEstimatorReaderWriterTest.scala
+++ b/core/src/test/scala/com/salesforce/op/stages/OpMinMaxEstimatorReaderWriterTest.scala
@@ -42,7 +42,7 @@ import org.scalatest.junit.JUnitRunner
 class OpMinMaxEstimatorReaderWriterTest extends OpPipelineStageReaderWriterTest {
   private val minMax = new MinMaxNormEstimator().setInput(weight).setMetadata(meta)
 
-  val stage: OpPipelineStageBase = minMax.fit(passengersDataSet)
+  lazy val stage = minMax.fit(passengersDataSet)
 
   val expected =
     Array(1.0.toReal, 0.0.toReal, Real.empty, 0.10476190476190476.toReal, 0.2761904761904762.toReal, 0.0.toReal)

--- a/core/src/test/scala/com/salesforce/op/stages/OpPipelineStageReaderWriterTest.scala
+++ b/core/src/test/scala/com/salesforce/op/stages/OpPipelineStageReaderWriterTest.scala
@@ -51,7 +51,7 @@ private[stages] abstract class OpPipelineStageReaderWriterTest
 
   val meta = new MetadataBuilder().putString("foo", "bar").build()
 
-  def stage: OpPipelineStageBase
+  def stage: OpPipelineStageBase with Transformer
   val expected: Array[Real]
   val hasOutputName = true
 

--- a/core/src/test/scala/com/salesforce/op/stages/OpTransformerReaderWriterTest.scala
+++ b/core/src/test/scala/com/salesforce/op/stages/OpTransformerReaderWriterTest.scala
@@ -42,7 +42,7 @@ class OpTransformerReaderWriterTest extends OpPipelineStageReaderWriterTest {
 
   override val hasOutputName = false
 
-  val stage: OpPipelineStageBase =
+  lazy val stage =
     new UnaryLambdaTransformer[Real, Real](
       operationName = "test",
       transformFn = _.v.map(_ * 0.1234).toReal,

--- a/features/src/main/scala/com/salesforce/op/stages/OpPipelineStageWriter.scala
+++ b/features/src/main/scala/com/salesforce/op/stages/OpPipelineStageWriter.scala
@@ -31,12 +31,12 @@
 package com.salesforce.op.stages
 
 import com.salesforce.op.features.types.FeatureType
+import com.salesforce.op.stages.OpPipelineStageReadWriteShared._
+import com.salesforce.op.stages.sparkwrappers.generic.SparkWrapperParams
 import com.salesforce.op.utils.reflection.ReflectionUtils
 import org.apache.hadoop.fs.Path
-import OpPipelineStageReadWriteShared._
-import com.salesforce.op.stages.sparkwrappers.generic.SparkWrapperParams
 import org.apache.spark.ml.util.MLWriter
-import org.apache.spark.ml.{Model, PipelineStage, SparkDefaultParamsReadWrite}
+import org.apache.spark.ml.{Estimator, Model, PipelineStage, SparkDefaultParamsReadWrite}
 import org.json4s.Extraction
 import org.json4s.JsonAST.{JObject, JValue}
 import org.json4s.jackson.JsonMethods.{compact, parse, render}
@@ -79,8 +79,9 @@ final class OpPipelineStageWriter(val stage: OpPipelineStageBase) extends MLWrit
     // Set save path for all Spark wrapped stages of type [[SparkWrapperParams]]
     // so they can save
     stage match {
+      case _: Estimator[_] => return Map.empty[String, Any] // no need to serialize estimators
       case s: SparkWrapperParams[_] => s.setStageSavePath(path)
-      case s => s
+      case _ =>
     }
     // We produce stage metadata for all the Spark params
     val metadataJson = SparkDefaultParamsReadWrite.getMetadataToSave(stage)

--- a/features/src/main/scala/com/salesforce/op/stages/OpPipelineStageWriter.scala
+++ b/features/src/main/scala/com/salesforce/op/stages/OpPipelineStageWriter.scala
@@ -80,7 +80,7 @@ final class OpPipelineStageWriter(val stage: OpPipelineStageBase) extends MLWrit
       case _: Estimator[_] => return Map.empty[String, Any] // no need to serialize estimators
       case s: SparkWrapperParams[_] =>
         // Set save path for all Spark wrapped stages of type [[SparkWrapperParams]] so they can save
-      s.setStageSavePath(path)
+        s.setStageSavePath(path)
       case _ =>
     }
     // We produce stage metadata for all the Spark params

--- a/features/src/main/scala/com/salesforce/op/stages/OpPipelineStageWriter.scala
+++ b/features/src/main/scala/com/salesforce/op/stages/OpPipelineStageWriter.scala
@@ -76,11 +76,11 @@ final class OpPipelineStageWriter(val stage: OpPipelineStageBase) extends MLWrit
    * @return stage metadata map
    */
   def writeToMap(path: String): Map[String, Any] = {
-    // Set save path for all Spark wrapped stages of type [[SparkWrapperParams]]
-    // so they can save
     stage match {
       case _: Estimator[_] => return Map.empty[String, Any] // no need to serialize estimators
-      case s: SparkWrapperParams[_] => s.setStageSavePath(path)
+      case s: SparkWrapperParams[_] =>
+        // Set save path for all Spark wrapped stages of type [[SparkWrapperParams]] so they can save
+      s.setStageSavePath(path)
       case _ =>
     }
     // We produce stage metadata for all the Spark params

--- a/features/src/main/scala/com/salesforce/op/test/OpPipelineStageSpec.scala
+++ b/features/src/main/scala/com/salesforce/op/test/OpPipelineStageSpec.scala
@@ -87,27 +87,6 @@ StageType <: OpPipelineStage[O] : ClassTag]
       case _ =>
     }
   }
-  it should "be json writable/readable" in {
-    val loaded = writeAndRead(stage)
-    assert(loaded, stage)
-  }
-
-  /**
-   * A helper function to write and read stage into savePath
-   *
-   * @param stage stage instance to write and then read
-   * @param savePath Spark stage save path
-   * @return read stage
-   */
-  protected def writeAndRead(stage: StageType, savePath: String = stageSavePath): OpPipelineStageBase = {
-    val json = new OpPipelineStageWriter(stage).overwrite().writeToJsonString(savePath)
-    new OpPipelineStageReader(stage).loadFromJsonString(json, savePath)
-  }
-
-  /**
-   * Spark stage save path
-   */
-  protected def stageSavePath: String = s"$tempDir/${specName.filter(_.isLetterOrDigit)}-${System.currentTimeMillis()}"
 
 }
 

--- a/features/src/main/scala/com/salesforce/op/test/OpTransformerSpec.scala
+++ b/features/src/main/scala/com/salesforce/op/test/OpTransformerSpec.scala
@@ -134,8 +134,7 @@ TransformerType <: OpPipelineStage[O] with Transformer with OpTransformer : Clas
    */
   protected def writeAndRead(stage: TransformerType, savePath: String = stageSavePath): OpPipelineStageBase = {
     val json = new OpPipelineStageWriter(stage).overwrite().writeToJsonString(savePath)
-    val features = stage.getInputFeatures().flatMap(_.allFeatures)
-    new OpPipelineStageReader(features).loadFromJsonString(json, savePath)
+    new OpPipelineStageReader(stage).loadFromJsonString(json, savePath)
   }
 
   /**


### PR DESCRIPTION
**Related issues**
Serializing estimator and testing it is unnecessary 

**Describe the proposed solution**
1. If attempted to serialize estimator -> return an empty map
2. Remove the check in base spec and other tests
3. Bonus: added transformer test for empty data

