### PR TITLE
Adding `key` ctor field in all RawFeatureFilter results

### DIFF
--- a/core/src/main/scala/com/salesforce/op/filters/RawFeatureFilter.scala
+++ b/core/src/main/scala/com/salesforce/op/filters/RawFeatureFilter.scala
@@ -235,7 +235,7 @@ class RawFeatureFilter[T]
       fillRatioDiffs: Seq[Option[Double]]
     ): Seq[RawFeatureFilterMetrics] = {
 
-      trainingDistribs.map(_.name)
+      trainingDistribs.map(dist => dist.name -> dist.key)
         .zip(trainingFillRates)
         .zip(trainingNullLabelAbsoluteCorrs)
         .zip(scoringFillRates)
@@ -243,10 +243,10 @@ class RawFeatureFilter[T]
         .zip(fillRateDiffs)
         .zip(fillRatioDiffs)
         .map {
-          case ((((((name, trainingFillRate), trainingNullLabelAbsoluteCorr),
+          case (((((((name, key), trainingFillRate), trainingNullLabelAbsoluteCorr),
           scoringFillRate), jsDivergence), fillRateDiff), fillRatioDiff) =>
             RawFeatureFilterMetrics(
-              name, trainingFillRate, trainingNullLabelAbsoluteCorr,
+              name, key, trainingFillRate, trainingNullLabelAbsoluteCorr,
               scoringFillRate, jsDivergence, fillRateDiff, fillRatioDiff)
         }
     }
@@ -342,7 +342,7 @@ class RawFeatureFilter[T]
       fillRatioDiffMismatches: Seq[Boolean]
     ): Seq[ExclusionReasons] = {
 
-      trainingDistribs.map(_.name)
+      trainingDistribs.map(dist => dist.name-> dist.key)
         .zip(trainingUnfilledStates)
         .zip(trainingNullLabelLeakers)
         .zip(scoringUnfilledStates)
@@ -350,10 +350,11 @@ class RawFeatureFilter[T]
         .zip(fillRateDiffMismatches)
         .zip(fillRatioDiffMismatches)
         .map {
-          case ((((((name, trainingUnfilledState), trainingNullLabelLeaker),
+          case (((((((name, key), trainingUnfilledState), trainingNullLabelLeaker),
           scoringUnfilledState), jsDivergenceMismatch), fillRateDiffMismatch), fillRatioDiffMismatch) =>
             ExclusionReasons(
               name,
+              key,
               trainingUnfilledState,
               trainingNullLabelLeaker,
               scoringUnfilledState,

--- a/core/src/main/scala/com/salesforce/op/filters/RawFeatureFilterResults.scala
+++ b/core/src/main/scala/com/salesforce/op/filters/RawFeatureFilterResults.scala
@@ -125,6 +125,7 @@ object RawFeatureFilterConfig extends RawFeatureFilterFormats {
  * Contains raw feature metrics computing in Raw Feature Filter
  *
  * @param name                          feature name
+ * @param key          map key associated with distribution (when the feature is a map)
  * @param trainingFillRate              proportion of values that are null in the training distribution
  * @param trainingNullLabelAbsoluteCorr correlation between null indicator and the label in the training distribution
  * @param scoringFillRate               proportion of values that are null in the scoring distribution
@@ -135,6 +136,7 @@ object RawFeatureFilterConfig extends RawFeatureFilterFormats {
 case class RawFeatureFilterMetrics
 (
   name: String,
+  key: Option[String],
   trainingFillRate: Double,
   trainingNullLabelAbsoluteCorr: Option[Double],
   scoringFillRate: Option[Double],
@@ -147,6 +149,7 @@ case class RawFeatureFilterMetrics
  * Contains results of Raw Feature Filter tests for a given feature
  *
  * @param name                    feature name
+ * @param key          map key associated with distribution (when the feature is a map)
  * @param trainingUnfilledState   training fill rate did not meet min required
  * @param trainingNullLabelLeaker null indicator correlation (absolute) exceeded max allowed
  * @param scoringUnfilledState    scoring fill rate did not meet min required
@@ -158,6 +161,7 @@ case class RawFeatureFilterMetrics
 case class ExclusionReasons
 (
   name: String,
+  key: Option[String],
   trainingUnfilledState: Boolean,
   trainingNullLabelLeaker: Boolean,
   scoringUnfilledState: Boolean,

--- a/core/src/main/scala/com/salesforce/op/filters/RawFeatureFilterResults.scala
+++ b/core/src/main/scala/com/salesforce/op/filters/RawFeatureFilterResults.scala
@@ -125,7 +125,7 @@ object RawFeatureFilterConfig extends RawFeatureFilterFormats {
  * Contains raw feature metrics computing in Raw Feature Filter
  *
  * @param name                          feature name
- * @param key          map key associated with distribution (when the feature is a map)
+ * @param key                           map key associated with distribution (when the feature is a map)
  * @param trainingFillRate              proportion of values that are null in the training distribution
  * @param trainingNullLabelAbsoluteCorr correlation between null indicator and the label in the training distribution
  * @param scoringFillRate               proportion of values that are null in the scoring distribution
@@ -149,7 +149,7 @@ case class RawFeatureFilterMetrics
  * Contains results of Raw Feature Filter tests for a given feature
  *
  * @param name                    feature name
- * @param key          map key associated with distribution (when the feature is a map)
+ * @param key                     map key associated with distribution (when the feature is a map)
  * @param trainingUnfilledState   training fill rate did not meet min required
  * @param trainingNullLabelLeaker null indicator correlation (absolute) exceeded max allowed
  * @param scoringUnfilledState    scoring fill rate did not meet min required

--- a/core/src/test/scala/com/salesforce/op/filters/RawFeatureFilterResultsComparison.scala
+++ b/core/src/test/scala/com/salesforce/op/filters/RawFeatureFilterResultsComparison.scala
@@ -64,6 +64,7 @@ object RawFeatureFilterResultsComparison extends FlatSpec with Matchers with Dou
 
   def compareMetrics(m1: RawFeatureFilterMetrics, m2: RawFeatureFilterMetrics): Unit = {
     m1.name shouldBe m2.name
+    m1.key shouldBe m2.key
     m1.trainingFillRate shouldBe m2.trainingFillRate
     m1.trainingNullLabelAbsoluteCorr shouldEqual m2.trainingNullLabelAbsoluteCorr
     m1.scoringFillRate shouldEqual m2.scoringFillRate
@@ -78,6 +79,7 @@ object RawFeatureFilterResultsComparison extends FlatSpec with Matchers with Dou
 
   def compareExclusionReasons(er1: ExclusionReasons, er2: ExclusionReasons): Unit = {
     er1.name shouldBe er2.name
+    er1.key shouldBe er2.key
     er1.trainingUnfilledState shouldBe er2.trainingUnfilledState
     er1.trainingNullLabelLeaker shouldBe er2.trainingNullLabelLeaker
     er1.scoringUnfilledState shouldBe er2.scoringUnfilledState

--- a/core/src/test/scala/com/salesforce/op/filters/RawFeatureFilterTest.scala
+++ b/core/src/test/scala/com/salesforce/op/filters/RawFeatureFilterTest.scala
@@ -174,6 +174,8 @@ class RawFeatureFilterTest extends FlatSpec with PassengerSparkFixtureTest with 
     val filter = new RawFeatureFilter(simpleReader, Some(dataReader), 10, 0.2, 1.0,
       Double.PositiveInfinity, 1.0, 1.0)
     val (rawFeatureFilterMetrics, _, _, _) = filter.getFeaturesToExclude(trainSummaries, scoreSummaries, Map.empty)
+    rawFeatureFilterMetrics.map(_.name) shouldBe Seq("A", "B", "C", "C", "D", "D")
+    rawFeatureFilterMetrics.map(_.key) shouldBe Seq(None, None, Some("1"), Some("2"), Some("1"), Some("2"))
     rawFeatureFilterMetrics.map(_.trainingFillRate) shouldEqual List(0.9, 0.0, 0.9, 0.05, 0.1, 0.05)
     rawFeatureFilterMetrics.map(_.trainingNullLabelAbsoluteCorr) shouldEqual List.fill(6)(None)
     rawFeatureFilterMetrics.map(_.scoringFillRate) shouldEqual
@@ -203,6 +205,8 @@ class RawFeatureFilterTest extends FlatSpec with PassengerSparkFixtureTest with 
     excludedTrainMK.keySet shouldEqual Set("C")
     excludedTrainMK.head._2 shouldEqual Set("2")
     exclusionReasons.filter(_.trainingUnfilledState).map { _.name}.toSet shouldEqual Set("B", "C", "D")
+    exclusionReasons.map(_.name) shouldBe Seq("A", "B", "C", "C", "D", "D")
+    exclusionReasons.map(_.key) shouldBe Seq(None, None, Some("1"), Some("2"), Some("1"), Some("2"))
   }
 
   it should "correctly determine which features to exclude based on the stats of training and scoring fill rate" in {


### PR DESCRIPTION
**Related issues**
`FeatureDistribution` contains the field `key`   which is the map key associated with distribution (when the feature is a map). But why not having the same field in `RawFeatureFilterMetrics` and `ExclusionReasons`?

**Describe the proposed solution**
Adding the same field in `RawFeatureFilterMetrics` and `ExclusionReasons`

**Describe alternatives you've considered**

**Additional context**
