### PR TITLE
Make model selector metadata to metric more robust

### DIFF
--- a/core/src/test/scala/com/salesforce/op/ModelInsightsTest.scala
+++ b/core/src/test/scala/com/salesforce/op/ModelInsightsTest.scala
@@ -30,6 +30,7 @@
 
 package com.salesforce.op
 
+import com.salesforce.op.evaluators.{MultiClassificationMetrics, MultiMetrics, OpEvaluatorNames, OpMultiClassificationEvaluator, OpRegressionEvaluator, RegressionMetrics}
 import com.salesforce.op.features.types._
 import com.salesforce.op.features.{Feature, FeatureDistributionType, FeatureLike}
 import com.salesforce.op.filters._
@@ -797,5 +798,45 @@ class ModelInsightsTest extends FlatSpec with PassengerSparkFixtureTest with Dou
       value.valueCounts.keySet.map(_.toDouble).subsetOf(actualUniques) shouldBe true
       }
     }
+  }
+
+  it should "return both metrics when having multiple multi-class classification metrics in model insights" in {
+    val prediction = MultiClassificationModelSelector
+      .withCrossValidation(seed = 42,
+        trainTestEvaluators = Seq(new OpMultiClassificationEvaluator(
+          name = OpEvaluatorNames.Custom("second", "second")
+        )),
+        splitter = Option(DataCutter(seed = 42, reserveTestFraction = 0.1)),
+        modelsAndParameters = models)
+      .setInput(label, checked)
+      .getOutput()
+    val workflow = new OpWorkflow().setResultFeatures(prediction).setParameters(params).setReader(dataReader)
+    val workflowModel = workflow.train()
+    val insights = workflowModel.modelInsights(prediction)
+    val trainEval = insights.selectedModelInfo.get.trainEvaluation
+    trainEval shouldBe a[MultiMetrics]
+    val trainMetric = trainEval.asInstanceOf[MultiMetrics].metrics
+    trainMetric.size shouldEqual 2
+    trainMetric.foreach( metric => metric._2 shouldBe a[MultiClassificationMetrics])
+  }
+
+  it should "return both metrics when having multiple regression metrics in model insights" in {
+    val prediction = RegressionModelSelector
+      .withCrossValidation(seed = 42,
+        trainTestEvaluators = Seq(new OpRegressionEvaluator(
+          name = OpEvaluatorNames.Custom("second", "second")
+        )),
+        dataSplitter = Option(DataSplitter(seed = 42, reserveTestFraction = 0.1)),
+        modelsAndParameters = models)
+      .setInput(label, features)
+      .getOutput()
+    val workflow = new OpWorkflow().setResultFeatures(prediction).setParameters(params).setReader(dataReader)
+    val workflowModel = workflow.train()
+    val insights = workflowModel.modelInsights(prediction)
+    val trainEval = insights.selectedModelInfo.get.trainEvaluation
+    trainEval shouldBe a[MultiMetrics]
+    val trainMetric = trainEval.asInstanceOf[MultiMetrics].metrics
+    trainMetric.size shouldEqual 2
+    trainMetric.foreach( metric => metric._2 shouldBe a[RegressionMetrics])
   }
 }

--- a/core/src/test/scala/com/salesforce/op/ModelInsightsTest.scala
+++ b/core/src/test/scala/com/salesforce/op/ModelInsightsTest.scala
@@ -816,11 +816,11 @@ class ModelInsightsTest extends FlatSpec with PassengerSparkFixtureTest with Dou
     val trainEval = insights.selectedModelInfo.get.trainEvaluation
     trainEval shouldBe a[MultiMetrics]
     val trainMetric = trainEval.asInstanceOf[MultiMetrics].metrics
-    trainMetric.size shouldEqual 4
+    trainMetric.size shouldEqual 3
     trainMetric.map( metric => metric._2.isInstanceOf[BinaryClassificationMetrics]).toArray should
-      contain theSameElementsAs Array(true, true, false, false)
+      contain theSameElementsAs Array(true, true, false)
     trainMetric.map( metric => metric._2.isInstanceOf[BinaryClassificationBinMetrics]).toArray should
-      contain theSameElementsAs Array(true, true, false, false)
+      contain theSameElementsAs Array(true, false, false)
   }
 
   it should "return both metrics when having multiple multi-class classification metrics in model insights" in {


### PR DESCRIPTION
**Related issues**

**Describe the proposed solution**
Change the matching when parsing model selector metadata into metrics from name of metric to metric keys

**Describe alternatives you've considered**
N/A

**Additional context**
Allows for parsing of metadata to be based on content rather than the name, allowing for multiple metrics of the same type