### PR TITLE
Quick Fix Alias Type Names

### DIFF
--- a/core/src/main/scala/com/salesforce/op/OpWorkflowCore.scala
+++ b/core/src/main/scala/com/salesforce/op/OpWorkflowCore.scala
@@ -255,7 +255,7 @@ private[op] trait OpWorkflowCore {
       val readerInputTypes = reader.get.subReaders.map(_.fullTypeName).toSet
       val unmatchedFeatures = rawFeatures.filterNot(f =>
         readerInputTypes
-          .contains(f.originStage.asInstanceOf[FeatureGeneratorStage[_, _ <: FeatureType]].tti.tpe.typeSymbol.fullName)
+          .contains(f.originStage.asInstanceOf[FeatureGeneratorStage[_, _ <: FeatureType]].tti.tpe.toString)
       )
       require(
         unmatchedFeatures.isEmpty,

--- a/core/src/main/scala/com/salesforce/op/OpWorkflowCore.scala
+++ b/core/src/main/scala/com/salesforce/op/OpWorkflowCore.scala
@@ -255,7 +255,7 @@ private[op] trait OpWorkflowCore {
       val readerInputTypes = reader.get.subReaders.map(_.fullTypeName).toSet
       val unmatchedFeatures = rawFeatures.filterNot(f =>
         readerInputTypes
-          .contains(f.originStage.asInstanceOf[FeatureGeneratorStage[_, _ <: FeatureType]].tti.tpe.toString)
+          .contains(f.originStage.asInstanceOf[FeatureGeneratorStage[_, _ <: FeatureType]].tti.tpe.typeSymbol.fullName)
       )
       require(
         unmatchedFeatures.isEmpty,

--- a/readers/src/main/scala/com/salesforce/op/readers/JoinedDataReader.scala
+++ b/readers/src/main/scala/com/salesforce/op/readers/JoinedDataReader.scala
@@ -149,7 +149,7 @@ private[op] abstract class JoinedReader[T, U]
   )(implicit spark: SparkSession): (DataFrame, Array[String]) = {
 
     def getData(r: DataReader[_]): DataFrame = {
-      val readerFeatures = rawFeatures.filter { f => getGenStage(f).tti.tpe.typeSymbol.fullName == r.fullTypeName }
+      val readerFeatures = rawFeatures.filter { f => getGenStage(f).tti.tpe.toString == r.fullTypeName }
       r.generateDataFrame(readerFeatures, opParams)
     }
 

--- a/readers/src/main/scala/com/salesforce/op/readers/Reader.scala
+++ b/readers/src/main/scala/com/salesforce/op/readers/Reader.scala
@@ -51,7 +51,7 @@ private[readers] trait ReaderType[T] extends Serializable {
    *
    * @return full input type name
    */
-  final def fullTypeName: String = wtt.tpe.typeSymbol.fullName
+  final def fullTypeName: String = wtt.tpe.toString
 
   /**
    * Short reader input type name

--- a/readers/src/main/scala/com/salesforce/op/readers/Reader.scala
+++ b/readers/src/main/scala/com/salesforce/op/readers/Reader.scala
@@ -66,7 +66,8 @@ private[readers] trait ReaderType[T] extends Serializable {
    * @param opParams contains map of reader type to ReaderParams instances
    * @return ReaderParams instance if it exists
    */
-  final def getReaderParams(opParams: OpParams): Option[ReaderParams] = opParams.readerParams.get(this.typeName)
+  final def getReaderParams(opParams: OpParams): Option[ReaderParams] = opParams.readerParams
+    .get(this.wtt.tpe.toString.split("\\.").last)
 
 }
 

--- a/readers/src/main/scala/com/salesforce/op/readers/Reader.scala
+++ b/readers/src/main/scala/com/salesforce/op/readers/Reader.scala
@@ -66,8 +66,7 @@ private[readers] trait ReaderType[T] extends Serializable {
    * @param opParams contains map of reader type to ReaderParams instances
    * @return ReaderParams instance if it exists
    */
-  final def getReaderParams(opParams: OpParams): Option[ReaderParams] = opParams.readerParams
-    .get(this.wtt.tpe.toString.split("\\.").last)
+  final def getReaderParams(opParams: OpParams): Option[ReaderParams] = opParams.readerParams.get(this.typeName)
 
 }
 


### PR DESCRIPTION
**Related issues**
When aliasing Type, the alias is sometimes lost in the reader.

**Describe the proposed solution**
Quick fix
