### PR TITLE
Make EmailVectorizer not clean the email domains by default.

### DIFF
--- a/core/src/main/scala/com/salesforce/op/dsl/RichMapFeature.scala
+++ b/core/src/main/scala/com/salesforce/op/dsl/RichMapFeature.scala
@@ -33,7 +33,7 @@ package com.salesforce.op.dsl
 import com.salesforce.op.features.FeatureLike
 import com.salesforce.op.features.types._
 import com.salesforce.op.stages.impl.feature._
-import com.salesforce.op.utils.text.Language
+import com.salesforce.op.utils.text.{CleanTextParams, Language}
 import org.apache.spark.ml.linalg.Vectors
 
 import scala.reflect.runtime.universe._
@@ -97,13 +97,15 @@ trait RichMapFeature {
       blackListKeys: Array[String] = Array.empty,
       trackNulls: Boolean = TransmogrifierDefaults.TrackNulls,
       others: Array[FeatureLike[T]] = Array.empty,
-      maxPctCardinality: Double = OpOneHotVectorizer.MaxPctCardinality
+      maxPctCardinality: Double = OpOneHotVectorizer.MaxPctCardinality,
+      cleanTextParams: CleanTextParams = TransmogrifierDefaults.CleanParams
     ): FeatureLike[OPVector] = {
       new TextMapPivotVectorizer[T]()
         .setInput(f +: others)
         .setTopK(topK)
         .setCleanKeys(cleanKeys)
         .setCleanText(cleanText)
+        .setCleanTextParams(cleanTextParams)
         .setMinSupport(minSupport)
         .setWhiteListKeys(whiteListKeys)
         .setBlackListKeys(blackListKeys)
@@ -1026,7 +1028,8 @@ trait RichMapFeature {
       blackListKeys: Array[String] = Array.empty,
       trackNulls: Boolean = TransmogrifierDefaults.TrackNulls,
       others: Array[FeatureLike[EmailMap]] = Array.empty,
-      maxPctCardinality: Double = OpOneHotVectorizer.MaxPctCardinality
+      maxPctCardinality: Double = OpOneHotVectorizer.MaxPctCardinality,
+      cleanTextParams: CleanTextParams = CleanTextParams(true, false)
     ): FeatureLike[OPVector] = {
       val domains: Array[FeatureLike[PickListMap]] = (f +: others).map { e =>
         new EmailToPickListMapTransformer().setInput(e).getOutput()
@@ -1034,7 +1037,7 @@ trait RichMapFeature {
 
       domains.head.vectorize(
         topK = topK, minSupport = minSupport, cleanText = cleanText, cleanKeys = cleanKeys,
-        whiteListKeys = whiteListKeys, blackListKeys = blackListKeys,
+        cleanTextParams = cleanTextParams, whiteListKeys = whiteListKeys, blackListKeys = blackListKeys,
         others = domains.tail, trackNulls = trackNulls, maxPctCardinality = maxPctCardinality
       )
     }

--- a/core/src/main/scala/com/salesforce/op/dsl/RichTextFeature.scala
+++ b/core/src/main/scala/com/salesforce/op/dsl/RichTextFeature.scala
@@ -74,12 +74,14 @@ trait RichTextFeature {
       minSupport: Int = TransmogrifierDefaults.MinSupport,
       cleanText: Boolean = TransmogrifierDefaults.CleanText,
       trackNulls: Boolean = TransmogrifierDefaults.TrackNulls,
-      maxPctCardinality: Double = OpOneHotVectorizer.MaxPctCardinality
+      maxPctCardinality: Double = OpOneHotVectorizer.MaxPctCardinality,
+      cleanTextParams: CleanTextParams = TransmogrifierDefaults.CleanParams
     ): FeatureLike[OPVector] = {
       val vectorizer = new OpTextPivotVectorizer[T]()
 
       f.transformWith[OPVector](
-        stage = vectorizer.setTopK(topK).setMinSupport(minSupport).setCleanText(cleanText)
+        stage = vectorizer.setTopK(topK).setMinSupport(minSupport)
+          .setCleanText(cleanText).setCleanTextParams(cleanTextParams)
           .setTrackNulls(trackNulls).setMaxPctCardinality(maxPctCardinality),
         fs = others
       )
@@ -600,11 +602,12 @@ trait RichTextFeature {
       minSupport: Int,
       trackNulls: Boolean = TransmogrifierDefaults.TrackNulls,
       others: Array[FeatureLike[Email]] = Array.empty,
-      maxPctCardinality: Double = OpOneHotVectorizer.MaxPctCardinality
+      maxPctCardinality: Double = OpOneHotVectorizer.MaxPctCardinality,
+      cleanTextParams: CleanTextParams = CleanTextParams(true, false)
     ): FeatureLike[OPVector] = {
       val domains = (f +: others).map(_.map[PickList](new EmailDomainToPickList))
       domains.head.pivot(others = domains.tail, topK = topK, minSupport = minSupport, cleanText = cleanText,
-        trackNulls = trackNulls, maxPctCardinality = maxPctCardinality
+        trackNulls = trackNulls, maxPctCardinality = maxPctCardinality, cleanTextParams = cleanTextParams
       )
     }
 

--- a/core/src/main/scala/com/salesforce/op/stages/impl/feature/OpOneHotVectorizer.scala
+++ b/core/src/main/scala/com/salesforce/op/stages/impl/feature/OpOneHotVectorizer.scala
@@ -183,7 +183,8 @@ class OpSetVectorizer[T <: OPSet[_]]
       shouldCleanText = shouldCleanText,
       shouldTrackNulls = shouldTrackNulls,
       operationName = operationName,
-      uid = uid)
+      uid = uid
+    ).setCleanTextParams($(cleanTextParams))
 
 }
 
@@ -231,7 +232,8 @@ class OpTextPivotVectorizer[T <: Text]
       shouldCleanText = shouldCleanText,
       shouldTrackNulls = shouldTrackNulls,
       operationName = operationName,
-      uid = uid)
+      uid = uid
+    ).setCleanTextParams($(cleanTextParams))
 }
 
 final class OpTextPivotVectorizerModel[T <: Text] private[op]

--- a/core/src/main/scala/com/salesforce/op/stages/impl/feature/TextMapPivotVectorizer.scala
+++ b/core/src/main/scala/com/salesforce/op/stages/impl/feature/TextMapPivotVectorizer.scala
@@ -86,7 +86,8 @@ class TextMapPivotVectorizer[T <: OPMap[String]]
       trackNulls = $(trackNulls),
       operationName = operationName,
       uid = uid
-    )
+    ).setCleanTextParams($(cleanTextParams))
+
   }
 }
 

--- a/core/src/test/scala/com/salesforce/op/stages/impl/feature/EmailVectorizerTest.scala
+++ b/core/src/test/scala/com/salesforce/op/stages/impl/feature/EmailVectorizerTest.scala
@@ -210,7 +210,7 @@ class EmailVectorizerTest
 
   it should "not remove punctuations by default from the domain when vectorizing Emails" in {
     val (ds2, f2) = TestFeatureBuilder(emails)
-    val vectorized = f2.vectorize(topK = TopK, minSupport = MinSupport, cleanText = CleanText, trackNulls = true)
+    val vectorized = f2.vectorize(topK = TopK, minSupport = MinSupport, cleanText = CleanText, trackNulls = false)
     val transformed = new OpWorkflow().setResultFeatures(vectorized).transform(ds2)
     val metadata = transformed.schema(vectorized.name).metadata.getMetadataArray(OpVectorMetadata.ColumnsKey)
     val actualIndicatorValues = metadata.map(_.getString(OpVectorColumnMetadata.IndicatorValueKey))

--- a/utils/src/main/scala/com/salesforce/op/utils/text/TextUtils.scala
+++ b/utils/src/main/scala/com/salesforce/op/utils/text/TextUtils.scala
@@ -30,23 +30,47 @@
 
 package com.salesforce.op.utils.text
 
+import org.json4s.DefaultFormats
+import org.json4s.jackson.Serialization
+
 
 case object TextUtils {
+  val defaultCleanParams = CleanTextParams(ignoreCase = true, cleanPunctuations = true)
 
-  def cleanOptString(raw: Option[String], splitOn: String = " "): Option[String] =
-    raw.map(t => cleanString(t, splitOn))
+  def cleanOptString(raw: Option[String], splitOn: String = " ",
+    cleanTextParams: CleanTextParams = defaultCleanParams): Option[String] =
+    raw.map(t => cleanString(t, splitOn, cleanTextParams))
 
-  def cleanString(raw: String, splitOn: String = " "): String = {
-    raw
-      .toLowerCase
+  def cleanString(raw: String, splitOn: String = " ", cleanTextParams: CleanTextParams = defaultCleanParams): String = {
+    val l = if (cleanTextParams.ignoreCase) raw.toLowerCase else raw
+    if (cleanTextParams.cleanPunctuations) {
+      l
       .replaceAll("[\\p{Punct}]", splitOn)
-      .replaceAll(s"$splitOn+", s"$splitOn")
-      .split(splitOn)
-      .map(w => w.capitalize)
-      .mkString("")
+        .replaceAll(s"$splitOn+", s"$splitOn")
+        .split(splitOn)
+        .map(w => w.capitalize)
+        .mkString("")
+    }
+    else {
+      l
+    }
   }
 
   def concat(l: String, r: String, separator: String): String =
     if (l.isEmpty) r else if (r.isEmpty) l else s"$l$separator$r"
 
+}
+
+case class CleanTextParams(ignoreCase: Boolean, cleanPunctuations: Boolean)
+
+object CleanTextParams {
+  def jsonEncode(value: CleanTextParams): String = {
+    implicit val formats = DefaultFormats
+    Serialization.write(value)
+  }
+
+  def jsonDecode(json: String): CleanTextParams = {
+    implicit val formats = DefaultFormats
+    Serialization.read[CleanTextParams](json)
+  }
 }

--- a/utils/src/test/scala/com/salesforce/op/utils/text/TextUtilsTest.scala
+++ b/utils/src/test/scala/com/salesforce/op/utils/text/TextUtilsTest.scala
@@ -53,12 +53,18 @@ class TextUtilsTest extends FlatSpec with TestCommon {
     TextUtils.concat("", "", ",") shouldBe ""
   }
 
-  it should "clean a string with special chars" in {
+  it should "clean a string with special chars by default" in {
     TextUtils.cleanString("A string wit#h %bad pun&ctuation mark<=>s") shouldBe "AStringWitHBadPunCtuationMarkS"
   }
 
-  it should "clean an Option(string) with special chars" in {
+  it should "clean an Option(string) with special chars by default" in {
     val testString: Option[String] = Some("A string wit#h %bad pun&ctuation mark<=>s")
     TextUtils.cleanOptString(testString) shouldBe Some("AStringWitHBadPunCtuationMarkS")
+  }
+
+  it should "ignore the case and not clean a string with punctuations " +
+    "when cleanPunctuations=true & ignoreCase=true" in {
+    val actual = TextUtils.cleanString("Salesforce.com", cleanTextParams = CleanTextParams(true, false))
+    actual shouldBe "salesforce.com"
   }
 }


### PR DESCRIPTION
**Related issues**
Users want to see the text of the email domain as an indicator variable, the way a true email address does (including punctuation)
EG: Today, email field marc.benioff@salesforce.com will have a column with indicator value salesforcecom, because the text of the domain name has been cleaned. Instead we would like it say "salesforce.com"

**Describe the proposed solution**
Added a `case class CleanTextParams(ignoreCase: Boolean, cleanPunctuations: Boolean)` which will give us more control on how the text is going to cleaned in general. In future more parameters can be added. 
By default across all features, this would be `CleanTextParams(true, true)` except for email/emailMap features, in which it would be `CleanTextParams(true, false)`


