### PR TITLE
Aggregate spark metrics during run time instead of post processing by default

### DIFF
--- a/utils/src/main/scala/com/salesforce/op/utils/spark/OpSparkListener.scala
+++ b/utils/src/main/scala/com/salesforce/op/utils/spark/OpSparkListener.scala
@@ -92,7 +92,7 @@ class OpSparkListener
     appStartTime = appStartTime,
     appEndTime = appEndTime,
     appDuration = appEndTime - appStartTime,
-    stageMetrics = stageMetrics.toList,
+    stageMetrics = if (collectStageMetrics) stageMetrics.toList else List(cumulativeStageMetrics),
     versionInfo = VersionInfo()
   )
 
@@ -102,7 +102,7 @@ class OpSparkListener
     if (collectStageMetrics) {
       stageMetrics += StageMetrics(si)
     } else {
-
+      cumulativeStageMetrics.plus(StageMetrics(si))
     }
     if (logStageMetrics) {
       log.info("{},STAGE:{},MEMORY_SPILLED_BYTES:{},GC_TIME_MS:{},STAGE_TIME_MS:{}",

--- a/utils/src/main/scala/com/salesforce/op/utils/spark/OpSparkListener.scala
+++ b/utils/src/main/scala/com/salesforce/op/utils/spark/OpSparkListener.scala
@@ -98,11 +98,7 @@ class OpSparkListener
     appStartTime = appStartTime,
     appEndTime = appEndTime,
     appDuration = appEndTime - appStartTime,
-    stageMetrics = if (collectStageMetrics) {
-      stageMetrics.toList
-    } else {
-      List.empty[StageMetrics]
-    },
+    stageMetrics = stageMetrics.toList,
     cumulativeStageMetrics = cumulativeStageMetrics,
     versionInfo = VersionInfo()
   )

--- a/utils/src/main/scala/com/salesforce/op/utils/spark/OpSparkListener.scala
+++ b/utils/src/main/scala/com/salesforce/op/utils/spark/OpSparkListener.scala
@@ -215,6 +215,7 @@ trait BaseStageMetrics {
   def shuffleWriteTime: Long
   def shuffleBytesWritten: Long
   def shuffleRecordsWritten: Long
+  def duration: Option[Long]
 }
 
 /**
@@ -257,7 +258,7 @@ case class StageMetrics private
   shuffleBytesWritten: Long,
   shuffleRecordsWritten: Long
 ) extends BaseStageMetrics with MetricJsonLike {
-  val duration: Option[Long] =
+  override val duration: Option[Long] =
     for {
       c <- completionTime
       s <- submissionTime
@@ -343,7 +344,8 @@ case class CumulativeStageMetrics(
   shuffleRemoteBlocksFetched: Long,
   shuffleWriteTime: Long,
   shuffleBytesWritten: Long,
-  shuffleRecordsWritten: Long
+  shuffleRecordsWritten: Long,
+  duration: Option[Long] = None
 ) extends BaseStageMetrics with MetricJsonLike
 
 object CumulativeStageMetrics {
@@ -374,7 +376,8 @@ object CumulativeStageMetrics {
     shuffleRemoteBlocksFetched = 0L,
     shuffleWriteTime = 0L,
     shuffleBytesWritten = 0L,
-    shuffleRecordsWritten = 0L)
+    shuffleRecordsWritten = 0L
+  )
 
   def plus(csm: CumulativeStageMetrics, sm: StageMetrics): CumulativeStageMetrics = csm +
     CumulativeStageMetrics(
@@ -402,6 +405,7 @@ object CumulativeStageMetrics {
       shuffleRemoteBlocksFetched = sm.shuffleRemoteBlocksFetched,
       shuffleWriteTime = sm.shuffleWriteTime,
       shuffleBytesWritten = sm.shuffleBytesWritten,
-      shuffleRecordsWritten = sm.shuffleRecordsWritten
+      shuffleRecordsWritten = sm.shuffleRecordsWritten,
+      duration = sm.duration
   )
 }

--- a/utils/src/main/scala/com/salesforce/op/utils/spark/OpSparkListener.scala
+++ b/utils/src/main/scala/com/salesforce/op/utils/spark/OpSparkListener.scala
@@ -205,7 +205,7 @@ case class StageMetrics private
   shuffleWriteTime: Long,
   shuffleBytesWritten: Long,
   shuffleRecordsWritten: Long
-) extends JsonLike {}
+) extends JsonLike
 
 object StageMetrics {
   /**

--- a/utils/src/test/scala/com/salesforce/op/utils/spark/OpSparkListenerTest.scala
+++ b/utils/src/test/scala/com/salesforce/op/utils/spark/OpSparkListenerTest.scala
@@ -83,6 +83,8 @@ class OpSparkListenerTest extends FlatSpec with TableDrivenPropertyChecks with T
     firstStage.stageId shouldBe 0
     firstStage.numTasks shouldBe 1
     firstStage.status shouldBe "succeeded"
+    firstStage.duration shouldBe Option(
+      firstStage.completionTime.getOrElse(0L) - firstStage.submissionTime.getOrElse(0L))
   }
 
   it should "log messages for listener initialization, stage completion, app completion" in {

--- a/utils/src/test/scala/com/salesforce/op/utils/spark/OpSparkListenerTest.scala
+++ b/utils/src/test/scala/com/salesforce/op/utils/spark/OpSparkListenerTest.scala
@@ -83,8 +83,6 @@ class OpSparkListenerTest extends FlatSpec with TableDrivenPropertyChecks with T
     firstStage.stageId shouldBe 0
     firstStage.numTasks shouldBe 1
     firstStage.status shouldBe "succeeded"
-
-    System.out.println(appMetrics.toJson(pretty = true))
   }
 
   it should "log messages for listener initialization, stage completion, app completion" in {
@@ -163,6 +161,7 @@ class OpSparkListenerTest extends FlatSpec with TableDrivenPropertyChecks with T
     val total = Seq(sm0, sm1).foldLeft(CumulativeStageMetrics.zero)(_ + _)
 
     total.peakExecutionMemory shouldBe Max(1001)
+    total.toJson(true).contains("\"peakExecutionMemory\" : 1001") shouldBe true
   }
 }
 

--- a/utils/src/test/scala/com/salesforce/op/utils/spark/OpSparkListenerTest.scala
+++ b/utils/src/test/scala/com/salesforce/op/utils/spark/OpSparkListenerTest.scala
@@ -32,6 +32,9 @@ package com.salesforce.op.utils.spark
 
 import com.salesforce.op.test.TestSparkContext
 import com.salesforce.op.utils.date.DateTimeUtils
+import com.twitter.algebird.Max
+import com.twitter.algebird.Operators._
+import com.twitter.algebird.macros.caseclass
 import org.apache.log4j._
 import org.junit.runner.RunWith
 import org.scalatest.FlatSpec
@@ -72,13 +75,16 @@ class OpSparkListenerTest extends FlatSpec with TableDrivenPropertyChecks with T
   }
 
   it should "capture app stage metrics" in {
-    val stageMetrics = listener.metrics.stageMetrics
+    val appMetrics = listener.metrics
+    val stageMetrics = appMetrics.stageMetrics
     stageMetrics.size should be > 0
     val firstStage = stageMetrics.head
     firstStage.name should startWith("csv at OpSparkListenerTest.scala")
     firstStage.stageId shouldBe 0
     firstStage.numTasks shouldBe 1
     firstStage.status shouldBe "succeeded"
+
+    System.out.println(appMetrics.toJson(pretty = true))
   }
 
   it should "log messages for listener initialization, stage completion, app completion" in {
@@ -93,6 +99,70 @@ class OpSparkListenerTest extends FlatSpec with TableDrivenPropertyChecks with T
       )
     )
     forAll(messages) { m => logs.contains(m) shouldBe true }
+  }
+
+  it should "be able to aggregate Stage metrics" in {
+    implicit val stageSG = caseclass.semigroup[StageMetrics]
+
+    val sm0 = CumulativeStageMetrics(
+      numTasks = 1,
+      numAccumulables = 100,
+      executorRunTime = 1000L,
+      executorCpuTime = 700L,
+      executorDeserializeTime = 750L,
+      executorDeserializeCpuTime = 740L,
+      resultSerializationTime = 450L,
+      jvmGCTime = 2000L,
+      resultSizeBytes = 1L,
+      numUpdatedBlockStatuses = 1,
+      diskBytesSpilled = 1L,
+      memoryBytesSpilled = 1L,
+      peakExecutionMemory = Max(1000L),
+      recordsRead = 1,
+      bytesRead = 1,
+      recordsWritten = 1,
+      bytesWritten = 1,
+      shuffleFetchWaitTime = 1,
+      shuffleTotalBytesRead = 1,
+      shuffleTotalBlocksFetched = 1,
+      shuffleLocalBlocksFetched = 1,
+      shuffleRemoteBlocksFetched = 1,
+      shuffleWriteTime = 1,
+      shuffleBytesWritten = 1,
+      shuffleRecordsWritten = 1
+    )
+
+    val sm1 = CumulativeStageMetrics(
+      numTasks = 10,
+      numAccumulables = 100,
+      executorRunTime = 1000,
+      executorCpuTime = 700,
+      executorDeserializeTime = 750,
+      executorDeserializeCpuTime = 740,
+      resultSerializationTime = 450,
+      jvmGCTime = 2000,
+      resultSizeBytes = 1,
+      numUpdatedBlockStatuses = 1,
+      diskBytesSpilled = 1,
+      memoryBytesSpilled = 1,
+      peakExecutionMemory = Max(1001),
+      recordsRead = 1,
+      bytesRead = 1,
+      recordsWritten = 1,
+      bytesWritten = 1,
+      shuffleFetchWaitTime = 1,
+      shuffleTotalBytesRead = 1,
+      shuffleTotalBlocksFetched = 1,
+      shuffleLocalBlocksFetched = 1,
+      shuffleRemoteBlocksFetched = 1,
+      shuffleWriteTime = 1,
+      shuffleBytesWritten = 1,
+      shuffleRecordsWritten = 1
+    )
+
+    val total = Seq(sm0, sm1).foldLeft(CumulativeStageMetrics.zero)(_ + _)
+
+    total.peakExecutionMemory shouldBe Max(1001)
   }
 }
 


### PR DESCRIPTION
Compute by job metrics (sum of stage metrics) by default because it's O(1) non-GC'able memory 