### PR TITLE
Allow TextStats length distribution to be token-based and refactor for testability

### DIFF
--- a/core/src/main/scala/com/salesforce/op/dsl/RichMapFeature.scala
+++ b/core/src/main/scala/com/salesforce/op/dsl/RichMapFeature.scala
@@ -273,6 +273,10 @@ trait RichMapFeature {
      * @param defaultLanguage           default language to assume in case autoDetectLanguage is disabled or
      *                                  failed to make a good enough prediction.
      * @param hashAlgorithm             hash algorithm to use
+     * @param tokenizeForLengths        If true, then the length counts will be lengths of the tokens in the entries.
+     *                                  If false, then the length counts will be the lengths of the entire entries
+     * @param minLengthStdDev           minimum standard deviation of the lengths of tokens in a text field for it to
+     *                                  be hashed instead of ignored
      * @param others                    additional text features
      * @return result feature of type Vector
      */
@@ -298,6 +302,8 @@ trait RichMapFeature {
       hashSpaceStrategy: HashSpaceStrategy = TransmogrifierDefaults.HashSpaceStrategy,
       defaultLanguage: Language = TextTokenizer.DefaultLanguage,
       hashAlgorithm: HashAlgorithm = TransmogrifierDefaults.HashAlgorithm,
+      tokenizeForLengths: Boolean = SmartTextVectorizer.TokenizeForLengths,
+      minLengthStdDev: Double = SmartTextVectorizer.MinTextLengthStdDev,
       others: Array[FeatureLike[TextMap]] = Array.empty
     ): FeatureLike[OPVector] = {
       // scalastyle:on parameter.number
@@ -322,6 +328,8 @@ trait RichMapFeature {
         .setHashSpaceStrategy(hashSpaceStrategy)
         .setHashAlgorithm(hashAlgorithm)
         .setBinaryFreq(binaryFreq)
+        .setTokenizeForLengths(tokenizeForLengths)
+        .setMinLengthStdDev(minLengthStdDev)
         .getOutput()
     }
   }
@@ -418,6 +426,10 @@ trait RichMapFeature {
      * @param defaultLanguage           default language to assume in case autoDetectLanguage is disabled or
      *                                  failed to make a good enough prediction.
      * @param hashAlgorithm             hash algorithm to use
+     * @param tokenizeForLengths        If true, then the length counts will be lengths of the tokens in the entries.
+     *                                  If false, then the length counts will be the lengths of the entire entries
+     * @param minLengthStdDev           minimum standard deviation of the lengths of tokens in a text field for it to
+     *                                  be hashed instead of ignored
      * @param others                    additional text features
      * @return result feature of type Vector
      */
@@ -443,6 +455,8 @@ trait RichMapFeature {
       hashSpaceStrategy: HashSpaceStrategy = TransmogrifierDefaults.HashSpaceStrategy,
       defaultLanguage: Language = TextTokenizer.DefaultLanguage,
       hashAlgorithm: HashAlgorithm = TransmogrifierDefaults.HashAlgorithm,
+      tokenizeForLengths: Boolean = SmartTextVectorizer.TokenizeForLengths,
+      minLengthStdDev: Double = SmartTextVectorizer.MinTextLengthStdDev,
       others: Array[FeatureLike[TextAreaMap]] = Array.empty
     ): FeatureLike[OPVector] = {
       // scalastyle:on parameter.number
@@ -467,6 +481,8 @@ trait RichMapFeature {
         .setHashSpaceStrategy(hashSpaceStrategy)
         .setHashAlgorithm(hashAlgorithm)
         .setBinaryFreq(binaryFreq)
+        .setTokenizeForLengths(tokenizeForLengths)
+        .setMinLengthStdDev(minLengthStdDev)
         .getOutput()
     }
   }

--- a/core/src/main/scala/com/salesforce/op/dsl/RichMapFeature.scala
+++ b/core/src/main/scala/com/salesforce/op/dsl/RichMapFeature.scala
@@ -273,8 +273,8 @@ trait RichMapFeature {
      * @param defaultLanguage           default language to assume in case autoDetectLanguage is disabled or
      *                                  failed to make a good enough prediction.
      * @param hashAlgorithm             hash algorithm to use
-     * @param tokenizeForLengths        If true, then the length counts will be lengths of the tokens in the entries.
-     *                                  If false, then the length counts will be the lengths of the entire entries
+     * @param textLengthType            Method to use for constructing text length distribution in TextStats. Current
+     *                                  options are from the full entry or from the tokens
      * @param minLengthStdDev           minimum standard deviation of the lengths of tokens in a text field for it to
      *                                  be hashed instead of ignored
      * @param others                    additional text features
@@ -302,7 +302,7 @@ trait RichMapFeature {
       hashSpaceStrategy: HashSpaceStrategy = TransmogrifierDefaults.HashSpaceStrategy,
       defaultLanguage: Language = TextTokenizer.DefaultLanguage,
       hashAlgorithm: HashAlgorithm = TransmogrifierDefaults.HashAlgorithm,
-      tokenizeForLengths: Boolean = SmartTextVectorizer.TokenizeForLengths,
+      textLengthType: TextLengthType = SmartTextVectorizer.LengthType,
       minLengthStdDev: Double = SmartTextVectorizer.MinTextLengthStdDev,
       others: Array[FeatureLike[TextMap]] = Array.empty
     ): FeatureLike[OPVector] = {
@@ -328,7 +328,7 @@ trait RichMapFeature {
         .setHashSpaceStrategy(hashSpaceStrategy)
         .setHashAlgorithm(hashAlgorithm)
         .setBinaryFreq(binaryFreq)
-        .setTokenizeForLengths(tokenizeForLengths)
+        .setTextLengthType(textLengthType)
         .setMinLengthStdDev(minLengthStdDev)
         .getOutput()
     }
@@ -455,7 +455,7 @@ trait RichMapFeature {
       hashSpaceStrategy: HashSpaceStrategy = TransmogrifierDefaults.HashSpaceStrategy,
       defaultLanguage: Language = TextTokenizer.DefaultLanguage,
       hashAlgorithm: HashAlgorithm = TransmogrifierDefaults.HashAlgorithm,
-      tokenizeForLengths: Boolean = SmartTextVectorizer.TokenizeForLengths,
+      textLengthType: TextLengthType = SmartTextVectorizer.LengthType,
       minLengthStdDev: Double = SmartTextVectorizer.MinTextLengthStdDev,
       others: Array[FeatureLike[TextAreaMap]] = Array.empty
     ): FeatureLike[OPVector] = {
@@ -481,7 +481,7 @@ trait RichMapFeature {
         .setHashSpaceStrategy(hashSpaceStrategy)
         .setHashAlgorithm(hashAlgorithm)
         .setBinaryFreq(binaryFreq)
-        .setTokenizeForLengths(tokenizeForLengths)
+        .setTextLengthType(textLengthType)
         .setMinLengthStdDev(minLengthStdDev)
         .getOutput()
     }

--- a/core/src/main/scala/com/salesforce/op/dsl/RichTextFeature.scala
+++ b/core/src/main/scala/com/salesforce/op/dsl/RichTextFeature.scala
@@ -211,8 +211,8 @@ trait RichTextFeature {
      * @param defaultLanguage           default language to assume in case autoDetectLanguage is disabled or
      *                                  failed to make a good enough prediction.
      * @param hashAlgorithm             hash algorithm to use
-     * @param tokenizeForLengths        If true, then the length counts will be lengths of the tokens in the entries.
-     *                                  If false, then the length counts will be the lengths of the entire entries
+     * @param textLengthType            Method to use for constructing text length distribution in TextStats. Current
+     *                                  options are from the full entry or from the tokens
      * @param minLengthStdDev           minimum standard deviation of the lengths of tokens in a text field for it to
      *                                  be hashed instead of ignored
      * @param others                    additional text features
@@ -239,7 +239,7 @@ trait RichTextFeature {
       hashSpaceStrategy: HashSpaceStrategy = TransmogrifierDefaults.HashSpaceStrategy,
       defaultLanguage: Language = TextTokenizer.DefaultLanguage,
       hashAlgorithm: HashAlgorithm = TransmogrifierDefaults.HashAlgorithm,
-      tokenizeForLengths: Boolean = SmartTextVectorizer.TokenizeForLengths,
+      textLengthType: TextLengthType = SmartTextVectorizer.LengthType,
       minLengthStdDev: Double = SmartTextVectorizer.MinTextLengthStdDev,
       others: Array[FeatureLike[T]] = Array.empty
     ): FeatureLike[OPVector] = {
@@ -264,7 +264,7 @@ trait RichTextFeature {
         .setHashSpaceStrategy(hashSpaceStrategy)
         .setHashAlgorithm(hashAlgorithm)
         .setBinaryFreq(binaryFreq)
-        .setTokenizeForLengths(tokenizeForLengths)
+        .setTextLengthType(textLengthType)
         .setMinLengthStdDev(minLengthStdDev)
         .getOutput()
     }

--- a/core/src/main/scala/com/salesforce/op/dsl/RichTextFeature.scala
+++ b/core/src/main/scala/com/salesforce/op/dsl/RichTextFeature.scala
@@ -211,6 +211,10 @@ trait RichTextFeature {
      * @param defaultLanguage           default language to assume in case autoDetectLanguage is disabled or
      *                                  failed to make a good enough prediction.
      * @param hashAlgorithm             hash algorithm to use
+     * @param tokenizeForLengths        If true, then the length counts will be lengths of the tokens in the entries.
+     *                                  If false, then the length counts will be the lengths of the entire entries
+     * @param minLengthStdDev           minimum standard deviation of the lengths of tokens in a text field for it to
+     *                                  be hashed instead of ignored
      * @param others                    additional text features
      * @return result feature of type Vector
      */
@@ -235,6 +239,8 @@ trait RichTextFeature {
       hashSpaceStrategy: HashSpaceStrategy = TransmogrifierDefaults.HashSpaceStrategy,
       defaultLanguage: Language = TextTokenizer.DefaultLanguage,
       hashAlgorithm: HashAlgorithm = TransmogrifierDefaults.HashAlgorithm,
+      tokenizeForLengths: Boolean = SmartTextVectorizer.TokenizeForLengths,
+      minLengthStdDev: Double = SmartTextVectorizer.MinTextLengthStdDev,
       others: Array[FeatureLike[T]] = Array.empty
     ): FeatureLike[OPVector] = {
       // scalastyle:on parameter.number
@@ -258,6 +264,8 @@ trait RichTextFeature {
         .setHashSpaceStrategy(hashSpaceStrategy)
         .setHashAlgorithm(hashAlgorithm)
         .setBinaryFreq(binaryFreq)
+        .setTokenizeForLengths(tokenizeForLengths)
+        .setMinLengthStdDev(minLengthStdDev)
         .getOutput()
     }
 

--- a/core/src/main/scala/com/salesforce/op/filters/FeatureDistribution.scala
+++ b/core/src/main/scala/com/salesforce/op/filters/FeatureDistribution.scala
@@ -33,8 +33,7 @@ package com.salesforce.op.filters
 import java.util.Objects
 
 import com.salesforce.op.features.{FeatureDistributionLike, FeatureDistributionType}
-import com.salesforce.op.stages.impl.feature.{HashAlgorithm, Inclusion, NumericBucketizer, TextStats,
-  SmartTextVectorizer}
+import com.salesforce.op.stages.impl.feature.{HashAlgorithm, Inclusion, NumericBucketizer, TextStats}
 import com.salesforce.op.utils.json.EnumEntrySerializer
 import com.twitter.algebird.Monoid._
 import com.twitter.algebird._
@@ -301,10 +300,6 @@ object FeatureDistribution {
       shouldTokenize = tokenizeForLengths,
       maxCardinality = RawFeatureFilter.MaxCardinality)
     )
-  }
-
-  private def countStringValues[T](seq: Seq[T]): Map[String, Long] = {
-    seq.groupBy(identity).map { case (k, valSeq) => k.toString -> valSeq.size.toLong }
   }
 
   /**

--- a/core/src/main/scala/com/salesforce/op/filters/FeatureDistribution.scala
+++ b/core/src/main/scala/com/salesforce/op/filters/FeatureDistribution.scala
@@ -293,8 +293,8 @@ object FeatureDistribution {
       case Left(stringSeq) => stringSeq
       case Right(doubleSeq) => doubleSeq.map(_.toString)
     }
-    stringVals.foldLeft(TextStats.empty)((acc, el) => acc + SmartTextVectorizer.computeTextStats(
-      Option(el),
+    stringVals.foldLeft(TextStats.empty)((acc, el) => acc + TextStats.textStatsFromString(
+      textString = el,
       shouldCleanText = true,
       shouldTokenize = tokenizeForLengths,
       maxCardinality = RawFeatureFilter.MaxCardinality)

--- a/core/src/main/scala/com/salesforce/op/filters/FeatureDistribution.scala
+++ b/core/src/main/scala/com/salesforce/op/filters/FeatureDistribution.scala
@@ -269,7 +269,7 @@ object FeatureDistribution {
    */
   private def momentsValues(values: ProcessedSeq): Moments = {
     val population = values match {
-      case Left(seq) => seq.map(x => x.length.toDouble)
+      case Left(seq) => seq.map(_.length.toDouble)
       case Right(seq) => seq
     }
     MomentsGroup.sum(population.map(x => Moments(x)))
@@ -290,7 +290,7 @@ object FeatureDistribution {
       case Right(doubleSeq) => doubleSeq.map(_.toString)
     }
     stringVals.foldLeft(TextStats.empty)((acc, el) => acc + SmartTextVectorizer.computeTextStats(
-      Option(el), shouldCleanText = false, maxCardinality = RawFeatureFilter.MaxCardinality)
+      Option(el), shouldCleanText = true, maxCardinality = RawFeatureFilter.MaxCardinality)
     )
   }
 

--- a/core/src/main/scala/com/salesforce/op/filters/PreparedFeatures.scala
+++ b/core/src/main/scala/com/salesforce/op/filters/PreparedFeatures.scala
@@ -88,6 +88,7 @@ private[filters] case class PreparedFeatures
    *                                Input arguments are [[Summary]] and number of bins to use in
    *                                computing feature distributions (histograms for numerics, hashes for strings).
    *                                Output is the bins for the text features.
+   * @param tokenizeForLengths      whether or not to tokenize strings before computing length distribution
    * @param featureDistributionType feature distribution type: training or scoring
    * @return a pair consisting of response and predictor feature distributions (in this order)
    */
@@ -96,6 +97,7 @@ private[filters] case class PreparedFeatures
     predictorSummaries: Array[(FeatureKey, Summary)],
     bins: Int,
     textBinsFormula: (Summary, Int) => Int,
+    tokenizeForLengths: Boolean,
     featureDistributionType: FeatureDistributionType
   ): (Array[FeatureDistribution], Array[FeatureDistribution]) = {
 
@@ -109,6 +111,7 @@ private[filters] case class PreparedFeatures
         value = features.get(featureKey),
         bins = bins,
         textBinsFormula = textBinsFormula,
+        tokenizeForLengths = tokenizeForLengths,
         `type` = featureDistributionType
       )
     }

--- a/core/src/main/scala/com/salesforce/op/filters/PreparedFeatures.scala
+++ b/core/src/main/scala/com/salesforce/op/filters/PreparedFeatures.scala
@@ -169,8 +169,7 @@ private[filters] object PreparedFeatures {
       case SomeValue(v: DenseVector) => Map((name, None) -> Right(v.toArray.toSeq))
       case SomeValue(v: SparseVector) => Map((name, None) -> Right(v.indices.map(_.toDouble).toSeq))
       case ft@SomeValue(_) => ft match {
-        // case v: Text => Map((name, None) -> Left(v.value.toSeq.flatMap(tokenize)))
-        case v: Text => Map((name, None) -> Left(v.value.toSeq))
+        case v: Text => Map((name, None) -> Left(v.value.toSeq.flatMap(tokenize)))
         case v: Date => Map((name, None) -> Right(v.value.map(prepareDateValue(_, timePeriod)).toSeq))
         case v: OPNumeric[_] => Map((name, None) -> Right(v.toDouble.toSeq))
         case v: Geolocation => Map((name, None) -> Right(v.value))

--- a/core/src/main/scala/com/salesforce/op/filters/PreparedFeatures.scala
+++ b/core/src/main/scala/com/salesforce/op/filters/PreparedFeatures.scala
@@ -88,7 +88,6 @@ private[filters] case class PreparedFeatures
    *                                Input arguments are [[Summary]] and number of bins to use in
    *                                computing feature distributions (histograms for numerics, hashes for strings).
    *                                Output is the bins for the text features.
-   * @param tokenizeForLengths      whether or not to tokenize strings before computing length distribution
    * @param featureDistributionType feature distribution type: training or scoring
    * @return a pair consisting of response and predictor feature distributions (in this order)
    */
@@ -97,7 +96,6 @@ private[filters] case class PreparedFeatures
     predictorSummaries: Array[(FeatureKey, Summary)],
     bins: Int,
     textBinsFormula: (Summary, Int) => Int,
-    tokenizeForLengths: Boolean,
     featureDistributionType: FeatureDistributionType
   ): (Array[FeatureDistribution], Array[FeatureDistribution]) = {
 
@@ -111,7 +109,6 @@ private[filters] case class PreparedFeatures
         value = features.get(featureKey),
         bins = bins,
         textBinsFormula = textBinsFormula,
-        tokenizeForLengths = tokenizeForLengths,
         `type` = featureDistributionType
       )
     }
@@ -172,7 +169,8 @@ private[filters] object PreparedFeatures {
       case SomeValue(v: DenseVector) => Map((name, None) -> Right(v.toArray.toSeq))
       case SomeValue(v: SparseVector) => Map((name, None) -> Right(v.indices.map(_.toDouble).toSeq))
       case ft@SomeValue(_) => ft match {
-        case v: Text => Map((name, None) -> Left(v.value.toSeq.flatMap(tokenize)))
+        // case v: Text => Map((name, None) -> Left(v.value.toSeq.flatMap(tokenize)))
+        case v: Text => Map((name, None) -> Left(v.value.toSeq))
         case v: Date => Map((name, None) -> Right(v.value.map(prepareDateValue(_, timePeriod)).toSeq))
         case v: OPNumeric[_] => Map((name, None) -> Right(v.toDouble.toSeq))
         case v: Geolocation => Map((name, None) -> Right(v.value))

--- a/core/src/main/scala/com/salesforce/op/filters/RawFeatureFilter.scala
+++ b/core/src/main/scala/com/salesforce/op/filters/RawFeatureFilter.scala
@@ -103,7 +103,6 @@ class RawFeatureFilter[T]
   val jsDivergenceProtectedFeatures: Set[String] = Set.empty,
   val protectedFeatures: Set[String] = Set.empty,
   val textBinsFormula: (Summary, Int) => Int = RawFeatureFilter.textBinsFormula,
-  val tokenizeForLengths: Boolean = RawFeatureFilter.TokenizeForLengths,
   val timePeriod: Option[TimePeriod] = None,
   val minScoringRows: Int = RawFeatureFilter.minScoringRowsDefault
 ) extends Serializable {
@@ -176,7 +175,6 @@ class RawFeatureFilter[T]
           predictorSummaries = predictorSummariesArr,
           bins = bins,
           textBinsFormula = textBinsFormula,
-          tokenizeForLengths = tokenizeForLengths,
           featureDistributionType
         )).reduce(_ + _)
     val correlationInfo: Map[FeatureKey, Map[FeatureKey, Double]] =
@@ -603,8 +601,6 @@ object RawFeatureFilter {
   // scoring sets since they will not be reliable. Currently, this is set to the same as the minimum training size.
   val minScoringRowsDefault = 500
   val MaxCardinality = 500
-  // Whether or not to tokenize string data when calculating length distributions in TextStats
-  val TokenizeForLengths = true
 
   val stageName = classOf[RawFeatureFilter[_]].getSimpleName
 

--- a/core/src/main/scala/com/salesforce/op/filters/RawFeatureFilter.scala
+++ b/core/src/main/scala/com/salesforce/op/filters/RawFeatureFilter.scala
@@ -80,6 +80,8 @@ import scala.util.Failure
  *                                      Input arguments are [[Summary]] and number of bins to use in computing feature
  *                                      distributions (histograms for numerics, hashes for strings).
  *                                      Output is the bins for the text features.
+ * @param tokenizeForLengths            Whether or not to tokenize text data when calculating length distributions
+ *                                      in the TextStats part of the feature distributions
  * @param timePeriod                    Time period used to apply circulate date transformation for date features, if
  *                                      not specified will use regular numeric feature transformation
  * @param minScoringRows                Minimum row threshold for scoring set comparisons to be used in checks. If
@@ -101,6 +103,7 @@ class RawFeatureFilter[T]
   val jsDivergenceProtectedFeatures: Set[String] = Set.empty,
   val protectedFeatures: Set[String] = Set.empty,
   val textBinsFormula: (Summary, Int) => Int = RawFeatureFilter.textBinsFormula,
+  val tokenizeForLengths: Boolean = RawFeatureFilter.TokenizeForLengths,
   val timePeriod: Option[TimePeriod] = None,
   val minScoringRows: Int = RawFeatureFilter.minScoringRowsDefault
 ) extends Serializable {
@@ -173,6 +176,7 @@ class RawFeatureFilter[T]
           predictorSummaries = predictorSummariesArr,
           bins = bins,
           textBinsFormula = textBinsFormula,
+          tokenizeForLengths = tokenizeForLengths,
           featureDistributionType
         )).reduce(_ + _)
     val correlationInfo: Map[FeatureKey, Map[FeatureKey, Double]] =
@@ -599,7 +603,8 @@ object RawFeatureFilter {
   // scoring sets since they will not be reliable. Currently, this is set to the same as the minimum training size.
   val minScoringRowsDefault = 500
   val MaxCardinality = 500
-
+  // Whether or not to tokenize string data when calculating length distributions in TextStats
+  val TokenizeForLengths = true
 
   val stageName = classOf[RawFeatureFilter[_]].getSimpleName
 

--- a/core/src/main/scala/com/salesforce/op/filters/RawFeatureFilter.scala
+++ b/core/src/main/scala/com/salesforce/op/filters/RawFeatureFilter.scala
@@ -80,8 +80,6 @@ import scala.util.Failure
  *                                      Input arguments are [[Summary]] and number of bins to use in computing feature
  *                                      distributions (histograms for numerics, hashes for strings).
  *                                      Output is the bins for the text features.
- * @param tokenizeForLengths            Whether or not to tokenize text data when calculating length distributions
- *                                      in the TextStats part of the feature distributions
  * @param timePeriod                    Time period used to apply circulate date transformation for date features, if
  *                                      not specified will use regular numeric feature transformation
  * @param minScoringRows                Minimum row threshold for scoring set comparisons to be used in checks. If

--- a/core/src/main/scala/com/salesforce/op/stages/impl/classification/BinaryClassificationModelSelector.scala
+++ b/core/src/main/scala/com/salesforce/op/stages/impl/classification/BinaryClassificationModelSelector.scala
@@ -56,10 +56,11 @@ case object BinaryClassificationModelSelector extends ModelSelectorFactory {
     /**
      * Subset of models to use in model selector
      *
-     * Note: [[OpNaiveBayes]], [[OpDecisionTreeClassifier]] and [[OpXGBoostClassifier]] are off by default
+     * Note: [[OpNaiveBayes]], [[OpDecisionTreeClassifier]], [[OpLinearSVC]], and [[OpXGBoostClassifier]] are
+     * off by default
      */
     val modelTypesToUse: Seq[BinaryClassificationModelsToTry] = Seq(
-      MTT.OpLogisticRegression, MTT.OpRandomForestClassifier, MTT.OpGBTClassifier, MTT.OpLinearSVC
+      MTT.OpLogisticRegression, MTT.OpRandomForestClassifier, MTT.OpGBTClassifier
     )
 
     /**

--- a/core/src/main/scala/com/salesforce/op/stages/impl/feature/SmartTextMapVectorizer.scala
+++ b/core/src/main/scala/com/salesforce/op/stages/impl/feature/SmartTextMapVectorizer.scala
@@ -155,7 +155,7 @@ class SmartTextMapVectorizer[T <: OPMap[String]]
       }
     }
 
-    logInfo(s"TextStats for features used in SmartTextMapVectorizer:")
+    logInfo("TextStats for features used in SmartTextMapVectorizer:")
     inN.map(_.name).zip(aggregatedStats).zip(allFeatureInfo).foreach { case ((mapName, mapStats), featInfo) =>
       logInfo(s"FeatureMap: $mapName")
       mapStats.keyValueCounts.zip(featInfo).foreach { case ((name, stats), info) =>

--- a/core/src/main/scala/com/salesforce/op/stages/impl/feature/SmartTextMapVectorizer.scala
+++ b/core/src/main/scala/com/salesforce/op/stages/impl/feature/SmartTextMapVectorizer.scala
@@ -155,6 +155,18 @@ class SmartTextMapVectorizer[T <: OPMap[String]]
       }
     }
 
+    logInfo(s"TextStats for features used in SmartTextMapVectorizer:")
+    inN.map(_.name).zip(aggregatedStats).zip(allFeatureInfo).foreach { case ((mapName, mapStats), featInfo) =>
+      logInfo(s"FeatureMap: $mapName")
+      mapStats.keyValueCounts.zip(featInfo).foreach { case ((name, stats), info) =>
+        logInfo(s"Key: $name")
+        logInfo(s"LengthCounts: ${stats.lengthCounts}")
+        logInfo(s"LengthMean: ${stats.lengthMean}")
+        logInfo(s"LengthStdDev: ${stats.lengthStdDev}")
+        logInfo(s"Vectorization method: ${info.vectorizationMethod}")
+      }
+    }
+
     SmartTextMapVectorizerModelArgs(
       allFeatureInfo = allFeatureInfo,
       shouldCleanKeys = shouldCleanKeys,
@@ -178,17 +190,6 @@ class SmartTextMapVectorizer[T <: OPMap[String]]
         maxCard)).toArray
     )
     val aggregatedStats: Array[TextMapStats] = valueStats.reduce(_ + _)
-
-    logInfo(s"TextStats for features used in SmartTextMapVectorizer:")
-    inN.map(_.name).zip(aggregatedStats).foreach { case(mapName, mapStats) =>
-      logInfo(s"FeatureMap: $mapName")
-      mapStats.keyValueCounts.foreach { case(name, stats) =>
-        logInfo(s"Key: $name")
-        logInfo(s"LengthCounts: ${stats.lengthCounts}")
-        logInfo(s"LengthMean: ${stats.lengthMean}")
-        logInfo(s"LengthStdDev: ${stats.lengthStdDev}")
-      }
-    }
 
     val smartTextMapVectorizerModelArgs = makeSmartTextMapVectorizerModelArgs(aggregatedStats)
 

--- a/core/src/main/scala/com/salesforce/op/stages/impl/feature/SmartTextMapVectorizer.scala
+++ b/core/src/main/scala/com/salesforce/op/stages/impl/feature/SmartTextMapVectorizer.scala
@@ -194,6 +194,16 @@ class SmartTextMapVectorizer[T <: OPMap[String]]
 
 object SmartTextMapVectorizer extends CleanTextFun {
 
+  /**
+   * Computes a TextMapStats instance from a text map entry
+   *
+   * @param textMap            Text value (eg. entry in a dataframe)
+   * @param shouldCleanKeys    Whether or not the keys (feature names) should be cleaned
+   * @param shouldCleanValues  Whether or not the values (the actual text) should be cleaned
+   * @param maxCardinality     Max cardinality to keep track of in maps (relevant for the text length distribution here)
+   * @tparam T                 Feature type that the text map value is coming from
+   * @return                   TextMapStats instance with value and length counts filled out appropriately for each key
+   */
   private[op] def computeTextMapStats[T <:  OPMap[String]](
     textMap: T#Value,
     shouldCleanKeys: Boolean,

--- a/core/src/main/scala/com/salesforce/op/stages/impl/feature/SmartTextMapVectorizer.scala
+++ b/core/src/main/scala/com/salesforce/op/stages/impl/feature/SmartTextMapVectorizer.scala
@@ -179,6 +179,17 @@ class SmartTextMapVectorizer[T <: OPMap[String]]
     )
     val aggregatedStats: Array[TextMapStats] = valueStats.reduce(_ + _)
 
+    logInfo(s"TextStats for features used in SmartTextMapVectorizer:")
+    inN.map(_.name).zip(aggregatedStats).foreach { case(mapName, mapStats) =>
+      logInfo(s"FeatureMap: $mapName")
+      mapStats.keyValueCounts.foreach { case(name, stats) =>
+        logInfo(s"Key: $name")
+        logInfo(s"LengthCounts: ${stats.lengthCounts}")
+        logInfo(s"LengthMean: ${stats.lengthMean}")
+        logInfo(s"LengthStdDev: ${stats.lengthStdDev}")
+      }
+    }
+
     val smartTextMapVectorizerModelArgs = makeSmartTextMapVectorizerModelArgs(aggregatedStats)
 
     val vecMetadata = makeVectorMetadata(smartTextMapVectorizerModelArgs)

--- a/core/src/main/scala/com/salesforce/op/stages/impl/feature/SmartTextMapVectorizer.scala
+++ b/core/src/main/scala/com/salesforce/op/stages/impl/feature/SmartTextMapVectorizer.scala
@@ -182,7 +182,7 @@ class SmartTextMapVectorizer[T <: OPMap[String]]
     val maxCard = $(maxCardinality)
     val shouldCleanKeys = $(cleanKeys)
     val shouldCleanValues = $(cleanText)
-    val shouldTokenize = $(tokenizeForLengths)
+    val shouldTokenize = $(textLengthType) == TextLengthType.Tokens.entryName
 
     implicit val testStatsMonoid: Monoid[TextMapStats] = TextMapStats.monoid(maxCard)
     val valueStats: Dataset[Array[TextMapStats]] = dataset.map(

--- a/core/src/main/scala/com/salesforce/op/stages/impl/feature/SmartTextMapVectorizer.scala
+++ b/core/src/main/scala/com/salesforce/op/stages/impl/feature/SmartTextMapVectorizer.scala
@@ -173,7 +173,7 @@ class SmartTextMapVectorizer[T <: OPMap[String]]
 
     implicit val testStatsMonoid: Monoid[TextMapStats] = TextMapStats.monoid(maxCard)
     val valueStats: Dataset[Array[TextMapStats]] = dataset.map(
-      _.map(SmartTextMapVectorizer.computeTextMapStats(_, maxCard, shouldCleanKeys, shouldCleanValues)).toArray
+      _.map(SmartTextMapVectorizer.computeTextMapStats(_, shouldCleanKeys, shouldCleanValues, maxCard)).toArray
     )
     val aggregatedStats: Array[TextMapStats] = valueStats.reduce(_ + _)
 
@@ -196,9 +196,9 @@ object SmartTextMapVectorizer extends CleanTextFun {
 
   private[op] def computeTextMapStats[T <:  OPMap[String]](
     textMap: T#Value,
-    maxCardinality: Int,
     shouldCleanKeys: Boolean,
-    shouldCleanValues: Boolean
+    shouldCleanValues: Boolean,
+    maxCardinality: Int
   )(implicit tti: TypeTag[T], ttiv: TypeTag[T#Value]): TextMapStats = {
     val keyValueCounts = textMap.map{ case (k, v) =>
       val cleanedText = cleanTextFn(v, shouldCleanValues)

--- a/core/src/main/scala/com/salesforce/op/stages/impl/feature/SmartTextVectorizer.scala
+++ b/core/src/main/scala/com/salesforce/op/stages/impl/feature/SmartTextVectorizer.scala
@@ -91,6 +91,14 @@ class SmartTextVectorizer[T <: Text](uid: String = UID[SmartTextVectorizer[T]])(
     )
     val aggregatedStats: Array[TextStats] = valueStats.reduce(_ + _)
 
+    logInfo(s"TextStats for features used in SmartTextVectorizer:")
+    inN.map(_.name).zip(aggregatedStats).foreach { case(name, stats) =>
+      logInfo(s"Feature: $name")
+      logInfo(s"LengthCounts: ${stats.lengthCounts}")
+      logInfo(s"LengthMean: ${stats.lengthMean}")
+      logInfo(s"LengthStdDev: ${stats.lengthStdDev}")
+    }
+
     val (vectorizationMethods, topValues) = aggregatedStats.map { stats =>
       val vecMethod: TextVectorizationMethod = stats match {
         case _ if stats.valueCounts.size <= maxCard => TextVectorizationMethod.Pivot

--- a/core/src/main/scala/com/salesforce/op/stages/impl/feature/SmartTextVectorizer.scala
+++ b/core/src/main/scala/com/salesforce/op/stages/impl/feature/SmartTextVectorizer.scala
@@ -112,7 +112,7 @@ class SmartTextVectorizer[T <: Text](uid: String = UID[SmartTextVectorizer[T]])(
       hashingParams = makeHashingParams()
     )
 
-    logInfo(s"TextStats for features used in SmartTextVectorizer:")
+    logInfo("TextStats for features used in SmartTextVectorizer:")
     inN.map(_.name).zip(aggregatedStats).zip(vectorizationMethods).foreach { case((name, stats), vecMethod) =>
       logInfo(s"Feature: $name")
       logInfo(s"LengthCounts: ${stats.lengthCounts}")

--- a/core/src/main/scala/com/salesforce/op/stages/impl/feature/SmartTextVectorizer.scala
+++ b/core/src/main/scala/com/salesforce/op/stages/impl/feature/SmartTextVectorizer.scala
@@ -167,6 +167,15 @@ object SmartTextVectorizer extends CleanTextFun {
     (all.collect { case (item, true) => item }, all.collect { case (item, false) => item })
   }
 
+  /**
+   * Computes a TextStats instance from a Text entry
+   *
+   * @param text            Text value (eg. entry in a dataframe)
+   * @param shouldCleanText Whether or not the text should be cleaned
+   * @param maxCardinality  Max cardinality to keep track of in maps (relevant for the text length distribution here)
+   * @tparam T              Feature type that the text value is coming from
+   * @return                TextStats instance with value and length counts filled out appropriately
+   */
   private[op] def computeTextStats[T <: Text : TypeTag](
     text: T#Value,
     shouldCleanText: Boolean,

--- a/core/src/main/scala/com/salesforce/op/stages/impl/feature/SmartTextVectorizer.scala
+++ b/core/src/main/scala/com/salesforce/op/stages/impl/feature/SmartTextVectorizer.scala
@@ -173,7 +173,7 @@ object SmartTextVectorizer extends CleanTextFun {
     maxCardinality: Int
   ): TextStats = {
     // Go through each token in text and start appending it to a TextStats instance
-    val lengthsMap: Map[Int, Long] = TextTokenizer.tokenizeString(text).tokens.value
+    val lengthsMap: Map[Int, Long] = TextTokenizer.tokenizeStringOpt(text).tokens.value
       .foldLeft(Map.empty[Int, Long])(
         (acc, el) => TextStats.additionHelper(acc, Map(el.length -> 1L), maxCardinality)
       )

--- a/core/src/main/scala/com/salesforce/op/stages/impl/feature/SmartTextVectorizer.scala
+++ b/core/src/main/scala/com/salesforce/op/stages/impl/feature/SmartTextVectorizer.scala
@@ -201,8 +201,8 @@ private[op] case class TextStats
   val lengthMean: Double = lengthCounts.foldLeft(0.0)((acc, el) => acc + el._1 * el._2) / lengthSize
   val lengthVariance: Double = lengthCounts.foldLeft(0.0)(
     (acc, el) => acc + el._2 * (el._1 - lengthMean) * (el._1 - lengthMean)
-  )
-  val lengthStdDev: Double = math.sqrt(lengthVariance / lengthSize)
+  ) / lengthSize
+  val lengthStdDev: Double = math.sqrt(lengthVariance)
 }
 
 private[op] object TextStats {

--- a/core/src/main/scala/com/salesforce/op/stages/impl/feature/SmartTextVectorizer.scala
+++ b/core/src/main/scala/com/salesforce/op/stages/impl/feature/SmartTextVectorizer.scala
@@ -91,14 +91,6 @@ class SmartTextVectorizer[T <: Text](uid: String = UID[SmartTextVectorizer[T]])(
     )
     val aggregatedStats: Array[TextStats] = valueStats.reduce(_ + _)
 
-    logInfo(s"TextStats for features used in SmartTextVectorizer:")
-    inN.map(_.name).zip(aggregatedStats).foreach { case(name, stats) =>
-      logInfo(s"Feature: $name")
-      logInfo(s"LengthCounts: ${stats.lengthCounts}")
-      logInfo(s"LengthMean: ${stats.lengthMean}")
-      logInfo(s"LengthStdDev: ${stats.lengthStdDev}")
-    }
-
     val (vectorizationMethods, topValues) = aggregatedStats.map { stats =>
       val vecMethod: TextVectorizationMethod = stats match {
         case _ if stats.valueCounts.size <= maxCard => TextVectorizationMethod.Pivot
@@ -119,6 +111,15 @@ class SmartTextVectorizer[T <: Text](uid: String = UID[SmartTextVectorizer[T]])(
       shouldTrackNulls = $(trackNulls),
       hashingParams = makeHashingParams()
     )
+
+    logInfo(s"TextStats for features used in SmartTextVectorizer:")
+    inN.map(_.name).zip(aggregatedStats).zip(vectorizationMethods).foreach { case((name, stats), vecMethod) =>
+      logInfo(s"Feature: $name")
+      logInfo(s"LengthCounts: ${stats.lengthCounts}")
+      logInfo(s"LengthMean: ${stats.lengthMean}")
+      logInfo(s"LengthStdDev: ${stats.lengthStdDev}")
+      logInfo(s"Vectorization method: $vecMethod")
+    }
 
     val vecMetadata = makeVectorMetadata(smartTextParams)
     setMetadata(vecMetadata.toMetadata)

--- a/core/src/main/scala/com/salesforce/op/stages/impl/feature/TextTokenizer.scala
+++ b/core/src/main/scala/com/salesforce/op/stages/impl/feature/TextTokenizer.scala
@@ -151,7 +151,7 @@ object TextTokenizer {
    * @param minTokenLength      minimum token length
    * @return detected language and sentence tokens
    */
-  def tokenizeString(
+  private[op] def tokenizeString(
     textString: String,
     languageDetector: LanguageDetector = LanguageDetector,
     analyzer: TextAnalyzer = Analyzer,
@@ -195,7 +195,7 @@ object TextTokenizer {
    * @param minTokenLength      minimum token length
    * @return detected language and sentence tokens
    */
-  def tokenizeStringOpt(
+  private[op] def tokenizeStringOpt(
     textStringOpt: Option[String],
     languageDetector: LanguageDetector = LanguageDetector,
     analyzer: TextAnalyzer = Analyzer,

--- a/core/src/main/scala/com/salesforce/op/stages/impl/feature/TextTokenizer.scala
+++ b/core/src/main/scala/com/salesforce/op/stages/impl/feature/TextTokenizer.scala
@@ -207,17 +207,8 @@ object TextTokenizer {
     minTokenLength: Int = MinTokenLength
   ): TextTokenizerResult = {
     textStringOpt match {
-      case Some(txt) => tokenizeString(
-        txt,
-        languageDetector,
-        analyzer,
-        sentenceSplitter,
-        autoDetectLanguage,
-        defaultLanguage,
-        autoDetectThreshold,
-        toLowercase,
-        minTokenLength
-      )
+      case Some(txt) => tokenizeString(txt, languageDetector, analyzer, sentenceSplitter, autoDetectLanguage,
+        defaultLanguage, autoDetectThreshold, toLowercase, minTokenLength)
       case None => TextTokenizerResult(defaultLanguage, Seq(TextList.empty))
     }
   }
@@ -246,19 +237,8 @@ object TextTokenizer {
     autoDetectThreshold: Double = AutoDetectThreshold,
     toLowercase: Boolean = ToLowercase,
     minTokenLength: Int = MinTokenLength
-  ): TextTokenizerResult = {
-    tokenizeStringOpt(
-      text.value,
-      languageDetector,
-      analyzer,
-      sentenceSplitter,
-      autoDetectLanguage,
-      defaultLanguage,
-      autoDetectThreshold,
-      toLowercase,
-      minTokenLength
-    )
-  }
+  ): TextTokenizerResult = tokenizeStringOpt(text.value, languageDetector, analyzer, sentenceSplitter,
+    autoDetectLanguage, defaultLanguage, autoDetectThreshold, toLowercase, minTokenLength)
 
   /**
    * Text tokenization result

--- a/core/src/main/scala/com/salesforce/op/stages/impl/feature/TextTokenizer.scala
+++ b/core/src/main/scala/com/salesforce/op/stages/impl/feature/TextTokenizer.scala
@@ -184,38 +184,6 @@ object TextTokenizer {
   /**
    * Language wise sentence tokenization
    *
-   * @param textStringOpt       text to tokenize (in Option[String] form)
-   * @param languageDetector    language detector instance
-   * @param analyzer            text analyzer instance
-   * @param sentenceSplitter    sentence splitter instance
-   * @param autoDetectLanguage  whether to attempt language detection
-   * @param defaultLanguage     default language
-   * @param autoDetectThreshold language detection threshold
-   * @param toLowercase         whether to convert all characters to lowercase before tokenizing
-   * @param minTokenLength      minimum token length
-   * @return detected language and sentence tokens
-   */
-  private[op] def tokenizeStringOpt(
-    textStringOpt: Option[String],
-    languageDetector: LanguageDetector = LanguageDetector,
-    analyzer: TextAnalyzer = Analyzer,
-    sentenceSplitter: Option[SentenceSplitter] = None,
-    autoDetectLanguage: Boolean = AutoDetectLanguage,
-    defaultLanguage: Language = DefaultLanguage,
-    autoDetectThreshold: Double = AutoDetectThreshold,
-    toLowercase: Boolean = ToLowercase,
-    minTokenLength: Int = MinTokenLength
-  ): TextTokenizerResult = {
-    textStringOpt match {
-      case Some(txt) => tokenizeString(txt, languageDetector, analyzer, sentenceSplitter, autoDetectLanguage,
-        defaultLanguage, autoDetectThreshold, toLowercase, minTokenLength)
-      case None => TextTokenizerResult(defaultLanguage, Seq(TextList.empty))
-    }
-  }
-
-  /**
-   * Language wise sentence tokenization
-   *
    * @param text                text to tokenize
    * @param languageDetector    language detector instance
    * @param analyzer            text analyzer instance
@@ -237,8 +205,13 @@ object TextTokenizer {
     autoDetectThreshold: Double = AutoDetectThreshold,
     toLowercase: Boolean = ToLowercase,
     minTokenLength: Int = MinTokenLength
-  ): TextTokenizerResult = tokenizeStringOpt(text.value, languageDetector, analyzer, sentenceSplitter,
-    autoDetectLanguage, defaultLanguage, autoDetectThreshold, toLowercase, minTokenLength)
+  ): TextTokenizerResult = {
+    text.value match {
+      case Some(txt) => tokenizeString(txt, languageDetector, analyzer, sentenceSplitter, autoDetectLanguage,
+        defaultLanguage, autoDetectThreshold, toLowercase, minTokenLength)
+      case _ => TextTokenizerResult(defaultLanguage, Seq(TextList.empty))
+    }
+  }
 
   /**
    * Text tokenization result

--- a/core/src/test/scala/com/salesforce/op/filters/FeatureDistributionTest.scala
+++ b/core/src/test/scala/com/salesforce/op/filters/FeatureDistributionTest.scala
@@ -63,7 +63,8 @@ class FeatureDistributionTest extends FlatSpec with PassengerSparkFixtureTest wi
       if (isEmpty) None else Option(processed)
     }
     val distribs = featureKeys.zip(summaries).zip(processedSeqs).map { case ((key, summary), seq) =>
-      FeatureDistribution.fromSummary(key, summary, seq, bins, (_, bins) => bins, FeatureDistributionType.Training)
+      FeatureDistribution.fromSummary(key, summary, seq, bins, (_, bins) => bins, tokenizeForLengths = true,
+        FeatureDistributionType.Training)
     }
     distribs.foreach{ d =>
       d.key shouldBe None
@@ -96,7 +97,8 @@ class FeatureDistributionTest extends FlatSpec with PassengerSparkFixtureTest wi
       if (isEmpty) None else Option(processed)
     }
     val distribs = featureKeys.zip(summary).zip(processedSeqs).map { case ((key, summ), seq) =>
-      FeatureDistribution.fromSummary(key, summ, seq, bins, (_, bins) => bins, FeatureDistributionType.Training)
+      FeatureDistribution.fromSummary(key, summ, seq, bins, (_, bins) => bins, tokenizeForLengths = true,
+        FeatureDistributionType.Training)
     }
 
     distribs(0).distribution.length shouldBe 100
@@ -120,7 +122,7 @@ class FeatureDistributionTest extends FlatSpec with PassengerSparkFixtureTest wi
       summaryMaps.map { case (key, summary) =>
         val featureKey = (name, Option(key))
         FeatureDistribution.fromSummary(featureKey, summary, valueMaps.get(key),
-          bins, (_, bins) => bins, FeatureDistributionType.Scoring)
+          bins, (_, bins) => bins, tokenizeForLengths = true, FeatureDistributionType.Scoring)
       }
     }
 

--- a/core/src/test/scala/com/salesforce/op/filters/FeatureDistributionTest.scala
+++ b/core/src/test/scala/com/salesforce/op/filters/FeatureDistributionTest.scala
@@ -78,9 +78,9 @@ class FeatureDistributionTest extends FlatSpec with PassengerSparkFixtureTest wi
     distribs(3).distribution.sum shouldBe 0
     distribs(4).distribution.sum shouldBe 3
     distribs(4).summaryInfo.length shouldBe bins
-    distribs(2).cardEstimate.get shouldBe TextStats(Map("male" -> 1, "female" -> 1), Map.empty)
+    distribs(2).cardEstimate.get shouldBe TextStats(Map("male" -> 1, "female" -> 1), Map(4 -> 1L, 6 -> 1L))
     distribs(2).moments.get shouldBe Moments(2, 5.0, 2.0, 0.0, 2.0)
-    distribs(4).cardEstimate.get shouldBe TextStats(Map("5.0" -> 1, "1.0" -> 1, "3.0" -> 1), Map.empty)
+    distribs(4).cardEstimate.get shouldBe TextStats(Map("5.0" -> 1, "1.0" -> 1, "3.0" -> 1), Map(3 -> 3L))
     distribs(4).moments.get shouldBe Moments(3, 3.0, 8.0, 0.0, 32.0)
   }
 

--- a/core/src/test/scala/com/salesforce/op/filters/FeatureDistributionTest.scala
+++ b/core/src/test/scala/com/salesforce/op/filters/FeatureDistributionTest.scala
@@ -63,8 +63,7 @@ class FeatureDistributionTest extends FlatSpec with PassengerSparkFixtureTest wi
       if (isEmpty) None else Option(processed)
     }
     val distribs = featureKeys.zip(summaries).zip(processedSeqs).map { case ((key, summary), seq) =>
-      FeatureDistribution.fromSummary(key, summary, seq, bins, (_, bins) => bins, tokenizeForLengths = true,
-        FeatureDistributionType.Training)
+      FeatureDistribution.fromSummary(key, summary, seq, bins, (_, bins) => bins, FeatureDistributionType.Training)
     }
     distribs.foreach{ d =>
       d.key shouldBe None
@@ -97,8 +96,7 @@ class FeatureDistributionTest extends FlatSpec with PassengerSparkFixtureTest wi
       if (isEmpty) None else Option(processed)
     }
     val distribs = featureKeys.zip(summary).zip(processedSeqs).map { case ((key, summ), seq) =>
-      FeatureDistribution.fromSummary(key, summ, seq, bins, (_, bins) => bins, tokenizeForLengths = true,
-        FeatureDistributionType.Training)
+      FeatureDistribution.fromSummary(key, summ, seq, bins, (_, bins) => bins, FeatureDistributionType.Training)
     }
 
     distribs(0).distribution.length shouldBe 100
@@ -122,7 +120,7 @@ class FeatureDistributionTest extends FlatSpec with PassengerSparkFixtureTest wi
       summaryMaps.map { case (key, summary) =>
         val featureKey = (name, Option(key))
         FeatureDistribution.fromSummary(featureKey, summary, valueMaps.get(key),
-          bins, (_, bins) => bins, tokenizeForLengths = true, FeatureDistributionType.Scoring)
+          bins, (_, bins) => bins, FeatureDistributionType.Scoring)
       }
     }
 

--- a/core/src/test/scala/com/salesforce/op/stages/impl/feature/SmartTextMapVectorizerTest.scala
+++ b/core/src/test/scala/com/salesforce/op/stages/impl/feature/SmartTextMapVectorizerTest.scala
@@ -40,7 +40,6 @@ import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 import com.salesforce.op.features.types._
 import com.salesforce.op.testkit.RandomText
-import org.scalatest.Assertion
 
 @RunWith(classOf[JUnitRunner])
 class SmartTextMapVectorizerTest
@@ -520,9 +519,9 @@ class SmartTextMapVectorizerTest
   it should "create a TextStats object from text that makes sense" in {
     val res = SmartTextMapVectorizer.computeTextMapStats[TextMap](
       textMapData,
-      maxCardinality = 100,
       shouldCleanKeys = false,
-      shouldCleanValues = false
+      shouldCleanValues = false,
+      maxCardinality = 100
     )
 
     // Check sizes
@@ -551,9 +550,9 @@ class SmartTextMapVectorizerTest
   it should "create a TextStats with the correct derived quantites" in {
     val res = SmartTextMapVectorizer.computeTextMapStats[TextMap](
       textMapData,
-      maxCardinality = 100,
       shouldCleanKeys = false,
-      shouldCleanValues = false
+      shouldCleanValues = false,
+      maxCardinality = 100
     )
 
     // Check derived quantities
@@ -580,9 +579,9 @@ class SmartTextMapVectorizerTest
   it should "turn a string into a corresponding TextStats instance that respects maxCardinality" in {
     val res = SmartTextMapVectorizer.computeTextMapStats[TextMap](
       textMapData,
-      maxCardinality = 2,
       shouldCleanKeys = false,
-      shouldCleanValues = false
+      shouldCleanValues = false,
+      maxCardinality = 2
     )
 
     // Check lengths

--- a/core/src/test/scala/com/salesforce/op/stages/impl/feature/SmartTextMapVectorizerTest.scala
+++ b/core/src/test/scala/com/salesforce/op/stages/impl/feature/SmartTextMapVectorizerTest.scala
@@ -452,7 +452,7 @@ class SmartTextMapVectorizerTest
 
     val smartVectorized = new SmartTextMapVectorizer()
       .setMaxCardinality(10).setNumFeatures(hashSize).setMinSupport(10).setTopK(topKCategorial)
-      .setMinLengthStdDev(0.5).setTokenizeForLengths(true)
+      .setMinLengthStdDev(0.5).setTextLengthType(TextLengthType.Tokens)
       .setAutoDetectLanguage(false).setMinTokenLength(1).setToLowercase(false)
       .setTrackNulls(true).setTrackTextLen(true)
       .setInput(rawTextMap).getOutput()
@@ -488,7 +488,7 @@ class SmartTextMapVectorizerTest
 
     val smartVectorized = new SmartTextMapVectorizer()
       .setMaxCardinality(10).setNumFeatures(hashSize).setMinSupport(10).setTopK(topKCategorial)
-      .setMinLengthStdDev(1.0).setTokenizeForLengths(false)
+      .setMinLengthStdDev(1.0).setTextLengthType(TextLengthType.FullEntry)
       .setAutoDetectLanguage(false).setMinTokenLength(1).setToLowercase(false)
       .setTrackNulls(true).setTrackTextLen(true)
       .setInput(rawTextMap).getOutput()
@@ -524,7 +524,7 @@ class SmartTextMapVectorizerTest
 
     val smartVectorized = new SmartTextMapVectorizer()
       .setMaxCardinality(10).setNumFeatures(hashSize).setMinSupport(10).setTopK(topKCategorial)
-      .setMinLengthStdDev(0.5).setTokenizeForLengths(true)
+      .setMinLengthStdDev(0.5).setTextLengthType(TextLengthType.Tokens)
       .setAutoDetectLanguage(false).setMinTokenLength(1).setToLowercase(false)
       .setTrackNulls(true).setTrackTextLen(true)
       .setInput(rawTextMap1, rawTextMap2, rawTextMap3).getOutput()
@@ -560,7 +560,7 @@ class SmartTextMapVectorizerTest
 
     val smartVectorized = new SmartTextMapVectorizer()
       .setMaxCardinality(10).setNumFeatures(hashSize).setMinSupport(10).setTopK(topKCategorial)
-      .setMinLengthStdDev(1.0).setTokenizeForLengths(false)
+      .setMinLengthStdDev(1.0).setTextLengthType(TextLengthType.FullEntry)
       .setAutoDetectLanguage(false).setMinTokenLength(1).setToLowercase(false)
       .setTrackNulls(true).setTrackTextLen(true)
       .setInput(rawTextMap1, rawTextMap2, rawTextMap3).getOutput()

--- a/core/src/test/scala/com/salesforce/op/stages/impl/feature/SmartTextMapVectorizerTest.scala
+++ b/core/src/test/scala/com/salesforce/op/stages/impl/feature/SmartTextMapVectorizerTest.scala
@@ -444,7 +444,7 @@ class SmartTextMapVectorizerTest
 
     val smartVectorized = new SmartTextMapVectorizer()
       .setMaxCardinality(10).setNumFeatures(hashSize).setMinSupport(10).setTopK(topKCategorial)
-      .setMinLengthStdDev(1.0)
+      .setMinLengthStdDev(0.5)
       .setAutoDetectLanguage(false).setMinTokenLength(1).setToLowercase(false)
       .setTrackNulls(true).setTrackTextLen(true)
       .setInput(rawTextMap).getOutput()
@@ -480,7 +480,7 @@ class SmartTextMapVectorizerTest
 
     val smartVectorized = new SmartTextMapVectorizer()
       .setMaxCardinality(10).setNumFeatures(hashSize).setMinSupport(10).setTopK(topKCategorial)
-      .setMinLengthStdDev(1.0)
+      .setMinLengthStdDev(0.5)
       .setAutoDetectLanguage(false).setMinTokenLength(1).setToLowercase(false)
       .setTrackNulls(true).setTrackTextLen(true)
       .setInput(rawTextMap1, rawTextMap2, rawTextMap3).getOutput()

--- a/core/src/test/scala/com/salesforce/op/stages/impl/feature/SmartTextMapVectorizerTest.scala
+++ b/core/src/test/scala/com/salesforce/op/stages/impl/feature/SmartTextMapVectorizerTest.scala
@@ -40,6 +40,7 @@ import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 import com.salesforce.op.features.types._
 import com.salesforce.op.testkit.RandomText
+import org.scalatest.Assertion
 
 @RunWith(classOf[JUnitRunner])
 class SmartTextMapVectorizerTest
@@ -117,6 +118,7 @@ class SmartTextMapVectorizerTest
     "f2" -> "Olly wolly polly woggy ump bump fizz!"
   )
   val tokensMap = textMapData.mapValues(s => TextTokenizer.tokenizeString(s).tokens)
+  val tol = 1e-12 // Tolerance for comparing real numbers
 
   /**
    * Estimator instance to be tested
@@ -556,22 +558,23 @@ class SmartTextMapVectorizerTest
 
     // Check derived quantities
     val lengthSeq1 = Seq(6, 3, 3, 5, 8, 8).map(_.toLong)
-    val expectedLengthMean1 = lengthSeq1.sum / 6.0
-    val expectedLengthVariance1 = lengthSeq1.map(x => math.pow((x - expectedLengthMean1), 2)).sum / 6.0
+    val expectedLengthMean1 = lengthSeq1.sum.toDouble / lengthSeq1.length
+    val expectedLengthVariance1 = lengthSeq1.map(x => math.pow((x - expectedLengthMean1), 2)).sum / lengthSeq1.length
     val expectedLengthStdDev1 = math.sqrt(expectedLengthVariance1)
     res.keyValueCounts("f1").lengthSize shouldBe lengthSeq1.length
-    (res.keyValueCounts("f1").lengthMean - expectedLengthMean1) / expectedLengthMean1 < 1e-12 shouldBe true
-    (res.keyValueCounts("f1").lengthVariance - expectedLengthVariance1) / expectedLengthVariance1 < 1e-12 shouldBe true
-    (res.keyValueCounts("f1").lengthStdDev - expectedLengthStdDev1) / expectedLengthStdDev1 < 1e-12 shouldBe true
+    compareWithTol(res.keyValueCounts("f1").lengthMean, expectedLengthMean1, tol)
+    compareWithTol(res.keyValueCounts("f1").lengthVariance, expectedLengthVariance1, tol)
+    compareWithTol(res.keyValueCounts("f1").lengthStdDev, expectedLengthStdDev1, tol)
 
     val lengthSeq2 = Seq(4, 5, 5, 5, 3, 4, 4).map(_.toLong)
-    val expectedLengthMean2 = lengthSeq2.sum / 6.0
-    val expectedLengthVariance2 = lengthSeq2.map(x => math.pow((x - expectedLengthMean2), 2)).sum / 6.0
+    val expectedLengthMean2 = lengthSeq2.sum.toDouble / lengthSeq2.length
+    val expectedLengthVariance2 = lengthSeq2.map(x => math.pow((x - expectedLengthMean2), 2)).sum / lengthSeq2.length
     val expectedLengthStdDev2 = math.sqrt(expectedLengthVariance2)
+
     res.keyValueCounts("f2").lengthSize shouldBe lengthSeq2.length
-    (res.keyValueCounts("f2").lengthMean - expectedLengthMean2) / expectedLengthMean2 < 1e-12 shouldBe true
-    (res.keyValueCounts("f2").lengthVariance - expectedLengthVariance2) / expectedLengthVariance2 < 1e-12 shouldBe true
-    (res.keyValueCounts("f2").lengthStdDev - expectedLengthStdDev2) / expectedLengthStdDev2 < 1e-12 shouldBe true
+    compareWithTol(res.keyValueCounts("f2").lengthMean, expectedLengthMean2, tol)
+    compareWithTol(res.keyValueCounts("f2").lengthVariance, expectedLengthVariance2, tol)
+    compareWithTol(res.keyValueCounts("f2").lengthStdDev, expectedLengthStdDev2, tol)
   }
 
   it should "turn a string into a corresponding TextStats instance that respects maxCardinality" in {
@@ -594,14 +597,13 @@ class SmartTextMapVectorizerTest
     res.keyValueCounts("f2").valueCounts should contain ("Olly wolly polly woggy ump bump fizz!" -> 1)
 
     // Check token length counts
-    res.keyValueCounts("f1").lengthCounts.size shouldBe tokensMap("f1").value.map(_.length).distinct.length
+    res.keyValueCounts("f1").lengthCounts.size shouldBe 3
     res.keyValueCounts("f1").lengthCounts should contain (6 -> 1L)
     res.keyValueCounts("f1").lengthCounts should contain (3 -> 1L)
     res.keyValueCounts("f1").lengthCounts should contain (5 -> 1L)
-    res.keyValueCounts("f2").lengthCounts.size shouldBe tokensMap("f2").value.map(_.length).distinct.length
-    res.keyValueCounts("f2").lengthCounts should contain (4 -> 3L)
+    res.keyValueCounts("f2").lengthCounts.size shouldBe 3
+    res.keyValueCounts("f2").lengthCounts should contain (4 -> 1L)
     res.keyValueCounts("f2").lengthCounts should contain (5 -> 3L)
     res.keyValueCounts("f2").lengthCounts should contain (3 -> 1L)
   }
-
 }

--- a/core/src/test/scala/com/salesforce/op/stages/impl/feature/SmartTextMapVectorizerTest.scala
+++ b/core/src/test/scala/com/salesforce/op/stages/impl/feature/SmartTextMapVectorizerTest.scala
@@ -521,6 +521,7 @@ class SmartTextMapVectorizerTest
       textMapData,
       shouldCleanKeys = false,
       shouldCleanValues = false,
+      shouldTokenize = true,
       maxCardinality = 100
     )
 
@@ -552,6 +553,7 @@ class SmartTextMapVectorizerTest
       textMapData,
       shouldCleanKeys = false,
       shouldCleanValues = false,
+      shouldTokenize = true,
       maxCardinality = 100
     )
 
@@ -581,6 +583,7 @@ class SmartTextMapVectorizerTest
       textMapData,
       shouldCleanKeys = false,
       shouldCleanValues = false,
+      shouldTokenize = true,
       maxCardinality = 2
     )
 

--- a/core/src/test/scala/com/salesforce/op/stages/impl/feature/SmartTextVectorizerTest.scala
+++ b/core/src/test/scala/com/salesforce/op/stages/impl/feature/SmartTextVectorizerTest.scala
@@ -95,6 +95,7 @@ class SmartTextVectorizerTest
 
   val stringOptData: Option[String] = Some("I have got a lovely bunch of coconuts. " +
     "Here they are all standing in a row.")
+  val tol = 1e-12 // Tolerance for comparing real numbers
 
   it should "detect one categorical and one non-categorical text feature" in {
     val smartVectorized = new SmartTextVectorizer()
@@ -456,13 +457,13 @@ class SmartTextVectorizerTest
 
     // Check derived quantities
     val lengthSeq = Seq(6, 3, 3, 5, 8, 8).map(_.toLong)
-    val expectedLengthMean = lengthSeq.sum / 6.0
-    val expectedLengthVariance = lengthSeq.map(x => math.pow((x - expectedLengthMean), 2)).sum / 6.0
+    val expectedLengthMean = lengthSeq.sum.toDouble / lengthSeq.length
+    val expectedLengthVariance = lengthSeq.map(x => math.pow((x - expectedLengthMean), 2)).sum / lengthSeq.length
     val expectedLengthStdDev = math.sqrt(expectedLengthVariance)
     res.lengthSize shouldBe lengthSeq.length
-    (res.lengthMean - expectedLengthMean) / expectedLengthMean < 1e-12 shouldBe true
-    (res.lengthVariance - expectedLengthVariance) / expectedLengthVariance < 1e-12 shouldBe true
-    (res.lengthStdDev - expectedLengthStdDev) / expectedLengthStdDev < 1e-12 shouldBe true
+    compareWithTol(res.lengthMean, expectedLengthMean, tol)
+    compareWithTol(res.lengthVariance, expectedLengthVariance, tol)
+    compareWithTol(res.lengthStdDev, expectedLengthStdDev, tol)
   }
 
   it should "turn a string into a corresponding TextStats instance without cleaning" in {

--- a/core/src/test/scala/com/salesforce/op/stages/impl/feature/SmartTextVectorizerTest.scala
+++ b/core/src/test/scala/com/salesforce/op/stages/impl/feature/SmartTextVectorizerTest.scala
@@ -518,4 +518,13 @@ class SmartTextVectorizerTest
     ts.lengthStdDev shouldBe math.sqrt(0.8)
   }
 
+  it should "return sane results when entries do not tokenize and result in empty maps" in {
+    val ts = TextStats(Map("the" -> 10, "and" -> 4), Map.empty[Int, Long])
+
+    ts.lengthSize shouldBe 0
+    ts.lengthMean.isNaN shouldBe true
+    ts.lengthVariance.isNaN shouldBe true
+    ts.lengthStdDev.isNaN shouldBe true
+  }
+
 }

--- a/core/src/test/scala/com/salesforce/op/stages/impl/feature/SmartTextVectorizerTest.scala
+++ b/core/src/test/scala/com/salesforce/op/stages/impl/feature/SmartTextVectorizerTest.scala
@@ -93,7 +93,8 @@ class SmartTextVectorizerTest
   val (rawDF, rawCountry, rawCategorical, rawTextId, rawText) = TestFeatureBuilder(
     "country", "categorical", "textId", "text", generatedData)
 
-  val stringData: Option[String] = Some("I have got a lovely bunch of coconuts. Here they are all standing in a row.")
+  val stringOptData: Option[String] = Some("I have got a lovely bunch of coconuts. " +
+    "Here they are all standing in a row.")
 
   it should "detect one categorical and one non-categorical text feature" in {
     val smartVectorized = new SmartTextVectorizer()
@@ -436,13 +437,13 @@ class SmartTextVectorizerTest
   }
 
   it should "tokenize text correctly using the shortcut used in computeTextStats" in {
-    val tokens: TextList = TextTokenizer.tokenizeString(stringData).tokens
+    val tokens: TextList = TextTokenizer.tokenizeStringOpt(stringOptData).tokens
     tokens.value should contain theSameElementsAs Seq("got", "lovely", "bunch", "coconuts", "standing", "row")
   }
 
   it should "turn a string into a corresponding TextStats instance with cleaning" in {
-    val res = SmartTextVectorizer.computeTextStats(stringData, shouldCleanText = true, maxCardinality = 50)
-    val tokens: TextList = TextTokenizer.tokenizeString(stringData).tokens
+    val res = SmartTextVectorizer.computeTextStats(stringOptData, shouldCleanText = true, maxCardinality = 50)
+    val tokens: TextList = TextTokenizer.tokenizeStringOpt(stringOptData).tokens
 
     res.valueCounts.size shouldBe 1
     res.valueCounts should contain ("IHaveGotALovelyBunchOfCoconutsHereTheyAreAllStandingInARow" -> 1)
@@ -470,8 +471,8 @@ class SmartTextVectorizerTest
   }
 
   it should "turn a string into a corresponding TextStats instance without cleaning" in {
-    val res = SmartTextVectorizer.computeTextStats(stringData, shouldCleanText = false, maxCardinality = 50)
-    val tokens: TextList = TextTokenizer.tokenizeString(stringData).tokens
+    val res = SmartTextVectorizer.computeTextStats(stringOptData, shouldCleanText = false, maxCardinality = 50)
+    val tokens: TextList = TextTokenizer.tokenizeStringOpt(stringOptData).tokens
 
     res.valueCounts.size shouldBe 1
     res.valueCounts should contain ("I have got a lovely bunch of coconuts. Here they are all standing in a row." -> 1)
@@ -485,7 +486,7 @@ class SmartTextVectorizerTest
 
   it should "turn a string into a corresponding TextStats instance that respects maxCardinality" in {
     val tinyCard = 2
-    val res = SmartTextVectorizer.computeTextStats(stringData, shouldCleanText = false, maxCardinality = 2)
+    val res = SmartTextVectorizer.computeTextStats(stringOptData, shouldCleanText = false, maxCardinality = 2)
 
     res.valueCounts.size shouldBe 1
     res.valueCounts should contain ("I have got a lovely bunch of coconuts. Here they are all standing in a row." -> 1)

--- a/core/src/test/scala/com/salesforce/op/stages/impl/feature/SmartTextVectorizerTest.scala
+++ b/core/src/test/scala/com/salesforce/op/stages/impl/feature/SmartTextVectorizerTest.scala
@@ -206,7 +206,7 @@ class SmartTextVectorizerTest
 
     val smartVectorized = new SmartTextVectorizer()
       .setMaxCardinality(10).setNumFeatures(hashSize).setMinSupport(10).setTopK(topKCategorial)
-      .setMinLengthStdDev(0.5).setTokenizeForLengths(true)
+      .setMinLengthStdDev(0.5).setTextLengthType(TextLengthType.Tokens)
       .setAutoDetectLanguage(false).setMinTokenLength(1).setToLowercase(false)
       .setTrackNulls(true).setTrackTextLen(true)
       .setInput(rawCountry, rawCategorical, rawTextId, rawText).getOutput()
@@ -241,7 +241,7 @@ class SmartTextVectorizerTest
 
     val smartVectorized = new SmartTextVectorizer()
       .setMaxCardinality(10).setNumFeatures(hashSize).setMinSupport(10).setTopK(topKCategorial)
-      .setMinLengthStdDev(1.0).setTokenizeForLengths(false)
+      .setMinLengthStdDev(1.0).setTextLengthType(TextLengthType.FullEntry)
       .setAutoDetectLanguage(false).setMinTokenLength(1).setToLowercase(false)
       .setTrackNulls(true).setTrackTextLen(true)
       .setInput(rawCountry, rawCategorical, rawTextId, rawText).getOutput()

--- a/core/src/test/scala/com/salesforce/op/stages/impl/feature/SmartTextVectorizerTest.scala
+++ b/core/src/test/scala/com/salesforce/op/stages/impl/feature/SmartTextVectorizerTest.scala
@@ -443,7 +443,8 @@ class SmartTextVectorizerTest
   }
 
   it should "turn a string into a corresponding TextStats instance with cleaning" in {
-    val res = SmartTextVectorizer.computeTextStats(stringOptData, shouldCleanText = true, maxCardinality = 50)
+    val res = SmartTextVectorizer.computeTextStats(stringOptData, shouldCleanText = true, shouldTokenize = true,
+      maxCardinality = 50)
     val tokens: TextList = TextTokenizer.tokenizeStringOpt(stringOptData).tokens
 
     res.valueCounts.size shouldBe 1
@@ -467,7 +468,8 @@ class SmartTextVectorizerTest
   }
 
   it should "turn a string into a corresponding TextStats instance without cleaning" in {
-    val res = SmartTextVectorizer.computeTextStats(stringOptData, shouldCleanText = false, maxCardinality = 50)
+    val res = SmartTextVectorizer.computeTextStats(stringOptData, shouldCleanText = false, shouldTokenize = true,
+      maxCardinality = 50)
     val tokens: TextList = TextTokenizer.tokenizeStringOpt(stringOptData).tokens
 
     res.valueCounts.size shouldBe 1
@@ -482,7 +484,8 @@ class SmartTextVectorizerTest
 
   it should "turn a string into a corresponding TextStats instance that respects maxCardinality" in {
     val tinyCard = 2
-    val res = SmartTextVectorizer.computeTextStats(stringOptData, shouldCleanText = false, maxCardinality = 2)
+    val res = SmartTextVectorizer.computeTextStats(stringOptData, shouldCleanText = false, shouldTokenize = true,
+      maxCardinality = 2)
 
     res.valueCounts.size shouldBe 1
     res.valueCounts should contain ("I have got a lovely bunch of coconuts. Here they are all standing in a row." -> 1)

--- a/core/src/test/scala/com/salesforce/op/stages/impl/feature/SmartTextVectorizerTest.scala
+++ b/core/src/test/scala/com/salesforce/op/stages/impl/feature/SmartTextVectorizerTest.scala
@@ -460,11 +460,6 @@ class SmartTextVectorizerTest
     val expectedLengthVariance = lengthSeq.map(x => math.pow((x - expectedLengthMean), 2)).sum / 6.0
     val expectedLengthStdDev = math.sqrt(expectedLengthVariance)
     res.lengthSize shouldBe lengthSeq.length
-    println((res.lengthMean -  expectedLengthMean) / expectedLengthMean)
-    println((res.lengthVariance -  expectedLengthVariance) / expectedLengthVariance)
-    println((res.lengthStdDev -  expectedLengthStdDev) / expectedLengthStdDev)
-    println()
-    println(res.lengthVariance, expectedLengthVariance)
     (res.lengthMean - expectedLengthMean) / expectedLengthMean < 1e-12 shouldBe true
     (res.lengthVariance - expectedLengthVariance) / expectedLengthVariance < 1e-12 shouldBe true
     (res.lengthStdDev - expectedLengthStdDev) / expectedLengthStdDev < 1e-12 shouldBe true

--- a/core/src/test/scala/com/salesforce/op/stages/impl/feature/SmartTextVectorizerTest.scala
+++ b/core/src/test/scala/com/salesforce/op/stages/impl/feature/SmartTextVectorizerTest.scala
@@ -205,7 +205,43 @@ class SmartTextVectorizerTest
     val hashSize = 5
 
     val smartVectorized = new SmartTextVectorizer()
-      .setMaxCardinality(10).setNumFeatures(hashSize).setMinSupport(10).setTopK(topKCategorial).setMinLengthStdDev(0.5)
+      .setMaxCardinality(10).setNumFeatures(hashSize).setMinSupport(10).setTopK(topKCategorial)
+      .setMinLengthStdDev(0.5).setTokenizeForLengths(true)
+      .setAutoDetectLanguage(false).setMinTokenLength(1).setToLowercase(false)
+      .setTrackNulls(true).setTrackTextLen(true)
+      .setInput(rawCountry, rawCategorical, rawTextId, rawText).getOutput()
+
+    val transformed = new OpWorkflow().setResultFeatures(smartVectorized).transform(rawDF)
+    val result = transformed.collect(smartVectorized)
+
+    /*
+      Feature vector should have 16 components, corresponding to two hashed text fields, one categorical field, and
+      one ignored text field.
+
+      Hashed text: (5 hash buckets + 1 length + 1 null indicator) = 7 elements
+      Categorical: (3 topK + 1 other + 1 null indicator) = 5 elements
+      Ignored text: (1 length + 1 null indicator) = 2 elements
+     */
+    val featureVectorSize = 2 * (hashSize + 2) + (topKCategorial + 2) + 2
+    val firstRes = result.head
+    firstRes.v.size shouldBe featureVectorSize
+
+    val meta = OpVectorMetadata(transformed.schema(smartVectorized.name))
+    meta.columns.length shouldBe featureVectorSize
+    meta.columns.slice(0, 5).forall(_.grouping.contains("categorical"))
+    meta.columns.slice(5, 10).forall(_.grouping.contains("country"))
+    meta.columns.slice(10, 15).forall(_.grouping.contains("text"))
+    meta.columns.slice(15, 18).forall(_.descriptorValue.contains(OpVectorColumnMetadata.TextLenString))
+    meta.columns.slice(18, 21).forall(_.indicatorValue.contains(OpVectorColumnMetadata.NullString))
+  }
+
+  it should "detect and ignore fields that looks like machine-generated IDs by having a low value length variance" in {
+    val topKCategorial = 3
+    val hashSize = 5
+
+    val smartVectorized = new SmartTextVectorizer()
+      .setMaxCardinality(10).setNumFeatures(hashSize).setMinSupport(10).setTopK(topKCategorial)
+      .setMinLengthStdDev(1.0).setTokenizeForLengths(false)
       .setAutoDetectLanguage(false).setMinTokenLength(1).setToLowercase(false)
       .setTrackNulls(true).setTrackTextLen(true)
       .setInput(rawCountry, rawCategorical, rawTextId, rawText).getOutput()

--- a/features/src/main/scala/com/salesforce/op/stages/OpPipelineStageReaderWriter.scala
+++ b/features/src/main/scala/com/salesforce/op/stages/OpPipelineStageReaderWriter.scala
@@ -214,6 +214,7 @@ trait OpPipelineStageReadWriteFormats {
       EnumEntrySerializer.json4s[AnyValueTypes](AnyValueTypes) +
       EnumEntrySerializer.json4s[HashAlgorithm](HashAlgorithm) +
       EnumEntrySerializer.json4s[HashSpaceStrategy](HashSpaceStrategy) +
+      EnumEntrySerializer.json4s[TextLengthType](TextLengthType) +
       EnumEntrySerializer.json4s[TextVectorizationMethod](TextVectorizationMethod) +
       EnumEntrySerializer.json4s[ScalingType](ScalingType) +
       EnumEntrySerializer.json4s[TimePeriod](TimePeriod) +

--- a/features/src/main/scala/com/salesforce/op/stages/impl/feature/TextLengthType.scala
+++ b/features/src/main/scala/com/salesforce/op/stages/impl/feature/TextLengthType.scala
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2017, Salesforce.com, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.salesforce.op.stages.impl.feature
+
+import enumeratum._
+
+
+/**
+ * Method for computing text lengths
+ */
+sealed trait TextLengthType extends EnumEntry with Serializable
+
+object TextLengthType extends Enum[TextLengthType] {
+  val values: Seq[TextLengthType] = findValues
+
+  /**
+   * Use the full entry length for the length distribution in TextStats
+   */
+  case object FullEntry extends TextLengthType
+
+  /**
+   * Use the token lengths for the length distribution in TextStats
+   */
+  case object Tokens extends TextLengthType
+}

--- a/utils/src/main/scala/com/salesforce/op/test/TestCommon.scala
+++ b/utils/src/main/scala/com/salesforce/op/test/TestCommon.scala
@@ -132,7 +132,7 @@ trait TestCommon extends Matchers with Assertions {
 
   /**
    * Compares two real numbers using relative difference with a tolerance.
-   * It uses relative differences unless the expected value is zero, in which case it uses absolution differences.
+   * It uses relative differences unless the expected value is zero, in which case it uses absolute differences.
    *
    * @param actual    Actual value produced
    * @param expected  Expected value

--- a/utils/src/main/scala/com/salesforce/op/test/TestCommon.scala
+++ b/utils/src/main/scala/com/salesforce/op/test/TestCommon.scala
@@ -143,9 +143,9 @@ trait TestCommon extends Matchers with Assertions {
   def compareWithTol(actual: Double, expected: Double, tol: Double): Assertion =
     withClue(s"Real number comparison failure! Actual: $actual, Expected: $expected \n") {
       if (expected != 0) {
-        math.abs((actual - expected) / expected) < tol shouldBe true
+        math.abs((actual - expected) / expected) should be < tol
       }
-      else math.abs(actual - expected) < tol shouldBe true
+      else math.abs(actual - expected) should be < tol
     }
 
 }

--- a/utils/src/main/scala/com/salesforce/op/test/TestCommon.scala
+++ b/utils/src/main/scala/com/salesforce/op/test/TestCommon.scala
@@ -130,4 +130,22 @@ trait TestCommon extends Matchers with Assertions {
     if (noSpaces) raw.mkString("").replaceAll("\\s", "") else raw.mkString("\n")
   }
 
+  /**
+   * Compares two real numbers using relative difference with a tolerance.
+   * It uses relative differences unless the expected value is zero, in which case it uses absolution differences.
+   *
+   * @param actual    Actual value produced
+   * @param expected  Expected value
+   * @param tol       Tolerance for comparison. Comparison succeeds if the difference (absolute or relative) is less
+   *                  than tol.
+   * @return          Assertion to check approximate equality between actual and expected
+   */
+  def compareWithTol(actual: Double, expected: Double, tol: Double): Assertion =
+    withClue(s"Real number comparison failure! Actual: $actual, Expected: $expected \n") {
+      if (expected != 0) {
+        math.abs((actual - expected) / expected) < tol shouldBe true
+      }
+      else math.abs(actual - expected) < tol shouldBe true
+    }
+
 }


### PR DESCRIPTION
**Related issues**
n/a

**Describe the proposed solution**
Tests did not catch that the token length distributions added to TextStats were actually entry length distributions. This PR refactors some of the functions in TextTokenizer, SmartTextVectorizer, and SmartTextMapVectorizer so that they are directly testable. It also adds more robust tests to check desired behavior of the TextStats object.

**Describe alternatives you've considered**
n/a

**Additional context**
n/a
