### PR TITLE
Descale feature contribution for Linear Regression & Binary Logistic Regression

### DIFF
--- a/core/src/main/scala/com/salesforce/op/ModelInsights.scala
+++ b/core/src/main/scala/com/salesforce/op/ModelInsights.scala
@@ -559,7 +559,8 @@ case object ModelInsights {
           }
           val keptIndex = indexInToIndexKept.get(h.index)
           val featureStd = getIfExists(h.index, s.featuresStatistics.variance).getOrElse(1.0)
-          val sparkFtrContrib = keptIndex.map(i => contributions.map(_.applyOrElse(i, (_: Int) => 0.0))).getOrElse(Seq.empty)
+          val sparkFtrContrib = keptIndex
+            .map(i => contributions.map(_.applyOrElse(i, (_: Int) => 0.0))).getOrElse(Seq.empty)
           val labelStd = label.distribution.getOrElse(1.0) match {
           case Continuous(_, _, _, variance) => math.sqrt(variance)
           // for (binary) logistic regression we only need to multiply by feature standard deviation
@@ -568,7 +569,7 @@ case object ModelInsights {
               val floatDomain = domain.map(_.toDouble)
               val sqfloatDomain = floatDomain.map(math.pow(_, 2))
               val weighted = (floatDomain, prob).zipped map (_ * _)
-              val sqweighted =  (sqfloatDomain, prob).zipped map (_ * _)
+              val sqweighted = (sqfloatDomain, prob).zipped map (_ * _)
               val mean = weighted.sum
               return sqweighted.sum - mean
             }
@@ -596,7 +597,7 @@ case object ModelInsights {
                   getIfExists(idx, s.categoricalStats(groupIdx).contingencyMatrix)
                 case _ => Map.empty[String, Double]
               },
-              contribution = keptIndex.map(i => contributions.map(_.applyOrElse(i, (_: Int) => 0.0))).getOrElse(Seq.empty),
+              contribution = sparkFtrContrib,
               min = getIfExists(h.index, s.featuresStatistics.min),
               max = getIfExists(h.index, s.featuresStatistics.max),
               mean = getIfExists(h.index, s.featuresStatistics.mean),


### PR DESCRIPTION
**Describe the proposed solution**
Descale feature contribution for engineered features by multiplying Spark's returned weight with the respective feature standard deviation, and divide by the label standard deviation. 

**Describe alternatives you've considered**
N/A. The descaling needs access to the trained model (after model selection), label summary stats & feature summary stats. 

**Additional context**
Spark returns feature contribution on the original scale of the feature, making it hard to compare relative importance between two features of different scales. 