### PR TITLE
0.6.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## 0.6.1
+
+Bug fixes:
+- Fix flaky `ModelInsight` tests [#395](https://github.com/salesforce/TransmogrifAI/pull/395)
+- Avoid creating `SparseVector`s for LOCO [#377](https://github.com/salesforce/TransmogrifAI/pull/377)
+
+New features / updates:
+- Model combiner [#385](https://github.com/salesforce/TransmogrifAI/pull/399)
+- Added new sample for HousingPrices [#365](https://github.com/salesforce/TransmogrifAI/pull/365)
+- Test to verify that custom metrics appear in model insight metrics [#387](https://github.com/salesforce/TransmogrifAI/pull/387)
+- Add `FeatureDistribution` to `SerializationFormat`s [#383](https://github.com/salesforce/TransmogrifAI/pull/383)
+- Add metadata to `OpStandadrdScaler` to allow for descaling [#378](https://github.com/salesforce/TransmogrifAI/pull/378)
+- Improve json serde error in `evalMetFromJson` [#380](https://github.com/salesforce/TransmogrifAI/pull/380)
+- Track mean & standard deviation of text length as a metric for text feature [#354](https://github.com/salesforce/TransmogrifAI/pull/354)
+- Making model selectors robust to failing models [#372](https://github.com/salesforce/TransmogrifAI/pull/372)
+- Use compact and compressed model json by default [#375](https://github.com/salesforce/TransmogrifAI/pull/375)
+- Descale feature contribution for Linear Regression & Logistic Regression [#345](https://github.com/salesforce/TransmogrifAI/pull/345)
+
+Dependency updates:   
+- Update tika version [#382](https://github.com/salesforce/TransmogrifAI/pull/382)
+- Revert back to Spark 2.3 [#399](https://github.com/salesforce/TransmogrifAI/pull/399)
+
 ## 0.6.0
 
 Bug fixes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.6.1
 
 Bug fixes:
+- Ensure correct metrics despite model failures on some CV folds [#404](https://github.com/salesforce/TransmogrifAI/pull/404)
 - Fix flaky `ModelInsight` tests [#395](https://github.com/salesforce/TransmogrifAI/pull/395)
 - Avoid creating `SparseVector`s for LOCO [#377](https://github.com/salesforce/TransmogrifAI/pull/377)
 
@@ -13,14 +14,13 @@ New features / updates:
 - Add `FeatureDistribution` to `SerializationFormat`s [#383](https://github.com/salesforce/TransmogrifAI/pull/383)
 - Add metadata to `OpStandadrdScaler` to allow for descaling [#378](https://github.com/salesforce/TransmogrifAI/pull/378)
 - Improve json serde error in `evalMetFromJson` [#380](https://github.com/salesforce/TransmogrifAI/pull/380)
-- Track mean & standard deviation of text length as a metric for text feature [#354](https://github.com/salesforce/TransmogrifAI/pull/354)
+- Track mean & standard deviation as metrics for numeric features and for text length of text features [#354](https://github.com/salesforce/TransmogrifAI/pull/354)
 - Making model selectors robust to failing models [#372](https://github.com/salesforce/TransmogrifAI/pull/372)
 - Use compact and compressed model json by default [#375](https://github.com/salesforce/TransmogrifAI/pull/375)
 - Descale feature contribution for Linear Regression & Logistic Regression [#345](https://github.com/salesforce/TransmogrifAI/pull/345)
 
 Dependency updates:   
 - Update tika version [#382](https://github.com/salesforce/TransmogrifAI/pull/382)
-- Revert back to Spark 2.3 [#399](https://github.com/salesforce/TransmogrifAI/pull/399)
 
 ## 0.6.0
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # TransmogrifAI
 
-[![Maven Central](https://img.shields.io/maven-central/v/com.salesforce.transmogrifai/transmogrifai-core_2.11.svg?colorB=blue)](https://search.maven.org/search?q=g:com.salesforce.transmogrifai) [![Download](https://api.bintray.com/packages/salesforce/maven/TransmogrifAI/images/download.svg)](https://bintray.com/salesforce/maven/TransmogrifAI/_latestVersion) [![Javadocs](https://www.javadoc.io/badge/com.salesforce.transmogrifai/transmogrifai-core_2.11/0.6.0.svg?color=blue)](https://www.javadoc.io/doc/com.salesforce.transmogrifai/transmogrifai-core_2.11/0.6.0) [![Spark version](https://img.shields.io/badge/spark-2.3-brightgreen.svg)](https://spark.apache.org/downloads.html) [![Scala version](https://img.shields.io/badge/scala-2.11-brightgreen.svg)](https://www.scala-lang.org/download/2.11.12.html) [![License](http://img.shields.io/:license-BSD--3-blue.svg)](./LICENSE) [![Chat](https://badges.gitter.im/salesforce/TransmogrifAI.svg)](https://gitter.im/salesforce/TransmogrifAI?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![Maven Central](https://img.shields.io/maven-central/v/com.salesforce.transmogrifai/transmogrifai-core_2.11.svg?colorB=blue)](https://search.maven.org/search?q=g:com.salesforce.transmogrifai) [![Download](https://api.bintray.com/packages/salesforce/maven/TransmogrifAI/images/download.svg)](https://bintray.com/salesforce/maven/TransmogrifAI/_latestVersion) [![Javadocs](https://www.javadoc.io/badge/com.salesforce.transmogrifai/transmogrifai-core_2.11/0.6.1.svg?color=blue)](https://www.javadoc.io/doc/com.salesforce.transmogrifai/transmogrifai-core_2.11/0.6.1) [![Spark version](https://img.shields.io/badge/spark-2.3-brightgreen.svg)](https://spark.apache.org/downloads.html) [![Scala version](https://img.shields.io/badge/scala-2.11-brightgreen.svg)](https://www.scala-lang.org/download/2.11.12.html) [![License](http://img.shields.io/:license-BSD--3-blue.svg)](./LICENSE) [![Chat](https://badges.gitter.im/salesforce/TransmogrifAI.svg)](https://gitter.im/salesforce/TransmogrifAI?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 [![TravisCI Build Status](https://travis-ci.com/salesforce/TransmogrifAI.svg?token=Ex9czVEUD7AzPTmVh6iX&branch=master)](https://travis-ci.com/salesforce/TransmogrifAI) [![CircleCI Build Status](https://circleci.com/gh/salesforce/TransmogrifAI.svg?&style=shield&circle-token=e84c1037ae36652d38b49207728181ee85337e0b)](https://circleci.com/gh/salesforce/TransmogrifAI) [![Documentation Status](https://readthedocs.org/projects/transmogrifai/badge/?version=stable)](https://docs.transmogrif.ai/en/stable/?badge=stable) [![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/2557/badge)](https://bestpractices.coreinfrastructure.org/projects/2557) [![Codecov](https://codecov.io/gh/salesforce/TransmogrifAI/branch/master/graph/badge.svg)](https://codecov.io/gh/salesforce/TransmogrifAI) [![CodeFactor](https://www.codefactor.io/repository/github/salesforce/transmogrifai/badge)](https://www.codefactor.io/repository/github/salesforce/transmogrifai)
 
@@ -126,11 +126,11 @@ While this may seem a bit too magical, for those who want more control, Transmog
 You can simply add TransmogrifAI as a regular dependency to an existing project.
 Start by picking TransmogrifAI version to match your project dependencies from the version matrix below (if not sure - take the **stable** version):
 
-| TransmogrifAI Version                           | Spark Version | Scala Version | Java Version |
-|-------------------------------------------------|:-------------:|:-------------:|:------------:|
-| 0.6.1 (unreleased, master)                      |      2.3      |      2.11     |      1.8     |
-| **0.6.0 (stable)**, 0.5.3, 0.5.2, 0.5.1, 0.5.0  |    **2.3**    |    **2.11**   |    **1.8**   |
-| 0.4.0, 0.3.4                                    |      2.2      |      2.11     |      1.8     |
+| TransmogrifAI Version                                 | Spark Version | Scala Version | Java Version |
+|-------------------------------------------------------|:-------------:|:-------------:|:------------:|
+| 0.6.2 (unreleased, master)                            |      2.3      |      2.11     |      1.8     |
+| **0.6.1 (stable)**, 0.6.0, 0.5.3, 0.5.2, 0.5.1, 0.5.0 |    **2.3**    |    **2.11**   |    **1.8**   |
+| 0.4.0, 0.3.4                                          |      2.2      |      2.11     |      1.8     |
 
 For Gradle in `build.gradle` add:
 ```gradle
@@ -140,10 +140,10 @@ repositories {
 }
 dependencies {
     // TransmogrifAI core dependency
-    compile 'com.salesforce.transmogrifai:transmogrifai-core_2.11:0.6.0'
+    compile 'com.salesforce.transmogrifai:transmogrifai-core_2.11:0.6.1'
 
     // TransmogrifAI pretrained models, e.g. OpenNLP POS/NER models etc. (optional)
-    // compile 'com.salesforce.transmogrifai:transmogrifai-models_2.11:0.6.0'
+    // compile 'com.salesforce.transmogrifai:transmogrifai-models_2.11:0.6.1'
 }
 ```
 
@@ -154,10 +154,10 @@ scalaVersion := "2.11.12"
 resolvers += Resolver.jcenterRepo
 
 // TransmogrifAI core dependency
-libraryDependencies += "com.salesforce.transmogrifai" %% "transmogrifai-core" % "0.6.0"
+libraryDependencies += "com.salesforce.transmogrifai" %% "transmogrifai-core" % "0.6.1"
 
 // TransmogrifAI pretrained models, e.g. OpenNLP POS/NER models etc. (optional)
-// libraryDependencies += "com.salesforce.transmogrifai" %% "transmogrifai-models" % "0.6.0"
+// libraryDependencies += "com.salesforce.transmogrifai" %% "transmogrifai-models" % "0.6.1"
 ```
 
 Then import TransmogrifAI into your code:

--- a/docs/examples/Bootstrap-Your-First-Project.md
+++ b/docs/examples/Bootstrap-Your-First-Project.md
@@ -7,10 +7,10 @@ Clone the TransmogrifAI repo:
 ```bash
 git clone https://github.com/salesforce/TransmogrifAI.git
 ```
-Checkout the latest release branch (in this example `0.6.0`):
+Checkout the latest release branch (in this example `0.6.1`):
 ```bash
 cd ./TransmogrifAI
-git checkout 0.6.0
+git checkout 0.6.1
 ```
 Build the TransmogrifAI CLI by running:
 ```bash

--- a/docs/examples/Running-from-Spark-Shell.md
+++ b/docs/examples/Running-from-Spark-Shell.md
@@ -3,7 +3,7 @@
 Start up your spark shell and add the [TransmogrifAI package](https://spark-packages.org/package/salesforce/TransmogrifAI):
 
 ```bash
-$SPARK_HOME/bin/spark-shell --packages com.salesforce.transmogrifai:transmogrifai-core_2.11:0.6.0
+$SPARK_HOME/bin/spark-shell --packages com.salesforce.transmogrifai:transmogrifai-core_2.11:0.6.1
 ```
 
 Or if you'd like to use the latest version from master:

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
-version=0.6.1-SNAPSHOT
+version=0.6.1
 group=com.salesforce.transmogrifai
 org.gradle.caching=true

--- a/helloworld/notebooks/OpHousingPrices.ipynb
+++ b/helloworld/notebooks/OpHousingPrices.ipynb
@@ -16,7 +16,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%classpath add mvn com.salesforce.transmogrifai transmogrifai-core_2.11 0.6.0"
+    "%classpath add mvn com.salesforce.transmogrifai transmogrifai-core_2.11 0.6.1"
    ]
   },
   {

--- a/helloworld/notebooks/OpIris.ipynb
+++ b/helloworld/notebooks/OpIris.ipynb
@@ -17,7 +17,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%classpath add mvn com.salesforce.transmogrifai transmogrifai-core_2.11 0.6.0"
+    "%classpath add mvn com.salesforce.transmogrifai transmogrifai-core_2.11 0.6.1"
    ]
   },
   {

--- a/helloworld/notebooks/OpTitanicSimple.ipynb
+++ b/helloworld/notebooks/OpTitanicSimple.ipynb
@@ -22,7 +22,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%classpath add mvn com.salesforce.transmogrifai transmogrifai-core_2.11 0.6.0"
+    "%classpath add mvn com.salesforce.transmogrifai transmogrifai-core_2.11 0.6.1"
    ]
   },
   {

--- a/local/README.md
+++ b/local/README.md
@@ -10,12 +10,12 @@ Add the `transmogrifai-local` dependency into your project.
 For Gradle in `build.gradle` add:
 ```gradle
 dependencies {
-    compile 'com.salesforce.transmogrifai:transmogrifai-local_2.11:0.6.0'
+    compile 'com.salesforce.transmogrifai:transmogrifai-local_2.11:0.6.1'
 }
 ```
 For SBT in `build.sbt` add:
 ```sbt
-libraryDependencies += "com.salesforce.transmogrifai" %% "transmogrifai-local" % "0.6.0"
+libraryDependencies += "com.salesforce.transmogrifai" %% "transmogrifai-local" % "0.6.1"
 ```
 
 Then in your code you may load and score models as follows:

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
 
     <groupId>com.salesforce.transmogrifai</groupId>
     <artifactId>TransmogrifAI</artifactId>
-    <version>0.6.0</version>
+    <version>0.6.1</version>
     <name>TransmogrifAI</name>
     <description>AutoML library for building modular, reusable, strongly typed machine learning workflows on Spark with minimal hand tuning</description>
     <url>https://github.com/salesforce/TransmogrifAI</url>


### PR DESCRIPTION
Bug fixes:
- Ensure correct metrics despite model failures on some CV folds [#404](https://github.com/salesforce/TransmogrifAI/pull/404)
- Fix flaky `ModelInsight` tests [#395](https://github.com/salesforce/TransmogrifAI/pull/395)
- Avoid creating `SparseVector`s for LOCO [#377](https://github.com/salesforce/TransmogrifAI/pull/377)

New features / updates:
- Model combiner [#385](https://github.com/salesforce/TransmogrifAI/pull/399)
- Added new sample for HousingPrices [#365](https://github.com/salesforce/TransmogrifAI/pull/365)
- Test to verify that custom metrics appear in model insight metrics [#387](https://github.com/salesforce/TransmogrifAI/pull/387)
- Add `FeatureDistribution` to `SerializationFormat`s [#383](https://github.com/salesforce/TransmogrifAI/pull/383)
- Add metadata to `OpStandadrdScaler` to allow for descaling [#378](https://github.com/salesforce/TransmogrifAI/pull/378)
- Improve json serde error in `evalMetFromJson` [#380](https://github.com/salesforce/TransmogrifAI/pull/380)
- Track mean & standard deviation as metrics for numeric features and for text length of text features [#354](https://github.com/salesforce/TransmogrifAI/pull/354)
- Making model selectors robust to failing models [#372](https://github.com/salesforce/TransmogrifAI/pull/372)
- Use compact and compressed model json by default [#375](https://github.com/salesforce/TransmogrifAI/pull/375)
- Descale feature contribution for Linear Regression & Logistic Regression [#345](https://github.com/salesforce/TransmogrifAI/pull/345)

Dependency updates:   
- Update tika version [#382](https://github.com/salesforce/TransmogrifAI/pull/382)