### PR TITLE
Skip serializing cardinality estimates in FeatureDistributions

### DIFF
--- a/core/src/main/scala/com/salesforce/op/filters/FeatureDistribution.scala
+++ b/core/src/main/scala/com/salesforce/op/filters/FeatureDistribution.scala
@@ -40,7 +40,7 @@ import com.twitter.algebird._
 import com.twitter.algebird.Operators._
 import org.apache.spark.mllib.feature.HashingTF
 import org.json4s.jackson.Serialization
-import org.json4s.{DefaultFormats, Formats}
+import org.json4s.{DefaultFormats, FieldSerializer, Formats}
 
 import scala.util.Try
 
@@ -192,8 +192,13 @@ object FeatureDistribution {
     override def plus(l: FeatureDistribution, r: FeatureDistribution): FeatureDistribution = l.reduce(r)
   }
 
+  val FeatureDistributionSerializer = FieldSerializer[FeatureDistribution](
+    FieldSerializer.ignore("cardEstimate")
+  )
+
   implicit val formats: Formats = DefaultFormats +
-    EnumEntrySerializer.json4s[FeatureDistributionType](FeatureDistributionType)
+    EnumEntrySerializer.json4s[FeatureDistributionType](FeatureDistributionType) +
+    FeatureDistributionSerializer
 
   /**
    * Feature distributions to json

--- a/core/src/main/scala/com/salesforce/op/filters/FeatureDistribution.scala
+++ b/core/src/main/scala/com/salesforce/op/filters/FeatureDistribution.scala
@@ -282,11 +282,11 @@ object FeatureDistribution {
    * @return TextStats object containing a Map from a value to its frequency (histogram)
    */
   private def cardinalityValues(values: ProcessedSeq): TextStats = {
-    val population = values match {
-      case Left(seq) => seq
-      case Right(seq) => seq.map(_.toString)
-    }
-    TextStats(population.groupBy(identity).map{case (key, value) => (key, value.size)})
+    TextStats(countStringValues(values.left.getOrElse(values.right.get)))
+  }
+
+  private def countStringValues[T](seq: Seq[T]): Map[String, Int] = {
+    seq.groupBy(identity).map { case (k, valSeq) => k.toString -> valSeq.size }
   }
 
   /**

--- a/core/src/test/scala/com/salesforce/op/ModelInsightsTest.scala
+++ b/core/src/test/scala/com/salesforce/op/ModelInsightsTest.scala
@@ -31,30 +31,28 @@
 package com.salesforce.op
 
 import com.salesforce.op.evaluators._
-import com.salesforce.op.features.types._
+import com.salesforce.op.features.types.{Real, _}
 import com.salesforce.op.features.{Feature, FeatureDistributionType, FeatureLike}
 import com.salesforce.op.filters._
 import com.salesforce.op.stages.impl.classification._
+import com.salesforce.op.stages.impl.feature.{CombinationStrategy, TextStats}
 import com.salesforce.op.stages.impl.preparators._
 import com.salesforce.op.stages.impl.regression.{OpLinearRegression, OpXGBoostRegressor, RegressionModelSelector}
 import com.salesforce.op.stages.impl.selector.ModelSelectorNames.EstimatorType
-import com.salesforce.op.stages.impl.selector.{SelectedModelCombiner, SelectedCombinerModel, SelectedModel}
 import com.salesforce.op.stages.impl.selector.ValidationType._
+import com.salesforce.op.stages.impl.selector.{SelectedCombinerModel, SelectedModel, SelectedModelCombiner}
 import com.salesforce.op.stages.impl.tuning.{DataCutter, DataSplitter}
 import com.salesforce.op.test.{PassengerSparkFixtureTest, TestFeatureBuilder}
 import com.salesforce.op.testkit.RandomReal
 import com.salesforce.op.utils.spark.{OpVectorColumnMetadata, OpVectorMetadata}
+import com.twitter.algebird.Moments
 import org.apache.spark.ml.param.ParamMap
 import org.apache.spark.ml.tuning.ParamGridBuilder
+import org.apache.spark.sql.DataFrame
+import org.apache.spark.sql.functions._
 import org.junit.runner.RunWith
-import com.salesforce.op.features.types.Real
-import com.salesforce.op.stages.impl.feature.{CombinationStrategy, TextStats}
-import com.twitter.algebird.Moments
-import org.apache.spark.sql.{DataFrame, Dataset}
-import org.scalactic.Equality
 import org.scalatest.FlatSpec
 import org.scalatest.junit.JUnitRunner
-import org.apache.spark.sql.functions._
 
 import scala.util.{Failure, Success}
 
@@ -175,7 +173,7 @@ class ModelInsightsTest extends FlatSpec with PassengerSparkFixtureTest with Dou
     val insights = model.modelInsights(inputModel)
     val featureMoments = insights.features.map(f => f.featureName -> f.distributions.head.moments.get).toMap
     val featureCardinality = insights.features.map(f => f.featureName -> f.distributions.head.cardEstimate.get).toMap
-    return (featureMoments, featureCardinality)
+    featureMoments -> featureCardinality
   }
 
   val params = new OpParams()
@@ -795,10 +793,9 @@ class ModelInsightsTest extends FlatSpec with PassengerSparkFixtureTest with Dou
     }
     }
 
-    cardinality.foreach { case (featureName, value) => {
-      val actualUniques = df.select(featureName).as[Double].collect().toSet
-      value.valueCounts.keySet.map(_.toDouble).subsetOf(actualUniques) shouldBe true
-    }
+    cardinality.foreach { case (featureName, value) =>
+        val actualUniques = df.select(featureName).as[Double].distinct.collect.toSet
+        actualUniques should contain (value.valueCounts.keySet)
     }
   }
 

--- a/core/src/test/scala/com/salesforce/op/ModelInsightsTest.scala
+++ b/core/src/test/scala/com/salesforce/op/ModelInsightsTest.scala
@@ -795,7 +795,7 @@ class ModelInsightsTest extends FlatSpec with PassengerSparkFixtureTest with Dou
 
     cardinality.foreach { case (featureName, value) =>
         val actualUniques = df.select(featureName).as[Double].distinct.collect.toSet
-        actualUniques should contain (value.valueCounts.keySet)
+        actualUniques should contain allElementsOf value.valueCounts.keySet.map(_.toDouble)
     }
   }
 

--- a/core/src/test/scala/com/salesforce/op/ModelInsightsTest.scala
+++ b/core/src/test/scala/com/salesforce/op/ModelInsightsTest.scala
@@ -166,15 +166,16 @@ class ModelInsightsTest extends FlatSpec with PassengerSparkFixtureTest with Dou
     return Array(descaledsmallCoeff, originalsmallCoeff, descaledbigCoeff, orginalbigCoeff)
   }
 
-  def getFeatureMoments(inputModel: FeatureLike[Prediction],
-    DF: DataFrame): Map[String, Moments] = {
+  def getFeatureMomentsAndCard(inputModel: FeatureLike[Prediction],
+    DF: DataFrame): (Map[String, Moments], Map[String, TextStats]) = {
     lazy val workFlow = new OpWorkflow().setResultFeatures(inputModel).setInputDataset(DF)
     lazy val dummyReader = workFlow.getReader()
     lazy val workFlowRFF = workFlow.withRawFeatureFilter(Some(dummyReader), None)
     lazy val model = workFlowRFF.train()
     val insights = model.modelInsights(inputModel)
     val featureMoments = insights.features.map(f => f.featureName -> f.distributions.head.moments.get).toMap
-    return featureMoments
+    val featureCardinality = insights.features.map(f => f.featureName -> f.distributions.head.cardEstimate.get).toMap
+    return (featureMoments, featureCardinality)
   }
 
   val params = new OpParams()
@@ -782,7 +783,7 @@ class ModelInsightsTest extends FlatSpec with PassengerSparkFixtureTest with Dou
     val df = linRegDF._3
     val meanTol = 0.01
     val varTol = 0.01
-    val moments = getFeatureMoments(standardizedLinpred, linRegDF._3)
+    val (moments, cardinality) = getFeatureMomentsAndCard(standardizedLinpred, linRegDF._3)
 
     // Go through each feature and check that the mean, variance, and unique counts match the data
     moments.foreach { case (featureName, value) => {
@@ -791,6 +792,12 @@ class ModelInsightsTest extends FlatSpec with PassengerSparkFixtureTest with Dou
         df.select(avg(featureName), variance(featureName)).as[(Double, Double)].collect().head
       math.abs((value.mean - expectedMean) / expectedMean) < meanTol shouldBe true
       math.abs((value.variance - expectedVariance) / expectedVariance) < varTol shouldBe true
+    }
+    }
+
+    cardinality.foreach { case (featureName, value) => {
+      val actualUniques = df.select(featureName).as[Double].collect().toSet
+      value.valueCounts.keySet.map(_.toDouble).subsetOf(actualUniques) shouldBe true
     }
     }
   }

--- a/core/src/test/scala/com/salesforce/op/filters/FeatureDistributionTest.scala
+++ b/core/src/test/scala/com/salesforce/op/filters/FeatureDistributionTest.scala
@@ -247,6 +247,6 @@ class FeatureDistributionTest extends FlatSpec with PassengerSparkFixtureTest wi
       Array.empty, Some(Moments(1.0)), Some(TextStats(Map("foo" -> 1, "bar" ->2))),
       FeatureDistributionType.Scoring)
 
-    FeatureDistribution.toJson(Seq(fd1)) shouldNot contain theSameElementsAs "cardEstimate"
+    FeatureDistribution.toJson(Seq(fd1)) shouldNot include ("cardEstimate")
   }
 }

--- a/core/src/test/scala/com/salesforce/op/filters/FeatureDistributionTest.scala
+++ b/core/src/test/scala/com/salesforce/op/filters/FeatureDistributionTest.scala
@@ -34,7 +34,10 @@ import com.salesforce.op.features.{FeatureDistributionType, TransientFeature}
 import com.salesforce.op.stages.impl.feature.TextStats
 import com.salesforce.op.test.PassengerSparkFixtureTest
 import com.salesforce.op.testkit.RandomText
+import com.salesforce.op.utils.json.EnumEntrySerializer
 import com.twitter.algebird.Moments
+import org.json4s.DefaultFormats
+import org.json4s.jackson.Serialization
 import org.junit.runner.RunWith
 import org.scalatest.FlatSpec
 import org.scalatest.junit.JUnitRunner
@@ -243,19 +246,20 @@ class FeatureDistributionTest extends FlatSpec with PassengerSparkFixtureTest wi
   }
 
   it should "not serialize cardEstimate field" in {
+    val cardEstimate = "cardEstimate"
     val fd1 = FeatureDistribution("A", None, 10, 1, Array(1, 4, 0, 0, 6),
       Array.empty, Some(Moments(1.0)), Some(TextStats(Map("foo" -> 1, "bar" ->2))),
       FeatureDistributionType.Scoring)
-    val fd2 = FeatureDistribution("A", None, 20, 20, Array(2, 8, 0, 0, 12),
-      Array.empty, None, None, FeatureDistributionType.Scoring)
-    FeatureDistribution.toJson(Seq(fd1, fd2)) shouldNot include ("cardEstimate")
+    val featureDistributions = Seq(fd1, fd1.copy(cardEstimate = None))
 
-    val json =
-      """[{"name":"A","count":10,"nulls":1,"distribution":[1.0,4.0,0.0,0.0,6.0],
-        |"summaryInfo":[],"moments":{"m0":1,"m1":1.0,"m2":0.0,"m3":0.0,"m4":0.0},
-        |"cardEstimate":{"valueCounts":{"foo":1,"bar":2}},"type":"Scoring"},
-        |{"name":"A","count":20,"nulls":20,"distribution":[2.0,8.0,0.0,0.0,12.0],
-        |"summaryInfo":[],"type":"Scoring"}]""".stripMargin
-    FeatureDistribution.fromJson(json) shouldBe Success(Seq(fd1, fd2))
+    FeatureDistribution.toJson(featureDistributions) shouldNot include (cardEstimate)
+
+    // deserialization from json with and without cardEstimate works
+    val jsonWithCardEstimate = Serialization.write(featureDistributions)(DefaultFormats +
+      EnumEntrySerializer.json4s[FeatureDistributionType](FeatureDistributionType))
+    jsonWithCardEstimate should fullyMatch regex Seq(cardEstimate).mkString(".*", ".*", ".*")
+    jsonWithCardEstimate shouldNot fullyMatch regex Seq.fill(2)(cardEstimate).mkString(".*", ".*", ".*")
+
+    FeatureDistribution.fromJson(jsonWithCardEstimate) shouldBe Success(featureDistributions)
   }
 }

--- a/core/src/test/scala/com/salesforce/op/filters/FeatureDistributionTest.scala
+++ b/core/src/test/scala/com/salesforce/op/filters/FeatureDistributionTest.scala
@@ -253,11 +253,9 @@ class FeatureDistributionTest extends FlatSpec with PassengerSparkFixtureTest wi
     val json =
       """[{"name":"A","count":10,"nulls":1,"distribution":[1.0,4.0,0.0,0.0,6.0],
         |"summaryInfo":[],"moments":{"m0":1,"m1":1.0,"m2":0.0,"m3":0.0,"m4":0.0},
-        |"cardEstimate":{"valueCounts":{"foo":1,"bar":2}},"type":"Scoring"}]
-        |""".stripMargin
-    FeatureDistribution.fromJson(json) match {
-      case Success(r) => r shouldBe Seq(fd1)
-      case Failure(e) => fail(e)
-    }
+        |"cardEstimate":{"valueCounts":{"foo":1,"bar":2}},"type":"Scoring"},
+        |{"name":"A","count":20,"nulls":20,"distribution":[2.0,8.0,0.0,0.0,12.0],
+        |"summaryInfo":[],"type":"Scoring"}]""".stripMargin
+    FeatureDistribution.fromJson(json) shouldBe Success(Seq(fd1, fd2))
   }
 }

--- a/core/src/test/scala/com/salesforce/op/filters/FeatureDistributionTest.scala
+++ b/core/src/test/scala/com/salesforce/op/filters/FeatureDistributionTest.scala
@@ -75,7 +75,9 @@ class FeatureDistributionTest extends FlatSpec with PassengerSparkFixtureTest wi
     distribs(3).distribution.sum shouldBe 0
     distribs(4).distribution.sum shouldBe 3
     distribs(4).summaryInfo.length shouldBe bins
+    distribs(2).cardEstimate.get shouldBe TextStats(Map("male" -> 1, "female" -> 1))
     distribs(2).moments.get shouldBe Moments(2, 5.0, 2.0, 0.0, 2.0)
+    distribs(4).cardEstimate.get shouldBe TextStats(Map("5.0" -> 1, "1.0" -> 1, "3.0" -> 1))
     distribs(4).moments.get shouldBe Moments(3, 3.0, 8.0, 0.0, 32.0)
   }
 
@@ -200,7 +202,8 @@ class FeatureDistributionTest extends FlatSpec with PassengerSparkFixtureTest wi
   it should "marshall to/from json" in {
     val fd1 = FeatureDistribution("A", None, 10, 1, Array(1, 4, 0, 0, 6), Array.empty)
     val fd2 = FeatureDistribution("A", None, 10, 1, Array(1, 4, 0, 0, 6),
-      Array.empty, Some(Moments(1.0)), FeatureDistributionType.Scoring)
+      Array.empty, Some(Moments(1.0)), Some(TextStats(Map("foo" -> 1, "bar" ->2))),
+      FeatureDistributionType.Scoring)
     val json = FeatureDistribution.toJson(Array(fd1, fd2))
     FeatureDistribution.fromJson(json) match {
       case Success(r) => r shouldBe Seq(fd1, fd2)
@@ -210,7 +213,7 @@ class FeatureDistributionTest extends FlatSpec with PassengerSparkFixtureTest wi
 
   it should "marshall to/from json with default vector args" in {
     val fd1 = FeatureDistribution("A", None, 10, 1, Array(1, 4, 0, 0, 6),
-      Array.empty, None, FeatureDistributionType.Scoring)
+      Array.empty, None, None, FeatureDistributionType.Scoring)
     val fd2 = FeatureDistribution("A", Some("X"), 20, 20, Array(2, 8, 0, 0, 12), Array.empty)
     val json =
       """[{"name":"A","count":10,"nulls":1,"distribution":[1.0,4.0,0.0,0.0,6.0],"type":"Scoring"},

--- a/core/src/test/scala/com/salesforce/op/filters/FeatureDistributionTest.scala
+++ b/core/src/test/scala/com/salesforce/op/filters/FeatureDistributionTest.scala
@@ -246,7 +246,9 @@ class FeatureDistributionTest extends FlatSpec with PassengerSparkFixtureTest wi
     val fd1 = FeatureDistribution("A", None, 10, 1, Array(1, 4, 0, 0, 6),
       Array.empty, Some(Moments(1.0)), Some(TextStats(Map("foo" -> 1, "bar" ->2))),
       FeatureDistributionType.Scoring)
-    FeatureDistribution.toJson(Seq(fd1)) shouldNot include ("cardEstimate")
+    val fd2 = FeatureDistribution("A", None, 20, 20, Array(2, 8, 0, 0, 12),
+      Array.empty, None, None, FeatureDistributionType.Scoring)
+    FeatureDistribution.toJson(Seq(fd1, fd2)) shouldNot include ("cardEstimate")
 
     val json =
       """[{"name":"A","count":10,"nulls":1,"distribution":[1.0,4.0,0.0,0.0,6.0],

--- a/core/src/test/scala/com/salesforce/op/filters/FeatureDistributionTest.scala
+++ b/core/src/test/scala/com/salesforce/op/filters/FeatureDistributionTest.scala
@@ -202,7 +202,7 @@ class FeatureDistributionTest extends FlatSpec with PassengerSparkFixtureTest wi
   it should "marshall to/from json" in {
     val fd1 = FeatureDistribution("A", None, 10, 1, Array(1, 4, 0, 0, 6), Array.empty)
     val fd2 = FeatureDistribution("A", None, 10, 1, Array(1, 4, 0, 0, 6),
-      Array.empty, Some(Moments(1.0)), Some(TextStats(Map("foo" -> 1, "bar" ->2))),
+      Array.empty, Some(Moments(1.0)), Option.empty,
       FeatureDistributionType.Scoring)
     val json = FeatureDistribution.toJson(Array(fd1, fd2))
     FeatureDistribution.fromJson(json) match {
@@ -240,5 +240,13 @@ class FeatureDistributionTest extends FlatSpec with PassengerSparkFixtureTest wi
 
     intercept[IllegalArgumentException](fd1.jsDivergence(fd1.copy(name = "boo"))) should have message
       "requirement failed: Name must match to compare or combine feature distributions: A != boo"
+  }
+
+  it should "not serialize cardEstimate field" in {
+    val fd1 = FeatureDistribution("A", None, 10, 1, Array(1, 4, 0, 0, 6),
+      Array.empty, Some(Moments(1.0)), Some(TextStats(Map("foo" -> 1, "bar" ->2))),
+      FeatureDistributionType.Scoring)
+
+    FeatureDistribution.toJson(Seq(fd1)) shouldNot contain theSameElementsAs "cardEstimate"
   }
 }

--- a/core/src/test/scala/com/salesforce/op/filters/FeatureDistributionTest.scala
+++ b/core/src/test/scala/com/salesforce/op/filters/FeatureDistributionTest.scala
@@ -246,7 +246,16 @@ class FeatureDistributionTest extends FlatSpec with PassengerSparkFixtureTest wi
     val fd1 = FeatureDistribution("A", None, 10, 1, Array(1, 4, 0, 0, 6),
       Array.empty, Some(Moments(1.0)), Some(TextStats(Map("foo" -> 1, "bar" ->2))),
       FeatureDistributionType.Scoring)
-
     FeatureDistribution.toJson(Seq(fd1)) shouldNot include ("cardEstimate")
+
+    val json =
+      """[{"name":"A","count":10,"nulls":1,"distribution":[1.0,4.0,0.0,0.0,6.0],
+        |"summaryInfo":[],"moments":{"m0":1,"m1":1.0,"m2":0.0,"m3":0.0,"m4":0.0},
+        |"cardEstimate":{"valueCounts":{"foo":1,"bar":2}},"type":"Scoring"}]
+        |""".stripMargin
+    FeatureDistribution.fromJson(json) match {
+      case Success(r) => r shouldBe Seq(fd1)
+      case Failure(e) => fail(e)
+    }
   }
 }

--- a/core/src/test/scala/com/salesforce/op/filters/FiltersTestData.scala
+++ b/core/src/test/scala/com/salesforce/op/filters/FiltersTestData.scala
@@ -47,16 +47,16 @@ trait FiltersTestData {
 
   protected val scoreSummaries = Seq(
     FeatureDistribution("A", None, 10, 8, Array(1, 4, 0, 0, 6), Array.empty,
-      None, FeatureDistributionType.Scoring),
+      None, None, FeatureDistributionType.Scoring),
     FeatureDistribution("B", None, 20, 20, Array(2, 8, 0, 0, 12), Array.empty,
-      None, FeatureDistributionType.Scoring),
+      None, None, FeatureDistributionType.Scoring),
     FeatureDistribution("C", Some("1"), 10, 1, Array(0, 0, 10, 10, 0),
-      Array.empty, None, FeatureDistributionType.Scoring),
+      Array.empty, None, None, FeatureDistributionType.Scoring),
     FeatureDistribution("C", Some("2"), 20, 19, Array(2, 8, 0, 0, 12),
-      Array.empty, None, FeatureDistributionType.Scoring),
+      Array.empty, None, None, FeatureDistributionType.Scoring),
     FeatureDistribution("D", Some("1"), 0, 0, Array(0, 0, 0, 0, 0), Array.empty,
-      None, FeatureDistributionType.Scoring),
+      None, None, FeatureDistributionType.Scoring),
     FeatureDistribution("D", Some("2"), 0, 0, Array(0, 0, 0, 0, 0), Array.empty,
-      None, FeatureDistributionType.Scoring)
+      None, None, FeatureDistributionType.Scoring)
   )
 }


### PR DESCRIPTION
**Related issues**
Tokens of text field are printing out while internal usage. 

**Describe the proposed solution**
Ignore cardinality field in serialization

**Additional context**
Previous PR #420 & #438 