### PR TITLE
Ensure correct metrics despite model failures on some CV folds

### DIFF
--- a/core/src/main/scala/com/salesforce/op/stages/impl/tuning/OpCrossValidation.scala
+++ b/core/src/main/scala/com/salesforce/op/stages/impl/tuning/OpCrossValidation.scala
@@ -53,11 +53,13 @@ private[op] class OpCrossValidation[M <: Model[_], E <: Estimator[_]]
   override def getParams(): Map[String, Any] = Map("numFolds" -> numFolds, "seed" -> seed,
     "evaluator" -> evaluator.name.humanFriendlyName, "stratify" -> stratify, "parallelism" -> parallelism)
 
+  /**
+   * Should be called only on instances of the same model
+   */
   private def findBestModel(
     folds: Seq[ValidatedModel[E]]
   ): ValidatedModel[E] = {
-    require(folds.map(_.model.uid).toSet.size == 1) // Should be called only on instances of the same model
-
+   
     val gridCounts = folds.flatMap(_.grids.map(_ -> 1)).sumByKey
     val (_, maxFolds) = gridCounts.maxBy{ case (_, count) => count }
     val gridsIn = gridCounts.filter{ case (_, foldCount) => foldCount == maxFolds }.keySet

--- a/core/src/main/scala/com/salesforce/op/stages/impl/tuning/OpCrossValidation.scala
+++ b/core/src/main/scala/com/salesforce/op/stages/impl/tuning/OpCrossValidation.scala
@@ -64,7 +64,7 @@ private[op] class OpCrossValidation[M <: Model[_], E <: Estimator[_]]
 
     val gridMetrics = folds.flatMap{
       f => f.grids.zip(f.metrics).collect { case (pm, met) if gridsIn.contains(pm) => (pm, met / maxFolds) }
-    }.sumByKey.toSeq
+    }.sumByKey
 
     val ((bestGrid, bestMetric), bestIndex) =
       if (evaluator.isLargerBetter) gridMetrics.zipWithIndex.maxBy{ case ((_, metric), _) => metric}

--- a/core/src/main/scala/com/salesforce/op/stages/impl/tuning/OpCrossValidation.scala
+++ b/core/src/main/scala/com/salesforce/op/stages/impl/tuning/OpCrossValidation.scala
@@ -58,12 +58,12 @@ private[op] class OpCrossValidation[M <: Model[_], E <: Estimator[_]]
   ): ValidatedModel[E] = {
     require(folds.map(_.model.uid).toSet.size == 1) // Should be called only on instances of the same model
 
-    val gridCounts = folds.flatMap(_.grids.map(_ -> 1).toMap).sumByKey
+    val gridCounts = folds.flatMap(_.grids.map(_ -> 1)).sumByKey
     val (_, maxFolds) = gridCounts.maxBy{ case (_, count) => count }
     val gridsIn = gridCounts.filter{ case (_, foldCount) => foldCount == maxFolds }.keySet
 
     val gridMetrics = folds.flatMap{
-      f => f.grids.zip(f.metrics).collect { case (pm, met) if gridsIn.contains(pm) => (pm, met / maxFolds) }.toMap
+      f => f.grids.zip(f.metrics).collect { case (pm, met) if gridsIn.contains(pm) => (pm, met / maxFolds) }
     }.sumByKey.toSeq
 
     val ((bestGrid, bestMetric), bestIndex) =

--- a/core/src/main/scala/com/salesforce/op/stages/impl/tuning/OpCrossValidation.scala
+++ b/core/src/main/scala/com/salesforce/op/stages/impl/tuning/OpCrossValidation.scala
@@ -59,14 +59,14 @@ private[op] class OpCrossValidation[M <: Model[_], E <: Estimator[_]]
   private def findBestModel(
     folds: Seq[ValidatedModel[E]]
   ): ValidatedModel[E] = {
-   
+
     val gridCounts = folds.flatMap(_.grids.map(_ -> 1)).sumByKey
     val (_, maxFolds) = gridCounts.maxBy{ case (_, count) => count }
     val gridsIn = gridCounts.filter{ case (_, foldCount) => foldCount == maxFolds }.keySet
 
     val gridMetrics = folds.flatMap{
       f => f.grids.zip(f.metrics).collect { case (pm, met) if gridsIn.contains(pm) => (pm, met / maxFolds) }
-    }.sumByKey
+    }.sumByKey.toSeq
 
     val ((bestGrid, bestMetric), bestIndex) =
       if (evaluator.isLargerBetter) gridMetrics.zipWithIndex.maxBy{ case ((_, metric), _) => metric}

--- a/core/src/test/scala/com/salesforce/op/stages/impl/classification/BinaryClassificationModelSelectorTest.scala
+++ b/core/src/test/scala/com/salesforce/op/stages/impl/classification/BinaryClassificationModelSelectorTest.scala
@@ -183,7 +183,7 @@ class BinaryClassificationModelSelectorTest extends FlatSpec with TestSparkConte
           numFolds = 4,
           validationMetric = Evaluators.BinaryClassification.error(),
           seed = 42,
-          modelTypesToUse = defaultModels //Seq(modelToTry)
+          modelTypesToUse = Seq(modelToTry)
         )
         .setInput(label, features)
 

--- a/core/src/test/scala/com/salesforce/op/stages/impl/classification/BinaryClassificationModelSelectorTest.scala
+++ b/core/src/test/scala/com/salesforce/op/stages/impl/classification/BinaryClassificationModelSelectorTest.scala
@@ -183,7 +183,7 @@ class BinaryClassificationModelSelectorTest extends FlatSpec with TestSparkConte
           numFolds = 4,
           validationMetric = Evaluators.BinaryClassification.error(),
           seed = 42,
-          modelTypesToUse = Seq(modelToTry)
+          modelTypesToUse = defaultModels //Seq(modelToTry)
         )
         .setInput(label, features)
 

--- a/core/src/test/scala/com/salesforce/op/stages/impl/regression/RegressionModelSelectorTest.scala
+++ b/core/src/test/scala/com/salesforce/op/stages/impl/regression/RegressionModelSelectorTest.scala
@@ -240,7 +240,7 @@ class RegressionModelSelectorTest extends FlatSpec with TestSparkContext
       assert(metaData.trainEvaluation.toJson(false).contains(s"${metric.entryName}"),
         s"Metric ${metric.entryName} is not present in metadata: " + metaData)
     )
-    metaData.validationResults.size shouldBe 42
+    metaData.validationResults.size shouldBe 40
   }
 
 

--- a/core/src/test/scala/com/salesforce/op/stages/impl/regression/RegressionModelSelectorTest.scala
+++ b/core/src/test/scala/com/salesforce/op/stages/impl/regression/RegressionModelSelectorTest.scala
@@ -264,7 +264,7 @@ class RegressionModelSelectorTest extends FlatSpec with TestSparkContext
       assert(metaData.trainEvaluation.toJson(false).contains(s"${metric.entryName}"),
         s"Metric ${metric.entryName} is not present in metadata: " + metaData)
     )
-    metaData.validationResults.size shouldBe 34
+    metaData.validationResults.size shouldBe 32
   }
 
 

--- a/core/src/test/scala/com/salesforce/op/stages/impl/regression/RegressionModelSelectorTest.scala
+++ b/core/src/test/scala/com/salesforce/op/stages/impl/regression/RegressionModelSelectorTest.scala
@@ -34,7 +34,6 @@ import com.salesforce.op.evaluators._
 import com.salesforce.op.features.types._
 import com.salesforce.op.features.{Feature, FeatureBuilder}
 import com.salesforce.op.stages.impl.CompareParamGrid
-import com.salesforce.op.stages.impl.regression.RegressionModelsToTry.OpGeneralizedLinearRegression
 import com.salesforce.op.stages.impl.regression.{RegressionModelsToTry => RMT}
 import com.salesforce.op.stages.impl.selector.ModelSelectorNames.EstimatorType
 import com.salesforce.op.stages.impl.selector.{DefaultSelectorParams, ModelSelectorSummary}
@@ -251,7 +250,7 @@ class RegressionModelSelectorTest extends FlatSpec with TestSparkContext
         numFolds = 4,
         validationMetric = Evaluators.Regression.mse(),
         seed = 10L,
-        modelTypesToUse = Seq(RegressionModelsToTry.OpGeneralizedLinearRegression)
+        modelTypesToUse = Seq(RMT.OpGeneralizedLinearRegression)
       )
       .setInput(label, features)
 

--- a/core/src/test/scala/com/salesforce/op/stages/impl/selector/ModelSelectorTest.scala
+++ b/core/src/test/scala/com/salesforce/op/stages/impl/selector/ModelSelectorTest.scala
@@ -148,7 +148,6 @@ class ModelSelectorTest extends OpEstimatorSpec[Prediction, SelectedModel, Model
     ).setInput(label, features)
 
     val model = testEstimator.fit(data)
-    println(ModelSelectorSummary.fromMetadata(model.getMetadata().getSummaryMetadata()).validationResults)
     model.modelStageIn.isInstanceOf[OpLogisticRegressionModel] shouldBe true
 
     val bestEstimator = model.modelStageIn.parent

--- a/core/src/test/scala/com/salesforce/op/stages/impl/selector/ModelSelectorTest.scala
+++ b/core/src/test/scala/com/salesforce/op/stages/impl/selector/ModelSelectorTest.scala
@@ -82,23 +82,23 @@ class ModelSelectorTest extends OpEstimatorSpec[Prediction, SelectedModel, Model
 
   private val lr = new OpLogisticRegression()
   private val lrParams = new ParamGridBuilder()
-    .addGrid(lr.regParam, Array(0.1, 100))
+    .addGrid(lr.regParam, Array(0.1, 10000))
     .addGrid(lr.elasticNetParam, Array(0, 0.5)).build()
 
   private val rf = new OpRandomForestClassifier()
   private val rfParams = new ParamGridBuilder()
     .addGrid(rf.numTrees, Array(2, 4))
-    .addGrid(rf.minInfoGain, Array(100.0, 10.0)).build()
+    .addGrid(rf.minInfoGain, Array(1000.0, 100.0)).build()
 
   private val linR = new OpLinearRegression()
   private val linRParams = new ParamGridBuilder()
-    .addGrid(linR.regParam, Array(0.1, 100))
+    .addGrid(linR.regParam, Array(0.1, 1000))
     .addGrid(linR.maxIter, Array(10, 20)).build()
 
   private val rfR = new OpRandomForestRegressor()
   private val rfRParams = new ParamGridBuilder()
     .addGrid(rfR.numTrees, Array(2, 4))
-    .addGrid(rfR.minInfoGain, Array(100.0, 10.0)).build()
+    .addGrid(rfR.minInfoGain, Array(1000.0, 100.0)).build()
 
   val (inputData, rawFeature1, feature2) = TestFeatureBuilder("label", "features",
     Seq[(RealNN, OPVector)](

--- a/core/src/test/scala/com/salesforce/op/stages/impl/selector/ModelSelectorTest.scala
+++ b/core/src/test/scala/com/salesforce/op/stages/impl/selector/ModelSelectorTest.scala
@@ -83,7 +83,7 @@ class ModelSelectorTest extends OpEstimatorSpec[Prediction, SelectedModel, Model
   private val lr = new OpLogisticRegression()
   private val lrParams = new ParamGridBuilder()
     .addGrid(lr.regParam, Array(0.1, 10000))
-    .addGrid(lr.elasticNetParam, Array(0, 0.5)).build()
+    .addGrid(lr.elasticNetParam, Array(0.5)).build()
 
   private val rf = new OpRandomForestClassifier()
   private val rfParams = new ParamGridBuilder()
@@ -148,6 +148,7 @@ class ModelSelectorTest extends OpEstimatorSpec[Prediction, SelectedModel, Model
     ).setInput(label, features)
 
     val model = testEstimator.fit(data)
+    println(ModelSelectorSummary.fromMetadata(model.getMetadata().getSummaryMetadata()).validationResults)
     model.modelStageIn.isInstanceOf[OpLogisticRegressionModel] shouldBe true
 
     val bestEstimator = model.modelStageIn.parent


### PR DESCRIPTION
**Related issues**
GLM optimizer is not very stable so sometimes runs will fail in some CV folds but not others - this was causing metrics and grids to not be computed correctly since we assumed that the same number of parameter grids successfully run in each cross validation fold 


**Describe the proposed solution**
throw out grids which are not in every cv run (since they are likely to fail in some modeling runs)

**Describe alternatives you've considered**
use grids with metrics in a map to make sure that the correct metrics are combined in CV and simply take the best metric

**Additional context**
Add any other context about the changes here.
