### PR TITLE
Bump Apache Tika to 1.21

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -80,7 +80,7 @@ configure(allProjs) {
         reflectionsVersion = '0.9.11'
         collectionsVersion = '3.2.2'
         optimaizeLangDetectorVersion = '0.0.1'
-        tikaVersion = '1.16'
+        tikaVersion = '1.21'
         sparkTestingBaseVersion = '2.3.1_0.10.0'
         sourceCodeVersion = '0.1.3'
         pegdownVersion = '1.4.2'

--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
         <dependency>
             <groupId>org.apache.tika</groupId>
             <artifactId>tika-core</artifactId>
-            <version>1.16</version>
+            <version>1.21</version>
             <scope>compile</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
**Related issues**
Apache Tika 1.16 has numerous security vulnerabilities.

**Describe the proposed solution**
Bump Apache Tika to 1.21

**Describe alternatives you've considered**
NA
