### PR TITLE
Try to fix the failing test

### DIFF
--- a/features/src/test/scala/com/salesforce/op/stages/base/sequence/SequenceEstimatorTest.scala
+++ b/features/src/test/scala/com/salesforce/op/stages/base/sequence/SequenceEstimatorTest.scala
@@ -73,14 +73,14 @@ class FractionOfResponsesEstimator(uid: String = UID[FractionOfResponsesEstimato
     import dataset.sparkSession.implicits._
     val sizes = dataset.map(_.map(_.size))
     val size = getInputFeatures().length
-    val counts = sizes.select(SequenceAggregators.SumNumSeq[Int](size = size).toColumn).first().toList
+    val counts = sizes.select(SequenceAggregators.SumNumSeq[Int](size = size).toColumn).first().map(_.toDouble)
     new FractionOfResponsesModel(counts = counts, operationName = operationName, uid = uid)
   }
 }
 
 final class FractionOfResponsesModel private[op]
 (
-  val counts: List[Int],
+  val counts: Seq[Double],
   operationName: String,
   uid: String
 ) extends SequenceModel[DateList, OPVector](operationName = operationName, uid = uid) {

--- a/features/src/test/scala/com/salesforce/op/stages/base/sequence/SequenceEstimatorTest.scala
+++ b/features/src/test/scala/com/salesforce/op/stages/base/sequence/SequenceEstimatorTest.scala
@@ -73,14 +73,14 @@ class FractionOfResponsesEstimator(uid: String = UID[FractionOfResponsesEstimato
     import dataset.sparkSession.implicits._
     val sizes = dataset.map(_.map(_.size))
     val size = getInputFeatures().length
-    val counts = sizes.select(SequenceAggregators.SumNumSeq[Int](size = size).toColumn).first()
+    val counts = sizes.select(SequenceAggregators.SumNumSeq[Int](size = size).toColumn).first().toList
     new FractionOfResponsesModel(counts = counts, operationName = operationName, uid = uid)
   }
 }
 
 final class FractionOfResponsesModel private[op]
 (
-  val counts: Seq[Int],
+  val counts: List[Int],
   operationName: String,
   uid: String
 ) extends SequenceModel[DateList, OPVector](operationName = operationName, uid = uid) {


### PR DESCRIPTION
**Related issues**
Sometimes TravisCI fails to deserialize the model in test and fails with the following error:
```
com.salesforce.op.stages.base.sequence.SequenceEstimatorTest
  [+] SequenceEstimator[OPVector] should produce output feature (1 ms)
  [+] SequenceEstimator[OPVector] should copy (10 ms)
  [+] SequenceEstimator[OPVector] should be serializable (16 ms)
  [+] SequenceEstimator[OPVector] should fit a model (479 ms)
  [+] SequenceEstimator[OPVector] model should produce output feature (1 ms)
  [+] SequenceEstimator[OPVector] model should copy (20 ms)
  [+] SequenceEstimator[OPVector] model should be serializable (13 ms)
  [-] SequenceEstimator[OPVector] model should be json writable/readable (33 ms)
com.salesforce.op.stages.base.sequence.SequenceEstimatorTest > SequenceEstimator[OPVector] model should be json writable/readable FAILED
    org.scalatest.exceptions.TestFailedException: Failed to read the stage of type 'com.salesforce.op.stages.base.sequence.FractionOfResponsesModel'
        Caused by:
        java.lang.RuntimeException: Failed to read the stage of type 'com.salesforce.op.stages.base.sequence.FractionOfResponsesModel'
            Caused by:
            java.lang.RuntimeException: Failed to extract value for param 'counts' for an instance of type 'com.salesforce.op.stages.base.sequence.FractionOfResponsesModel' due to: Failed to parse argument 'counts' from value 'List(5, 4, 4)' of class 'scala.collection.immutable.$colon$colon'
                Caused by:
                java.lang.RuntimeException: Failed to parse argument 'counts' from value 'List(5, 4, 4)' of class 'scala.collection.immutable.$colon$colon'
                    Caused by:
                    org.json4s.package$MappingException: Parsed JSON values do not match with class constructor
                    args=
                    arg types=
                    constructor=public scala.Int()
```

**Describe the proposed solution**
Trying out different solutions...

**Describe alternatives you've considered**
NA

