### PR TITLE
Fixed SmartTextMapVectorizer counting empty string entries

### DIFF
--- a/core/src/main/scala/com/salesforce/op/stages/impl/feature/SmartTextMapVectorizer.scala
+++ b/core/src/main/scala/com/salesforce/op/stages/impl/feature/SmartTextMapVectorizer.scala
@@ -72,7 +72,9 @@ class SmartTextMapVectorizer[T <: OPMap[String]]
     textMap: T#Value, shouldCleanKeys: Boolean, shouldCleanValues: Boolean
   ): TextMapStats = {
     val keyValueCounts = textMap.map{ case (k, v) =>
-      cleanTextFn(k, shouldCleanKeys) -> TextStats(Map(cleanTextFn(v, shouldCleanValues) -> 1))
+      cleanTextFn(k, shouldCleanKeys) -> TextStats(
+        if (v.isEmpty) Map.empty[String, Int] else Map(cleanTextFn(v, shouldCleanValues) -> 1)
+      )
     }
     TextMapStats(keyValueCounts)
   }

--- a/core/src/test/scala/com/salesforce/op/stages/impl/feature/SmartTextMapVectorizerTest.scala
+++ b/core/src/test/scala/com/salesforce/op/stages/impl/feature/SmartTextMapVectorizerTest.scala
@@ -444,12 +444,7 @@ class SmartTextMapVectorizerTest
 
     result foreach { case (vec1, vec2, vec3) =>
       vec2 shouldBe vec3
-      // NOTE: vec1 will not be exactly equal to vec2 or vec3 because only empty _maps_ are treated as null
-      // Null entries for the categorical key in a map will instead get matched to the "OTHER" column in the vector
-      // However, the overall contribution from this row as a feature should stay the same regardless if the info
-      // comes in a map or as its column, hence the following checks:
-      Vectors.norm(vec1.value, 1) shouldBe Vectors.norm(vec2.value, 1)
-      Vectors.norm(vec1.value, 1) shouldBe Vectors.norm(vec3.value, 1)
+      vec1 shouldBe vec2
     }
   }
 

--- a/core/src/test/scala/com/salesforce/op/stages/impl/feature/SmartTextMapVectorizerTest.scala
+++ b/core/src/test/scala/com/salesforce/op/stages/impl/feature/SmartTextMapVectorizerTest.scala
@@ -32,14 +32,14 @@ package com.salesforce.op.stages.impl.feature
 
 import com.salesforce.op._
 import com.salesforce.op.features.Feature
+import com.salesforce.op.features.types._
 import com.salesforce.op.stages.base.sequence.SequenceModel
-import com.salesforce.op.test.{OpEstimatorSpec, TestFeatureBuilder, TestSparkContext}
-import com.salesforce.op.utils.spark.{OpVectorColumnMetadata, OpVectorMetadata}
+import com.salesforce.op.test.{OpEstimatorSpec, TestFeatureBuilder}
+import com.salesforce.op.utils.spark.OpVectorMetadata
 import com.salesforce.op.utils.spark.RichDataset._
 import org.apache.spark.ml.linalg.Vectors
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
-import com.salesforce.op.features.types._
 
 @RunWith(classOf[JUnitRunner])
 class SmartTextMapVectorizerTest
@@ -400,18 +400,16 @@ class SmartTextMapVectorizerTest
   }
 
   it should "treat null entries the same way as SmartTextVectorizer (i.e. ignoring them)" in {
-    // Note that if nulls are treated as their own category, the following feature has three categories
+    // NOTE: If nulls are treated as their own category, the following feature has three categories
     // while the maxCardinality is set for 2 for each estimator in the test
     val categoricalText: Seq[Text] = Seq("red", "blue", "blue").toText ++ Seq(Text.empty, Text.empty)
     val nonCategoricalText: Seq[Text] =
       Seq("hello, how are you", "good yourself?", "not bad").toText ++ Seq(Text.empty, Text.empty)
     val textMap: Seq[TextMap] = categoricalText.zip(nonCategoricalText) map { case (categorical, nonCategorical) =>
-      TextMap(Map("categorical" -> categorical.value.getOrElse(""),
-        "nonCategorical" -> nonCategorical.value.getOrElse("")))
+      TextMap(Map("f1" -> categorical.value.getOrElse(""), "f2" -> nonCategorical.value.getOrElse("")))
     }
     val textAreaMap: Seq[TextMap] = categoricalText.zip(nonCategoricalText) map { case (categorical, nonCategorical) =>
-      TextAreaMap(Map("categorical" -> categorical.value.getOrElse(""),
-        "nonCategorical" -> nonCategorical.value.getOrElse("")))
+      TextAreaMap(Map("f1" -> categorical.value.getOrElse(""), "f2" -> nonCategorical.value.getOrElse("")))
     }
     val (data, features) = TestFeatureBuilder(categoricalText, nonCategoricalText, textMap, textAreaMap)
     val (f_categorical, f_nonCategorical, f_textMap, f_textAreaMap) = (
@@ -432,33 +430,26 @@ class SmartTextMapVectorizerTest
       .setMaxCardinality(2).setNumFeatures(4).setMinSupport(1).setTopK(2).setPrependFeatureName(true)
       .setCleanKeys(false)
       .setInput(f_textAreaMap).getOutput()
-
     val transformed = new OpWorkflow().setResultFeatures(
       textVectorized, textMapVectorized, textAreaMapVectorized).transform(data)
     val result = transformed.collect(textVectorized, textMapVectorized, textAreaMapVectorized)
 
+    val expectedNominalOutput = Array.fill(4)(true) ++ Array.fill(4)(false) :+ true
     val field = transformed.schema(textVectorized.name)
-      assertNominal(field, Array.fill(4)(true) ++ Array.fill(4)(false) :+ true, transformed.collect(textVectorized))
-    val meta = OpVectorMetadata(transformed.schema(textVectorized.name))
-
-    Seq((textMapVectorized, f_textMap), (textAreaMapVectorized, f_textAreaMap)) foreach { case (output, input) =>
+      assertNominal(field, expectedNominalOutput, transformed.collect(textVectorized))
+    Seq(textMapVectorized, textAreaMapVectorized) foreach { output =>
       val fieldMap = transformed.schema(output.name)
-      assertNominal(fieldMap, Array.fill(4)(true) ++ Array.fill(4)(false) :+ true, transformed.collect(output))
-      val mapMeta = OpVectorMetadata(transformed.schema(output.name))
-      mapMeta.history.keys shouldBe Set(input.name)
-      mapMeta.columns.length shouldBe meta.columns.length
-
-      mapMeta.columns.zip(meta.columns).foreach { case (m, f) =>
-        m.parentFeatureName shouldBe Array(input.name)
-        m.parentFeatureType shouldBe Array(input.typeName)
-        m.grouping shouldBe f.grouping
-        m.indicatorValue shouldBe f.indicatorValue
-      }
+      assertNominal(fieldMap, expectedNominalOutput, transformed.collect(output))
     }
 
-    result.foreach { case (vec1, vec2, vec3) =>
-      vec1 shouldBe vec2
+    result foreach { case (vec1, vec2, vec3) =>
       vec2 shouldBe vec3
+      // NOTE: vec1 will not be exactly equal to vec2 or vec3 because only empty _maps_ are treated as null
+      // Null entries for the categorical key in a map will instead get matched to the "OTHER" column in the vector
+      // However, the overall contribution from this row as a feature should stay the same regardless if the info
+      // comes in a map or as its column, hence the following checks:
+      Vectors.norm(vec1.value, 1) shouldBe Vectors.norm(vec2.value, 1)
+      Vectors.norm(vec1.value, 1) shouldBe Vectors.norm(vec3.value, 1)
     }
   }
 

--- a/core/src/test/scala/com/salesforce/op/stages/impl/feature/TextMapPivotVectorizerTest.scala
+++ b/core/src/test/scala/com/salesforce/op/stages/impl/feature/TextMapPivotVectorizerTest.scala
@@ -66,14 +66,6 @@ class TextMapPivotVectorizerTest
     ).map(v => v._1.toTextMap -> v._2.toTextMap)
   )
 
-  lazy val (dataSetEmptyStrings, _, _) = TestFeatureBuilder(top.name, bot.name,
-    Seq(
-      (Map("a" -> "d", "b" -> "d"), Map("x" -> "")),
-      (Map("a" -> "e", "b" -> ""), Map[String, String]()),
-      (Map("a" -> ""), Map[String, String]())
-    ).map(v => v._1.toTextMap -> v._2.toTextMap)
-  )
-
   lazy val (dataSetAllEmpty, _, _) = TestFeatureBuilder(top.name, bot.name,
     Seq(
       (Map[String, String](), Map[String, String]()),
@@ -442,22 +434,4 @@ class TextMapPivotVectorizerTest
     result shouldBe expected
   }
 
-  it should "treat present but empty string entries as nulls" in {
-    val newVectorizer = new TextMapPivotVectorizer[TextMap]().setInput(top, bot)
-      .setCleanKeys(true).setMinSupport(0).setTopK(10).setTrackNulls(false)
-    val expected = {
-      val fitted = newVectorizer.setCleanText(true).setTrackNulls(true).setMinSupport(0).fit(dataSetEmpty)
-      val transformed = fitted.transform(dataSetEmpty)
-      transformed.collect(fitted.getOutput())
-    }
-
-    val fitted = newVectorizer.setCleanText(true).setTrackNulls(true).setMinSupport(0).fit(dataSetEmptyStrings)
-    val transformed = fitted.transform(dataSetEmptyStrings)
-    val vectorMetadata = fitted.getMetadata()
-    log.info(OpVectorMetadata(newVectorizer.getOutputFeatureName, vectorMetadata).toString)
-    val field = transformed.schema(fitted.getOutput().name)
-    val result = transformed.collect(fitted.getOutput())
-    assertNominal(field, Array.fill(expected.head.value.size)(true), result)
-    result shouldBe expected
-  }
 }


### PR DESCRIPTION
**Related issues**
Tangentially related to the name detection changes I've been making as part of my internship (#445 and other deprecated PRs).

**Describe the proposed solution**
Previously, `SmartTextMapVectorizer` would treat empty string values in input maps as their own category. This could lead to edge case behavior where an otherwise categorical input would be treated as non-categorical due to the presence of empty strings (probably unlikely to happen IRL but it has tripped me up in tests for my other work). This PR implements:
- the one-line fix in `SmartTextMapVectorizer` to not count empty strings when determining which input features are categorical
- a test for `SmartTextMapVectorizer` against this behavior
- the one-line fix in `TextMapPivotVectorizer` to treat empty string entries as null values rather than other values