### PR TITLE
Bump shadowjar plugin to 5.0.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ plugins {
     id 'org.scoverage' version '2.5.0'
     id 'net.minecrell.licenser' version '0.4.1'
     id 'com.github.jk1.dependency-license-report' version '0.5.0'
-    id 'com.github.johnrengelman.shadow' version '4.0.4'
+    id 'com.github.johnrengelman.shadow' version '5.0.0'
 }
 
 allprojects {

--- a/helloworld/build.gradle
+++ b/helloworld/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     }
 }
 plugins {
-    id 'com.github.johnrengelman.shadow' version '4.0.4'
+    id 'com.github.johnrengelman.shadow' version '5.0.0'
     id 'com.commercehub.gradle.plugin.avro' version '0.8.0'
     id 'org.scoverage' version '2.5.0'
 }

--- a/templates/simple/build.gradle.template
+++ b/templates/simple/build.gradle.template
@@ -10,7 +10,7 @@ buildscript {
 
 plugins {
     id 'com.commercehub.gradle.plugin.avro' version '0.8.0'
-    id 'com.github.johnrengelman.shadow' version '4.0.4'
+    id 'com.github.johnrengelman.shadow' version '5.0.0'
 }
 
 repositories {


### PR DESCRIPTION
**Related issues**
Shadow jar plugin 4.0.4 does not work well with gradle 5.x

**Describe the proposed solution**
Update to Shadow jar plugin to version 5.0.0

**Describe alternatives you've considered**
NA
