### PR TITLE
Fix `ModelInsightsTest` flakiness due to coefficients turning negative 

### DIFF
--- a/core/src/test/scala/com/salesforce/op/ModelInsightsTest.scala
+++ b/core/src/test/scala/com/salesforce/op/ModelInsightsTest.scala
@@ -754,9 +754,9 @@ class ModelInsightsTest extends FlatSpec with PassengerSparkFixtureTest with Dou
     val descaledbigCoeff = coeffs(2)
     val orginalbigCoeff = coeffs(3)
     val absError = math.abs(orginalbigCoeff * math.sqrt(smallFeatureVariance) / labelStd - descaledbigCoeff)
-    val bigCoeffSum = orginalbigCoeff * math.sqrt(smallFeatureVariance) / labelStd + descaledbigCoeff
+    val bigCoeffSum = math.abs(orginalbigCoeff * math.sqrt(smallFeatureVariance) / labelStd + descaledbigCoeff)
     val absError2 = math.abs(originalsmallCoeff * math.sqrt(bigFeatureVariance) / labelStd - descaledsmallCoeff)
-    val smallCoeffSum = originalsmallCoeff * math.sqrt(bigFeatureVariance) / labelStd + descaledsmallCoeff
+    val smallCoeffSum = math.abs(originalsmallCoeff * math.sqrt(bigFeatureVariance) / labelStd + descaledsmallCoeff)
     absError should be < tol * bigCoeffSum / 2
     absError2 should be < tol * smallCoeffSum / 2
   }
@@ -770,9 +770,9 @@ class ModelInsightsTest extends FlatSpec with PassengerSparkFixtureTest with Dou
     val orginalbigCoeff = coeffs(3)
     // difference between the real coefficient and the analytical formula
     val absError = math.abs(orginalbigCoeff * math.sqrt(smallFeatureVariance) - descaledbigCoeff)
-    val bigCoeffSum = orginalbigCoeff * math.sqrt(smallFeatureVariance) + descaledbigCoeff
+    val bigCoeffSum = math.abs(orginalbigCoeff * math.sqrt(smallFeatureVariance) + descaledbigCoeff)
     val absError2 = math.abs(originalsmallCoeff * math.sqrt(mediumFeatureVariance) - descaledsmallCoeff)
-    val smallCoeffSum = originalsmallCoeff * math.sqrt(mediumFeatureVariance) + descaledsmallCoeff
+    val smallCoeffSum = math.abs(originalsmallCoeff * math.sqrt(mediumFeatureVariance) + descaledsmallCoeff)
     absError should be < tol * bigCoeffSum / 2
     absError2 should be < tol * smallCoeffSum / 2
   }


### PR DESCRIPTION
[ModelInsightsTest](https://github.com/salesforce/TransmogrifAI/blob/95a77b17269a71bf0d53c54df7d76f0bfe862275/core/src/test/scala/com/salesforce/op/ModelInsightsTest.scala#L750-L778) was flaky due to returned coefficients being negative sometimes.

**Describe the proposed solution**
Adding absolute value when summing descaled coefficients 