### PR TITLE
Avoid having to have an implicit SparkSession in OpWorkFlow(Model)

### DIFF
--- a/core/src/main/scala/com/salesforce/op/OpWorkflow.scala
+++ b/core/src/main/scala/com/salesforce/op/OpWorkflow.scala
@@ -493,10 +493,8 @@ class OpWorkflow(val uid: String = UID[OpWorkflow]) extends OpWorkflowCore {
    * @param path to the trained workflow model
    * @return workflow model
    */
-  def loadModel(path: String)(implicit spark: SparkSession): OpWorkflowModel = {
-    JobGroupUtil.withJobGroup(OpStep.ModelIO) {
-      new OpWorkflowModelReader(Some(this)).load(path)
-    }
+  def loadModel(path: String): OpWorkflowModel = {
+    new OpWorkflowModelReader(Some(this)).load(path)
   }
 
   /**

--- a/core/src/main/scala/com/salesforce/op/OpWorkflowModel.scala
+++ b/core/src/main/scala/com/salesforce/op/OpWorkflowModel.scala
@@ -220,10 +220,8 @@ class OpWorkflowModel(val uid: String = UID[OpWorkflowModel], val trainingParams
    * @param path      path to save the model
    * @param overwrite should overwrite if the path exists
    */
-  def save(path: String, overwrite: Boolean = true)(implicit spark: SparkSession): Unit = {
-    JobGroupUtil.withJobGroup(OpStep.ModelIO) {
-      OpWorkflowModelWriter.save(this, path = path, overwrite = overwrite)
-    }
+  def save(path: String, overwrite: Boolean = true): Unit = {
+    new OpWorkflowModelWriter(this).save(path = path, overwrite = overwrite)
   }
 
   /**

--- a/core/src/main/scala/com/salesforce/op/OpWorkflowModelReader.scala
+++ b/core/src/main/scala/com/salesforce/op/OpWorkflowModelReader.scala
@@ -36,7 +36,9 @@ import com.salesforce.op.features.{FeatureJsonHelper, OPFeature, TransientFeatur
 import com.salesforce.op.filters.{FeatureDistribution, RawFeatureFilterResults}
 import com.salesforce.op.stages.OpPipelineStageReaderWriter._
 import com.salesforce.op.stages._
+import com.salesforce.op.utils.spark.{JobGroupUtil, OpStep}
 import org.apache.spark.ml.util.MLReader
+import org.apache.spark.sql.SparkSession
 import org.json4s.JsonAST.{JArray, JNothing, JValue}
 import org.json4s.jackson.JsonMethods.parse
 
@@ -59,10 +61,13 @@ class OpWorkflowModelReader(val workflowOpt: Option[OpWorkflow]) extends MLReade
    * @return workflow model
    */
   final override def load(path: String): OpWorkflowModel = {
-    Try(sc.textFile(OpWorkflowModelReadWriteShared.jsonPath(path), 1).collect().mkString)
-      .flatMap(loadJson(_, path = path)) match {
-      case Failure(error) => throw new RuntimeException(s"Failed to load Workflow from path '$path'", error)
-      case Success(wf) => wf
+    implicit val spark: SparkSession = this.sparkSession
+    JobGroupUtil.withJobGroup(OpStep.ModelIO) {
+      Try(sc.textFile(OpWorkflowModelReadWriteShared.jsonPath(path), 1).collect().mkString)
+        .flatMap(loadJson(_, path = path)) match {
+        case Failure(error) => throw new RuntimeException(s"Failed to load Workflow from path '$path'", error)
+        case Success(wf) => wf
+      }
     }
   }
 


### PR DESCRIPTION
**Related issues**
N/A

**Describe the proposed solution**
Avoid having to provide a `SparkSession` implicit to `OpWorkflow.loadModel`/`OpWorkflowModel.save` to keep backward compatibility.

**Describe alternatives you've considered**
N/A

**Additional context**
Small follow-up on https://github.com/salesforce/TransmogrifAI/pull/467 
