### PR TITLE
Added base spec for testing Spark wrapping transformers

### DIFF
--- a/core/src/test/scala/com/salesforce/op/stages/impl/feature/OpIndexToStringTest.scala
+++ b/core/src/test/scala/com/salesforce/op/stages/impl/feature/OpIndexToStringTest.scala
@@ -31,23 +31,24 @@
 package com.salesforce.op.stages.impl.feature
 
 import com.salesforce.op.features.types._
-import com.salesforce.op.test.{TestFeatureBuilder, TestSparkContext}
+import com.salesforce.op.test.{SwTransformerSpec, TestFeatureBuilder}
 import com.salesforce.op.utils.spark.RichDataset._
+import org.apache.spark.ml.feature.IndexToString
 import org.junit.runner.RunWith
-import org.scalatest.FlatSpec
 import org.scalatest.junit.JUnitRunner
 
+
 @RunWith(classOf[JUnitRunner])
-class OpIndexToStringTest extends FlatSpec with TestSparkContext {
+class OpIndexToStringTest extends SwTransformerSpec[Text, IndexToString, OpIndexToString] {
 
   val (inputData, indF) = TestFeatureBuilder(Seq(0.0, 2.0, 1.0, 0.0, 0.0, 1.0).map(_.toRealNN))
   val labels = Array("a", "c", "b")
 
+  val transformer = new OpIndexToString().setInput(indF).setLabels(labels)
+
   val expectedResult: Seq[Text] = Array("a", "b", "c", "a", "a", "c").map(_.toText)
 
-  val transformer: OpIndexToString = new OpIndexToString().setInput(indF).setLabels(labels)
-
-  Spec[OpIndexToString] should "correctly deindex a numeric column" in {
+  it should "correctly deindex a numeric column" in {
     val strs = transformer.transform(inputData).collect(transformer.getOutput())
     strs shouldBe expectedResult
   }
@@ -58,7 +59,7 @@ class OpIndexToStringTest extends FlatSpec with TestSparkContext {
     strs shouldBe expectedResult
   }
 
-  it should "getLabels" in {
+  it should "get labels" in {
     transformer.getLabels shouldBe labels
   }
 }

--- a/core/src/test/scala/com/salesforce/op/stages/impl/feature/OpStringIndexerNoFilterTest.scala
+++ b/core/src/test/scala/com/salesforce/op/stages/impl/feature/OpStringIndexerNoFilterTest.scala
@@ -43,8 +43,8 @@ import org.scalatest.junit.JUnitRunner
 
 
 @RunWith(classOf[JUnitRunner])
-class OpStringIndexerNoFilterTest extends
-  OpEstimatorSpec[RealNN, UnaryModel[Text, RealNN], OpStringIndexerNoFilter[Text]] {
+class OpStringIndexerNoFilterTest
+  extends OpEstimatorSpec[RealNN, UnaryModel[Text, RealNN], OpStringIndexerNoFilter[Text]] {
 
   val txtData = Seq("a", "b", "c", "a", "a", "c").map(_.toText)
   val (inputData, txtF) = TestFeatureBuilder(txtData)

--- a/core/src/test/scala/com/salesforce/op/stages/impl/feature/OpStringIndexerTest.scala
+++ b/core/src/test/scala/com/salesforce/op/stages/impl/feature/OpStringIndexerTest.scala
@@ -68,7 +68,7 @@ class OpStringIndexerTest extends FlatSpec with TestSparkContext {
     indices shouldBe expected
   }
 
-  it should "correctly deinxed a numeric column" in {
+  it should "correctly deindex a numeric column" in {
     val indexedStage = new OpStringIndexer[Text]().setInput(txtF)
     val indexed = indexedStage.getOutput()
     val indices = indexedStage.fit(ds).transform(ds)

--- a/features/src/main/scala/com/salesforce/op/stages/sparkwrappers/generic/SparkWrapperParams.scala
+++ b/features/src/main/scala/com/salesforce/op/stages/sparkwrappers/generic/SparkWrapperParams.scala
@@ -38,7 +38,7 @@ import org.apache.spark.ml.param.{Params, StringArrayParam}
 /**
  * Object to allow generic string based access to parameters of wrapped spark class
  *
- * @tparam S type of spark object to wrap
+ * @tparam S type of Spark stage to wrap
  */
 trait SparkWrapperParams[S <: PipelineStage with Params] extends Params {
   self: PipelineStage =>
@@ -46,17 +46,18 @@ trait SparkWrapperParams[S <: PipelineStage with Params] extends Params {
   final val sparkInputColParamNames = new StringArrayParam(
     parent = this,
     name = "sparkInputColParamNames",
-    doc = "names of parameters that control input columns for spark stage"
+    doc = "names of parameters that control input columns for Spark stage"
   )
 
   final val sparkOutputColParamNames = new StringArrayParam(
     parent = this,
     name = "sparkOutputColParamNames",
-    doc = "names of parameters that control output columns for spark stage"
+    doc = "names of parameters that control output columns for Spark stage"
   )
 
   final val sparkMlStage = new SparkStageParam[S](
-    parent = this, name = "sparkMlStage", doc = "the spark stage that is being wrapped for TransmogrifAI"
+    parent = this, name = SparkWrapperParams.SparkStageParamName,
+    doc = "the spark stage that is being wrapped for TransmogrifAI"
   )
 
   setDefault(sparkMlStage, None)
@@ -87,6 +88,16 @@ trait SparkWrapperParams[S <: PipelineStage with Params] extends Params {
    * Gets a save path for wrapped spark stage
    */
   def getStageSavePath(): Option[String] = sparkMlStage.savePath
+
+  /**
+   * Gets names of parameters that control input columns for Spark stage
+   */
+  def getInputColParamNames(): Array[String] = $(sparkInputColParamNames)
+
+  /**
+   * Gets names of parameters that control output columns for Spark stage
+   */
+  def getOutputColParamNames(): Array[String] = $(sparkOutputColParamNames)
 }
 
 object SparkWrapperParams {

--- a/features/src/main/scala/com/salesforce/op/test/OpTransformerSpec.scala
+++ b/features/src/main/scala/com/salesforce/op/test/OpTransformerSpec.scala
@@ -94,7 +94,7 @@ private[test] trait TransformerSpecCommon[O <: FeatureType, TransformerType <: O
   self: OpPipelineStageSpec[O, TransformerType] =>
 
   /**
-   * Transfotmer instance to be tested
+   * Transformer instance to be tested
    */
   val transformer: TransformerType
 

--- a/features/src/main/scala/com/salesforce/op/test/OpTransformerSpec.scala
+++ b/features/src/main/scala/com/salesforce/op/test/OpTransformerSpec.scala
@@ -49,54 +49,12 @@ import scala.reflect.runtime.universe._
  * @tparam O               output feature type
  * @tparam TransformerType type of the transformer being tested
  */
-abstract class OpTransformerSpec[O <: FeatureType : WeakTypeTag : ClassTag,
-TransformerType <: OpPipelineStage[O] with Transformer with OpTransformer : ClassTag]
-  extends OpPipelineStageSpec[O, TransformerType] {
+abstract class OpTransformerSpec[O <: FeatureType,
+TransformerType <: OpPipelineStage[O] with Transformer with OpTransformer]
+(
+  implicit val cto: ClassTag[O], val wto: WeakTypeTag[O], val ttc: ClassTag[TransformerType]
+) extends OpPipelineStageSpec[O, TransformerType] with TransformerSpecCommon[O, TransformerType] {
 
-  /**
-   * [[OpTransformer]] instance to be tested
-   */
-  val transformer: TransformerType
-
-  /**
-   * Input Dataset to transform
-   */
-  val inputData: Dataset[_]
-
-  /**
-   * Expected result of the transformer applied on the Input Dataset
-   */
-  val expectedResult: Seq[O]
-
-  final override lazy val stage = transformer
-  protected val convert = FeatureTypeSparkConverter[O]()
-
-  it should "be json writable/readable" in {
-    val loaded = writeAndRead(stage)
-    assert(loaded, stage)
-  }
-  it should "transform schema" in {
-    val transformedSchema = transformer.transformSchema(inputData.schema)
-    val output = transformer.getOutput()
-    val validationResults =
-      FeatureSparkTypes.validateSchema(transformedSchema, transformer.getInputFeatures() :+ output)
-    if (validationResults.nonEmpty) {
-      fail("Dataset schema is invalid. Errors: " + validationResults.mkString("'", "','", "'"))
-    }
-  }
-  it should "transform data" in {
-    val transformed = transformer.transform(inputData)
-    val output = transformer.getOutput()
-    val res: Seq[O] = transformed.collect(output)(convert, classTag[O]).toSeq
-    res shouldEqual expectedResult
-  }
-  it should "transform empty data" in {
-    val empty = spark.emptyDataset(RowEncoder(inputData.schema))
-    val transformed = transformer.transform(empty)
-    val output = transformer.getOutput()
-    val res: Seq[O] = transformed.collect(output)(convert, classTag[O]).toSeq
-    res.size shouldBe 0
-  }
   it should "transform rows" in {
     val rows = inputData.toDF().collect()
     val res: Seq[O] = rows.view.map(row => transformer.transformRow(row)).map(convert.fromSpark)
@@ -124,11 +82,69 @@ TransformerType <: OpPipelineStage[O] with Transformer with OpTransformer : Clas
 
   // TODO: test metadata on stages
 
+}
+
+/**
+ * Common test transformer functionality for [[OpTransformerSpec]] and [[SwTransformerSpec]] specs
+ *
+ * @tparam O               output feature type
+ * @tparam TransformerType type of the transformer being tested
+ */
+private[test] trait TransformerSpecCommon[O <: FeatureType, TransformerType <: OpPipelineStage[O] with Transformer] {
+  self: OpPipelineStageSpec[O, TransformerType] =>
+
+  /**
+   * Transfotmer instance to be tested
+   */
+  val transformer: TransformerType
+
+  /**
+   * Input Dataset to transform
+   */
+  val inputData: Dataset[_]
+
+  /**
+   * Expected result of the transformer applied on the Input Dataset
+   */
+  val expectedResult: Seq[O]
+
+  implicit def cto: ClassTag[O]
+  implicit def wto: WeakTypeTag[O]
+  protected lazy val convert: FeatureTypeSparkConverter[O] = FeatureTypeSparkConverter[O]()
+
+  final override lazy val stage = transformer
+
+  it should "be json writable/readable" in {
+    val loaded = writeAndRead(transformer)
+    assert(loaded, transformer)
+  }
+  it should "transform schema" in {
+    val transformedSchema = transformer.transformSchema(inputData.schema)
+    val output = transformer.getOutput()
+    val validationResults =
+      FeatureSparkTypes.validateSchema(transformedSchema, transformer.getInputFeatures() :+ output)
+    if (validationResults.nonEmpty) {
+      fail("Dataset schema is invalid. Errors: " + validationResults.mkString("'", "','", "'"))
+    }
+  }
+  it should "transform data" in {
+    val transformed = transformer.transform(inputData)
+    val output = transformer.getOutput()
+    val res: Seq[O] = transformed.collect(output)(convert, classTag[O]).toSeq
+    res shouldEqual expectedResult
+  }
+  it should "transform empty data" in {
+    val empty = spark.emptyDataset(RowEncoder(inputData.schema))
+    val transformed = transformer.transform(empty)
+    val output = transformer.getOutput()
+    val res: Seq[O] = transformed.collect(output)(convert, classTag[O]).toSeq
+    res.size shouldBe 0
+  }
 
   /**
    * A helper function to write and read stage into savePath
    *
-   * @param stage stage instance to write and then read
+   * @param stage    stage instance to write and then read
    * @param savePath Spark stage save path
    * @return read stage
    */

--- a/features/src/main/scala/com/salesforce/op/test/SwTransformerSpec.scala
+++ b/features/src/main/scala/com/salesforce/op/test/SwTransformerSpec.scala
@@ -72,10 +72,10 @@ TransformerType <: OpPipelineStage[O] with Transformer with Params with SparkWra
         }
     }
   }
-  it should "have inputs column names set" in {
+  it should "have input column names set" in {
     transformer.getInputColParamNames() should not be empty
   }
-  it should "have output column names set" in {
+  it should "have output column name set" in {
     transformer.getOutputColParamNames() should not be empty
   }
   it should "have inputs set on Spark stage" in {

--- a/features/src/main/scala/com/salesforce/op/test/SwTransformerSpec.scala
+++ b/features/src/main/scala/com/salesforce/op/test/SwTransformerSpec.scala
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2017, Salesforce.com, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.salesforce.op.test
+
+import com.salesforce.op.features.types.FeatureType
+import com.salesforce.op.stages.OpPipelineStage
+import com.salesforce.op.stages.sparkwrappers.generic.SparkWrapperParams
+import org.apache.spark.ml.Transformer
+import org.apache.spark.ml.param.Params
+
+import scala.reflect.ClassTag
+import scala.reflect.runtime.universe.WeakTypeTag
+
+/**
+ * Base test class for testing Spark transformer wrapper instances,
+ * e.g [[SwUnaryTransformer]], [[SwBinaryTransformer]] etc.
+ * Includes common tests for schema and data transformations.
+ *
+ * @tparam O                    output feature type
+ * @tparam SparkTransformerType type of Spark transformer
+ * @tparam TransformerType      type of Spark transformer wrapper being tested,
+ *                              e.g. [[SwUnaryTransformer]], [[SwBinaryTransformer]] etc.
+ */
+abstract class SwTransformerSpec[
+O <: FeatureType,
+SparkTransformerType <: Transformer with Params,
+TransformerType <: OpPipelineStage[O] with Transformer with Params with SparkWrapperParams[SparkTransformerType]]
+(
+  implicit val cto: ClassTag[O], val wto: WeakTypeTag[O],
+  val stc: ClassTag[SparkTransformerType], val ttc: ClassTag[TransformerType]
+) extends OpPipelineStageSpec[O, TransformerType] with TransformerSpecCommon[O, TransformerType] {
+
+  /**
+   * The wrapped Spark stage instance
+   */
+  def sparkStage: Option[SparkTransformerType] = transformer.getSparkMlStage()
+
+  it should "have a Spark stage set" in {
+    sparkStage match {
+      case None => fail("Spark stage is not set")
+      case Some(s) =>
+        withClue(s"Spark stage type is '${s.getClass.getName}' (expected '${stc.runtimeClass.getName}'):") {
+          s.isInstanceOf[SparkTransformerType] shouldBe true
+        }
+    }
+  }
+  it should "have inputs column names set" in {
+    transformer.getInputColParamNames() should not be empty
+  }
+  it should "have output column names set" in {
+    transformer.getOutputColParamNames() should not be empty
+  }
+  it should "have inputs set on Spark stage" in {
+    transformer.getInputColParamNames().flatMap(name => sparkStage.flatMap(s => s.get(s.getParam(name)))) shouldBe
+      transformer.getInputFeatures().map(_.name)
+  }
+  it should "have output set on Spark stage" in {
+    transformer.getOutputColParamNames().flatMap(name => sparkStage.flatMap(s => s.get(s.getParam(name)))) shouldBe
+      Array(transformer.getOutputFeatureName)
+  }
+
+}

--- a/features/src/main/scala/com/salesforce/op/test/SwTransformerSpec.scala
+++ b/features/src/main/scala/com/salesforce/op/test/SwTransformerSpec.scala
@@ -49,8 +49,7 @@ import scala.reflect.runtime.universe.WeakTypeTag
  * @tparam TransformerType      type of Spark transformer wrapper being tested,
  *                              e.g. [[SwUnaryTransformer]], [[SwBinaryTransformer]] etc.
  */
-abstract class SwTransformerSpec[
-O <: FeatureType,
+abstract class SwTransformerSpec[O <: FeatureType,
 SparkTransformerType <: Transformer with Params,
 TransformerType <: OpPipelineStage[O] with Transformer with Params with SparkWrapperParams[SparkTransformerType]]
 (


### PR DESCRIPTION
**Related issues**
Spark wrapping transformers were missing a test spec

**Describe the proposed solution**
1. Added `SwTransformerSpec` for testing Spark wrapping transformers
2. Factored out some common functionality between `OpTransformerSpec` and `SwTransformerSpec` into private `TransformerSpecCommon`
3. Updated `OpIndexToStringTest` to use it

