### PR TITLE
Improve WeekOfMonth in date transformers

### DIFF
--- a/core/src/main/scala/com/salesforce/op/stages/impl/feature/DateToUnitCircleTransformer.scala
+++ b/core/src/main/scala/com/salesforce/op/stages/impl/feature/DateToUnitCircleTransformer.scala
@@ -35,7 +35,6 @@ import com.salesforce.op.utils.spark.OpVectorMetadata
 import com.salesforce.op.{FeatureHistory, UID}
 import org.apache.spark.ml.linalg.Vectors
 import org.apache.spark.ml.param.{Param, Params}
-import org.joda.time.{DateTime => JDateTime, DateTimeZone}
 
 import scala.reflect.runtime.universe.TypeTag
 
@@ -115,16 +114,12 @@ private[op] object DateToUnitCircle {
     }.getOrElse(Array(0.0, 0.0))
 
   private def getPeriodWithSize(timestamp: Long, timePeriod: TimePeriod): (Double, Int) = {
-    val dt = new JDateTime(timestamp).withZone(DateTimeZone.UTC)
-    timePeriod match {
-      case TimePeriod.DayOfMonth => (dt.dayOfMonth.get.toDouble - 1, 31)
-      case TimePeriod.DayOfWeek => (dt.dayOfWeek.get.toDouble - 1, 7)
-      case TimePeriod.DayOfYear => (dt.dayOfYear.get.toDouble - 1, 366)
-      case TimePeriod.HourOfDay => (dt.hourOfDay.get.toDouble, 24)
-      case TimePeriod.MonthOfYear => (dt.monthOfYear.get.toDouble - 1, 12)
-      case TimePeriod.WeekOfMonth =>
-        ((dt.weekOfWeekyear.get - dt.withDayOfMonth(1).weekOfWeekyear.get).toDouble, 6)
-      case TimePeriod.WeekOfYear => (dt.weekOfWeekyear.get.toDouble - 1, 53)
+    val tpv = timePeriod.extractTimePeriodVal(timestamp)
+    val period = if (tpv.min == 1) {
+      tpv.value - 1
+    } else {
+      tpv.value
     }
+    (period.toDouble, tpv.max)
   }
 }

--- a/core/src/main/scala/com/salesforce/op/stages/impl/feature/DateToUnitCircleTransformer.scala
+++ b/core/src/main/scala/com/salesforce/op/stages/impl/feature/DateToUnitCircleTransformer.scala
@@ -115,11 +115,7 @@ private[op] object DateToUnitCircle {
 
   private def getPeriodWithSize(timestamp: Long, timePeriod: TimePeriod): (Double, Int) = {
     val tpv = timePeriod.extractTimePeriodVal(timestamp)
-    val period = if (tpv.min == 1) {
-      tpv.value - 1
-    } else {
-      tpv.value
-    }
+    val period = if (tpv.min == 1) tpv.value - 1 else tpv.value
     (period.toDouble, tpv.max)
   }
 }

--- a/core/src/main/scala/com/salesforce/op/stages/impl/feature/TimePeriodListTransformer.scala
+++ b/core/src/main/scala/com/salesforce/op/stages/impl/feature/TimePeriodListTransformer.scala
@@ -53,5 +53,5 @@ class TimePeriodListTransformer[I <: DateList]
 ) extends UnaryTransformer[I, OPVector](operationName = "dateListToTimePeriod", uid = uid) {
 
   override def transformFn: I => OPVector =
-    (i: I) => i.value.map(t => period.extractFromTime(t).toDouble).toOPVector
+    (i: I) => i.value.map(t => period.extractIntFromMillis(t).toDouble).toOPVector
 }

--- a/core/src/main/scala/com/salesforce/op/stages/impl/feature/TimePeriodMapTransformer.scala
+++ b/core/src/main/scala/com/salesforce/op/stages/impl/feature/TimePeriodMapTransformer.scala
@@ -53,5 +53,5 @@ class TimePeriodMapTransformer[I <: DateMap]
 ) extends UnaryTransformer[I, IntegralMap](operationName = "dateMapToTimePeriod", uid = uid) {
 
   override def transformFn: I => IntegralMap =
-    (i: I) => i.value.mapValues(t => period.extractFromTime(t).toLong).toIntegralMap
+    (i: I) => i.value.mapValues(t => period.extractIntFromMillis(t).toLong).toIntegralMap
 }

--- a/core/src/main/scala/com/salesforce/op/stages/impl/feature/TimePeriodTransformer.scala
+++ b/core/src/main/scala/com/salesforce/op/stages/impl/feature/TimePeriodTransformer.scala
@@ -52,5 +52,5 @@ class TimePeriodTransformer[I <: Date]
   implicit override val tti: TypeTag[I]
 ) extends UnaryTransformer[I, Integral](operationName = "dateToTimePeriod", uid = uid){
 
-  override def transformFn: I => Integral = (i: I) => i.value.map(t => period.extractFromTime(t).toLong).toIntegral
+  override def transformFn: I => Integral = (i: I) => i.value.map(t => period.extractIntFromMillis(t).toLong).toIntegral
 }

--- a/core/src/test/scala/com/salesforce/op/stages/impl/feature/DateToUnitCircleTransformerTest.scala
+++ b/core/src/test/scala/com/salesforce/op/stages/impl/feature/DateToUnitCircleTransformerTest.scala
@@ -176,7 +176,7 @@ class DateToUnitCircleTransformerTest extends OpTransformerSpec[OPVector, DateTo
       new JDateTime(2017, 1, 23, 0, 0, 0, 0)
     )
     val actual = transformData(dateTimes, WeekOfYear)
-    val sampleWeeksOfYearMinusOne = Seq(51, 0, 1, 2, 3)
+    val sampleWeeksOfYearMinusOne = Seq(0, 1, 2, 3, 4)
     val expected = indexSeqToUnitCircle(sampleWeeksOfYearMinusOne, 53)
     all(actual.zip(expected).map(g => Vectors.sqdist(g._1.value, g._2.value))) should be < eps
   }

--- a/core/src/test/scala/com/salesforce/op/stages/impl/feature/TimePeriodTransformerTest.scala
+++ b/core/src/test/scala/com/salesforce/op/stages/impl/feature/TimePeriodTransformerTest.scala
@@ -70,7 +70,7 @@ class TimePeriodTransformerTest extends OpTransformerSpec[Integral, TimePeriodTr
         case TimePeriod.DayOfYear => Array(Integral(73), Integral(316), Integral(67), Integral.empty, Integral(120))
         case TimePeriod.HourOfDay => Array(Integral(0), Integral(10), Integral(12), Integral.empty, Integral(13))
         case TimePeriod.MonthOfYear => Array(Integral(3), Integral(11), Integral(3), Integral.empty, Integral(4))
-        case TimePeriod.WeekOfMonth => Array(Integral(2), Integral(1), Integral(1), Integral.empty, Integral(4))
+        case TimePeriod.WeekOfMonth => Array(Integral(3), Integral(2), Integral(2), Integral.empty, Integral(5))
         case TimePeriod.WeekOfYear => Array(Integral(11), Integral(45), Integral(10), Integral.empty, Integral(18))
         case _ => throw new Exception(s"Unexpected TimePeriod encountered, $tp")
       }

--- a/core/src/test/scala/com/salesforce/op/stages/impl/feature/TimePeriodTransformerTest.scala
+++ b/core/src/test/scala/com/salesforce/op/stages/impl/feature/TimePeriodTransformerTest.scala
@@ -41,7 +41,7 @@ import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 
 @RunWith(classOf[JUnitRunner])
-class TimePeriodTransformerTest extends OpTransformerSpec[Integral, TimePeriodTransformer[Date]] {
+class ot extends OpTransformerSpec[Integral, TimePeriodTransformer[Date]] {
 
   val (inputData, f1) = TestFeatureBuilder(Seq[Date](
     new JDateTime(1879, 3, 14, 0, 0, DateTimeUtils.DefaultTimeZone).getMillis.toDate,
@@ -71,7 +71,7 @@ class TimePeriodTransformerTest extends OpTransformerSpec[Integral, TimePeriodTr
         case TimePeriod.HourOfDay => Array(Integral(0), Integral(10), Integral(12), Integral.empty, Integral(13))
         case TimePeriod.MonthOfYear => Array(Integral(3), Integral(11), Integral(3), Integral.empty, Integral(4))
         case TimePeriod.WeekOfMonth => Array(Integral(3), Integral(2), Integral(2), Integral.empty, Integral(5))
-        case TimePeriod.WeekOfYear => Array(Integral(11), Integral(45), Integral(10), Integral.empty, Integral(18))
+        case TimePeriod.WeekOfYear => Array(Integral(11), Integral(46), Integral(11), Integral.empty, Integral(18))
         case _ => throw new Exception(s"Unexpected TimePeriod encountered, $tp")
       }
 

--- a/core/src/test/scala/com/salesforce/op/stages/impl/feature/TimePeriodTransformerTest.scala
+++ b/core/src/test/scala/com/salesforce/op/stages/impl/feature/TimePeriodTransformerTest.scala
@@ -41,7 +41,7 @@ import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 
 @RunWith(classOf[JUnitRunner])
-class ot extends OpTransformerSpec[Integral, TimePeriodTransformer[Date]] {
+class TimePeriodTransformerTest extends OpTransformerSpec[Integral, TimePeriodTransformer[Date]] {
 
   val (inputData, f1) = TestFeatureBuilder(Seq[Date](
     new JDateTime(1879, 3, 14, 0, 0, DateTimeUtils.DefaultTimeZone).getMillis.toDate,

--- a/features/src/main/scala/com/salesforce/op/stages/impl/feature/TimePeriod.scala
+++ b/features/src/main/scala/com/salesforce/op/stages/impl/feature/TimePeriod.scala
@@ -38,13 +38,12 @@ import enumeratum.{Enum, EnumEntry}
 case class TimePeriodVal(value: Int, min: Int, max: Int)
 
 sealed abstract class TimePeriod(extractFn: LocalDateTime => TimePeriodVal) extends EnumEntry with Serializable {
-  def extractTimePeriodVal: Long => TimePeriodVal =
-    ((millis: Long) => Instant
+  def extractTimePeriodVal(millis: Long): TimePeriodVal = extractFn(
+    Instant
       .ofEpochMilli(millis)
       .atZone(ZoneId.of(DateTimeUtils.DefaultTimeZone.toString)).toLocalDateTime)
-      .andThen(extractFn)
 
-  def extractIntFromMillis: Long => Int = extractTimePeriodVal.andThen((x: TimePeriodVal) => x.value)
+  def extractIntFromMillis(millis: Long): Int = extractTimePeriodVal(millis).value
 }
 
 object TimePeriod extends Enum[TimePeriod] {


### PR DESCRIPTION
**Related issues**
Fixes #322

**Describe the proposed solution**
Use an approach from https://stackoverflow.com/questions/3806473/python-week-number-of-the-month. Reuse logic throughout datetime transformers.
