### PR TITLE
Fix Days.daysBetween int overflow

### DIFF
--- a/core/src/main/scala/com/salesforce/op/stages/impl/feature/DateListVectorizer.scala
+++ b/core/src/main/scala/com/salesforce/op/stages/impl/feature/DateListVectorizer.scala
@@ -41,7 +41,7 @@ import com.salesforce.op.utils.spark.OpVectorColumnMetadata
 import enumeratum._
 import org.apache.spark.ml.linalg.Vectors
 import org.apache.spark.ml.param.{BooleanParam, DoubleParam, LongParam, ParamValidators}
-import org.joda.time.{DateTime, DateTimeConstants, Days}
+import org.joda.time.{DateTime, DateTimeConstants, Duration}
 
 import scala.reflect.runtime.universe._
 
@@ -203,7 +203,10 @@ class DateListVectorizer[T <: OPList[Long]]
       if (dt.isEmpty) Seq($(fillValue))
       else {
         val compareDate = if ($(first)) dt.v.min else dt.v.max
-        Seq(Days.daysBetween(new DateTime(compareDate, DateTimeUtils.DefaultTimeZone), getReferenceDate()).getDays)
+        Seq(new Duration(
+          new DateTime(compareDate, DateTimeUtils.DefaultTimeZone
+          ), getReferenceDate()).getStandardDays.toDouble
+        )
       }
     if ($(trackNulls)) days :+ (dt.isEmpty : Double) else days
   }

--- a/core/src/main/scala/com/salesforce/op/stages/impl/feature/DateListVectorizer.scala
+++ b/core/src/main/scala/com/salesforce/op/stages/impl/feature/DateListVectorizer.scala
@@ -41,7 +41,7 @@ import com.salesforce.op.utils.spark.OpVectorColumnMetadata
 import enumeratum._
 import org.apache.spark.ml.linalg.Vectors
 import org.apache.spark.ml.param.{BooleanParam, DoubleParam, LongParam, ParamValidators}
-import org.joda.time.{DateTime, DateTimeConstants, Duration}
+import org.joda.time.{DateTime, DateTimeConstants}
 
 import scala.reflect.runtime.universe._
 
@@ -203,10 +203,7 @@ class DateListVectorizer[T <: OPList[Long]]
       if (dt.isEmpty) Seq($(fillValue))
       else {
         val compareDate = if ($(first)) dt.v.min else dt.v.max
-        Seq(new Duration(
-          new DateTime(compareDate, DateTimeUtils.DefaultTimeZone
-          ), getReferenceDate()).getStandardDays.toDouble
-        )
+        Seq(DateTimeUtils.getStandardDays(startMillis = compareDate, endMillis = $(referenceDate)))
       }
     if ($(trackNulls)) days :+ (dt.isEmpty : Double) else days
   }

--- a/core/src/main/scala/com/salesforce/op/stages/impl/feature/OPMapVectorizer.scala
+++ b/core/src/main/scala/com/salesforce/op/stages/impl/feature/OPMapVectorizer.scala
@@ -40,7 +40,7 @@ import org.apache.spark.ml.linalg.Vectors
 import org.apache.spark.ml.param._
 import org.apache.spark.sql.types.MetadataBuilder
 import org.apache.spark.sql.{Dataset, Encoders}
-import org.joda.time.{DateTime, DateTimeZone, Days}
+import org.joda.time.{DateTime, DateTimeZone, Days, Duration}
 
 import scala.reflect.runtime.universe.TypeTag
 
@@ -397,7 +397,7 @@ final class DateMapVectorizerModel[T <: OPMap[Long]] private[op]
   val timeZone: DateTimeZone = DateTimeUtils.DefaultTimeZone
 
   def convertFn: DateMap#Value => RealMap#Value = (dt: DateMap#Value) =>
-    dt.mapValues(v => Days.daysBetween(new DateTime(v, timeZone), referenceDate).getDays.toDouble)
+    dt.mapValues(v => new Duration(new DateTime(v, timeZone), referenceDate).getStandardDays.toDouble)
 }
 
 final class RealMapVectorizerModel[T <: OPMap[Double]] private[op]

--- a/core/src/main/scala/com/salesforce/op/stages/impl/feature/OPMapVectorizer.scala
+++ b/core/src/main/scala/com/salesforce/op/stages/impl/feature/OPMapVectorizer.scala
@@ -40,7 +40,7 @@ import org.apache.spark.ml.linalg.Vectors
 import org.apache.spark.ml.param._
 import org.apache.spark.sql.types.MetadataBuilder
 import org.apache.spark.sql.{Dataset, Encoders}
-import org.joda.time.{DateTime, DateTimeZone, Days, Duration}
+import org.joda.time.DateTime
 
 import scala.reflect.runtime.universe.TypeTag
 
@@ -394,10 +394,9 @@ final class DateMapVectorizerModel[T <: OPMap[Long]] private[op]
   uid: String
 )(implicit tti: TypeTag[T])
   extends OPMapVectorizerModel[Long, T](args = args, operationName = operationName, uid = uid) {
-  val timeZone: DateTimeZone = DateTimeUtils.DefaultTimeZone
 
   def convertFn: DateMap#Value => RealMap#Value = (dt: DateMap#Value) =>
-    dt.mapValues(v => new Duration(new DateTime(v, timeZone), referenceDate).getStandardDays.toDouble)
+    dt.mapValues(v => DateTimeUtils.getStandardDays(v, referenceDate.getMillis))
 }
 
 final class RealMapVectorizerModel[T <: OPMap[Double]] private[op]

--- a/core/src/test/scala/com/salesforce/op/stages/impl/feature/DateMapVectorizerTest.scala
+++ b/core/src/test/scala/com/salesforce/op/stages/impl/feature/DateMapVectorizerTest.scala
@@ -38,7 +38,7 @@ import com.salesforce.op.utils.date.DateTimeUtils
 import com.salesforce.op.utils.spark.RichDataset._
 import com.salesforce.op.utils.spark.OpVectorMetadata
 import org.apache.spark.ml.linalg.Vectors
-import org.joda.time.{DateTimeConstants, Days, DateTime => JDateTime}
+import org.joda.time.{DateTimeConstants, Duration, DateTime => JDateTime}
 import org.junit.runner.RunWith
 import org.scalatest.FlatSpec
 import org.scalatest.junit.JUnitRunner
@@ -106,9 +106,10 @@ class DateMapVectorizerTest extends FlatSpec with TestSparkContext with Attribut
     val zero = 0
     val threeDaysAgo = moment.minus(3 * DateTimeConstants.MILLIS_PER_DAY).getMillis / DateTimeConstants.MILLIS_PER_DAY
     val defaultTimeAgo = moment.minus(defaultDate).getMillis / DateTimeConstants.MILLIS_PER_DAY
-    val hundredDaysAgo = Days
-      .daysBetween(new JDateTime(moment.plusDays(100).getMillis, DateTimeUtils.DefaultTimeZone), moment)
-      .getDays
+    val hundredDaysAgo = new Duration(
+      new JDateTime(moment.plusDays(100).getMillis, DateTimeUtils.DefaultTimeZone),
+      moment
+    ).getStandardDays
 
     Array(
       Array(nowMinusMilli, defaultTimeAgo, threeDaysAgo),
@@ -122,6 +123,7 @@ class DateMapVectorizerTest extends FlatSpec with TestSparkContext with Attribut
   }
 
   it should "vectorize dates correctly on test date" in {
+    checkAt(new JDateTime(2017, 9, 28, 15, 45, 39, DateTimeUtils.DefaultTimeZone))
     checkAt(new JDateTime(1901, 1, 1, 0, 0, 0, DateTimeUtils.DefaultTimeZone))
   }
 

--- a/core/src/test/scala/com/salesforce/op/stages/impl/feature/DateMapVectorizerTest.scala
+++ b/core/src/test/scala/com/salesforce/op/stages/impl/feature/DateMapVectorizerTest.scala
@@ -122,7 +122,7 @@ class DateMapVectorizerTest extends FlatSpec with TestSparkContext with Attribut
   }
 
   it should "vectorize dates correctly on test date" in {
-    checkAt(new JDateTime(2017, 9, 28, 15, 45, 39, DateTimeUtils.DefaultTimeZone))
+    checkAt(new JDateTime(1901, 1, 1, 0, 0, 0, DateTimeUtils.DefaultTimeZone))
   }
 
   it should "serialize correctly" in new SampleData(DateTimeUtils.now().minusHours(1)) {

--- a/core/src/test/scala/com/salesforce/op/stages/impl/feature/DateMapVectorizerTest.scala
+++ b/core/src/test/scala/com/salesforce/op/stages/impl/feature/DateMapVectorizerTest.scala
@@ -30,15 +30,14 @@
 
 package com.salesforce.op.stages.impl.feature
 
-import com.salesforce.op._
+import com.salesforce.op.{OpWorkflow, _}
 import com.salesforce.op.features.types._
-import com.salesforce.op.OpWorkflow
 import com.salesforce.op.test.{TestFeatureBuilder, TestSparkContext}
 import com.salesforce.op.utils.date.DateTimeUtils
-import com.salesforce.op.utils.spark.RichDataset._
 import com.salesforce.op.utils.spark.OpVectorMetadata
+import com.salesforce.op.utils.spark.RichDataset._
 import org.apache.spark.ml.linalg.Vectors
-import org.joda.time.{DateTimeConstants, Duration, DateTime => JDateTime}
+import org.joda.time.{DateTimeConstants, DateTime => JDateTime}
 import org.junit.runner.RunWith
 import org.scalatest.FlatSpec
 import org.scalatest.junit.JUnitRunner
@@ -106,10 +105,8 @@ class DateMapVectorizerTest extends FlatSpec with TestSparkContext with Attribut
     val zero = 0
     val threeDaysAgo = moment.minus(3 * DateTimeConstants.MILLIS_PER_DAY).getMillis / DateTimeConstants.MILLIS_PER_DAY
     val defaultTimeAgo = moment.minus(defaultDate).getMillis / DateTimeConstants.MILLIS_PER_DAY
-    val hundredDaysAgo = new Duration(
-      new JDateTime(moment.plusDays(100).getMillis, DateTimeUtils.DefaultTimeZone),
-      moment
-    ).getStandardDays
+    val hundredDaysAgo = DateTimeUtils
+      .getStandardDays(moment.plusDays(100).getMillis, moment.getMillis)
 
     Array(
       Array(nowMinusMilli, defaultTimeAgo, threeDaysAgo),

--- a/core/src/test/scala/com/salesforce/op/stages/impl/feature/DateTimeVectorizerTest.scala
+++ b/core/src/test/scala/com/salesforce/op/stages/impl/feature/DateTimeVectorizerTest.scala
@@ -37,7 +37,7 @@ import com.salesforce.op.utils.date.DateTimeUtils
 import com.salesforce.op.utils.spark.OpVectorMetadata
 import com.salesforce.op.utils.spark.RichDataset._
 import org.apache.spark.ml.linalg.Vectors
-import org.joda.time.{DateTimeConstants, Days, DateTime => JDateTime}
+import org.joda.time.{DateTimeConstants, Days, Duration, DateTime => JDateTime}
 import org.junit.runner.RunWith
 import org.scalatest.FlatSpec
 import org.scalatest.junit.JUnitRunner
@@ -56,9 +56,10 @@ class DateTimeVectorizerTest extends FlatSpec with TestSparkContext with Attribu
     val zero = 0
     val threeDaysAgo = moment.minus(3 * DateTimeConstants.MILLIS_PER_DAY).getMillis / DateTimeConstants.MILLIS_PER_DAY
     val defaultTimeAgo = moment.minus(defaultDate).getMillis / DateTimeConstants.MILLIS_PER_DAY
-    val hundredDaysAgo = Days
-      .daysBetween(new JDateTime(moment.plusDays(100).getMillis, DateTimeUtils.DefaultTimeZone), moment)
-      .getDays
+    val hundredDaysAgo = new Duration(
+      new JDateTime(moment.plusDays(100).getMillis, DateTimeUtils.DefaultTimeZone),
+      moment
+    ).getStandardDays
 
     Array(
       Array(nowMinusMilli, zero, now),

--- a/core/src/test/scala/com/salesforce/op/stages/impl/feature/DateTimeVectorizerTest.scala
+++ b/core/src/test/scala/com/salesforce/op/stages/impl/feature/DateTimeVectorizerTest.scala
@@ -37,7 +37,7 @@ import com.salesforce.op.utils.date.DateTimeUtils
 import com.salesforce.op.utils.spark.OpVectorMetadata
 import com.salesforce.op.utils.spark.RichDataset._
 import org.apache.spark.ml.linalg.Vectors
-import org.joda.time.{DateTimeConstants, Days, Duration, DateTime => JDateTime}
+import org.joda.time.{DateTimeConstants, DateTime => JDateTime}
 import org.junit.runner.RunWith
 import org.scalatest.FlatSpec
 import org.scalatest.junit.JUnitRunner
@@ -56,10 +56,10 @@ class DateTimeVectorizerTest extends FlatSpec with TestSparkContext with Attribu
     val zero = 0
     val threeDaysAgo = moment.minus(3 * DateTimeConstants.MILLIS_PER_DAY).getMillis / DateTimeConstants.MILLIS_PER_DAY
     val defaultTimeAgo = moment.minus(defaultDate).getMillis / DateTimeConstants.MILLIS_PER_DAY
-    val hundredDaysAgo = new Duration(
-      new JDateTime(moment.plusDays(100).getMillis, DateTimeUtils.DefaultTimeZone),
-      moment
-    ).getStandardDays
+    val hundredDaysAgo = DateTimeUtils.getStandardDays(
+      moment.plusDays(100).getMillis,
+      moment.getMillis
+    )
 
     Array(
       Array(nowMinusMilli, zero, now),

--- a/core/src/test/scala/com/salesforce/op/stages/impl/feature/DateVectorizerTest.scala
+++ b/core/src/test/scala/com/salesforce/op/stages/impl/feature/DateVectorizerTest.scala
@@ -37,7 +37,7 @@ import com.salesforce.op.utils.date.DateTimeUtils
 import com.salesforce.op.utils.spark.OpVectorMetadata
 import com.salesforce.op.utils.spark.RichDataset._
 import org.apache.spark.ml.linalg.Vectors
-import org.joda.time.{DateTime, DateTimeConstants, DateTimeZone, Days}
+import org.joda.time.{DateTime, DateTimeConstants, DateTimeZone, Duration}
 import org.junit.runner.RunWith
 import org.scalatest.FlatSpec
 import org.scalatest.junit.JUnitRunner
@@ -122,9 +122,10 @@ class DateVectorizerTest extends FlatSpec with TestSparkContext with AttributeAs
     val zero = 0
     val threeDaysAgo = moment.minus(3 * DateTimeConstants.MILLIS_PER_DAY).getMillis / DateTimeConstants.MILLIS_PER_DAY
     val defaultTimeAgo = moment.minus(defaultDate).getMillis / DateTimeConstants.MILLIS_PER_DAY
-    val hundredDaysAgo = Days
-      .daysBetween(new DateTime(moment.plusDays(100).getMillis, DateTimeUtils.DefaultTimeZone), moment)
-      .getDays
+    val hundredDaysAgo = new Duration(
+      new DateTime(moment.plusDays(100).getMillis, DateTimeUtils.DefaultTimeZone),
+      moment
+    ).getStandardDays
 
     Array(
       Array(nowMinusMilli, zero, now),

--- a/core/src/test/scala/com/salesforce/op/stages/impl/feature/DateVectorizerTest.scala
+++ b/core/src/test/scala/com/salesforce/op/stages/impl/feature/DateVectorizerTest.scala
@@ -37,7 +37,7 @@ import com.salesforce.op.utils.date.DateTimeUtils
 import com.salesforce.op.utils.spark.OpVectorMetadata
 import com.salesforce.op.utils.spark.RichDataset._
 import org.apache.spark.ml.linalg.Vectors
-import org.joda.time.{DateTime, DateTimeConstants, DateTimeZone, Duration}
+import org.joda.time.{DateTime, DateTimeConstants, DateTimeZone}
 import org.junit.runner.RunWith
 import org.scalatest.FlatSpec
 import org.scalatest.junit.JUnitRunner
@@ -122,10 +122,10 @@ class DateVectorizerTest extends FlatSpec with TestSparkContext with AttributeAs
     val zero = 0
     val threeDaysAgo = moment.minus(3 * DateTimeConstants.MILLIS_PER_DAY).getMillis / DateTimeConstants.MILLIS_PER_DAY
     val defaultTimeAgo = moment.minus(defaultDate).getMillis / DateTimeConstants.MILLIS_PER_DAY
-    val hundredDaysAgo = new Duration(
-      new DateTime(moment.plusDays(100).getMillis, DateTimeUtils.DefaultTimeZone),
-      moment
-    ).getStandardDays
+    val hundredDaysAgo = DateTimeUtils.getStandardDays(
+      moment.plusDays(100).getMillis,
+      moment.getMillis
+    )
 
     Array(
       Array(nowMinusMilli, zero, now),

--- a/utils/src/main/scala/com/salesforce/op/utils/date/DateTimeUtils.scala
+++ b/utils/src/main/scala/com/salesforce/op/utils/date/DateTimeUtils.scala
@@ -129,6 +129,13 @@ object DateTimeUtils {
   }
 
 
+  /**
+   * Days between epoch start and end
+   *
+   * @param startMillis start Unix time in millis
+   * @param endMillis end Unix time in millis
+   * @return Duration in days between start and end Unix times
+   */
   def getStandardDays(startMillis: Long, endMillis: Long): Long = {
     Duration.millis(endMillis - startMillis).getStandardDays
   }

--- a/utils/src/main/scala/com/salesforce/op/utils/date/DateTimeUtils.scala
+++ b/utils/src/main/scala/com/salesforce/op/utils/date/DateTimeUtils.scala
@@ -110,7 +110,7 @@ object DateTimeUtils {
     val start = new DateTime(parse(startDate, DefaultTimeZoneStr), DefaultTimeZone)
     val end = new DateTime(parse(endDate, DefaultTimeZoneStr), DefaultTimeZone)
     val days = new Duration(start, end).getStandardDays
-    (0 to days).map(d => parseUnix(start.plusDays(d.toInt).getMillis))
+    (0 to days.toInt).map(d => parseUnix(start.plusDays(d).getMillis))
   }
 
   /**

--- a/utils/src/main/scala/com/salesforce/op/utils/date/DateTimeUtils.scala
+++ b/utils/src/main/scala/com/salesforce/op/utils/date/DateTimeUtils.scala
@@ -33,7 +33,7 @@ package com.salesforce.op.utils.date
 import java.util.TimeZone
 
 import org.joda.time.format.{DateTimeFormat, DateTimeFormatter, DateTimeFormatterBuilder, ISODateTimeFormat}
-import org.joda.time.{DateTime, DateTimeZone, Days}
+import org.joda.time.{DateTime, DateTimeZone, Duration}
 
 
 object DateTimeUtils {
@@ -109,8 +109,8 @@ object DateTimeUtils {
   def getRange(startDate: String, endDate: String): Seq[String] = {
     val start = new DateTime(parse(startDate, DefaultTimeZoneStr), DefaultTimeZone)
     val end = new DateTime(parse(endDate, DefaultTimeZoneStr), DefaultTimeZone)
-    val days = Days.daysBetween(start, end).getDays
-    (0 to days).map(d => parseUnix(start.plusDays(d).getMillis))
+    val days = new Duration(start, end).getStandardDays
+    (0 to days).map(d => parseUnix(start.plusDays(d.toInt).getMillis))
   }
 
   /**

--- a/utils/src/main/scala/com/salesforce/op/utils/date/DateTimeUtils.scala
+++ b/utils/src/main/scala/com/salesforce/op/utils/date/DateTimeUtils.scala
@@ -107,10 +107,13 @@ object DateTimeUtils {
    * @return sequence of YYYY/MM/dd strings from the start to the end dates inclusive
    */
   def getRange(startDate: String, endDate: String): Seq[String] = {
-    val start = new DateTime(parse(startDate, DefaultTimeZoneStr), DefaultTimeZone)
-    val end = new DateTime(parse(endDate, DefaultTimeZoneStr), DefaultTimeZone)
-    val days = new Duration(start, end).getStandardDays
-    (0 to days.toInt).map(d => parseUnix(start.plusDays(d).getMillis))
+    val start = parse(startDate, DefaultTimeZoneStr)
+    val end = parse(endDate, DefaultTimeZoneStr)
+    val days = getStandardDays(start, end)
+    (0 to days.toInt).map { day =>
+      val dur = Duration.millis(start).plus(Duration.standardDays(day))
+      parseUnix(dur.getMillis)
+    }
   }
 
   /**
@@ -123,5 +126,10 @@ object DateTimeUtils {
   def getDatePlusDays(startDate: String, difference: Int): String = {
     val start = new DateTime(parse(startDate, DefaultTimeZoneStr), DefaultTimeZone)
     parseUnix(start.plusDays(difference).getMillis)
+  }
+
+
+  def getStandardDays(startMillis: Long, endMillis: Long): Long = {
+    Duration.millis(endMillis - startMillis).getStandardDays
   }
 }


### PR DESCRIPTION
`Days.daysBetween(datetime_1, datetime_2)` could throw `java.lang.ArithmeticException: Value cannot fit in an int:` if the duration between two dates in milliseconds cannot fit a 32-bit int representation. See related Stack Overflow issue [here](https://stackoverflow.com/questions/25204043/joda-time-calculation-of-seconds-between-two-dates-throws-an-exception)

**Describe the proposed solution**
Switch to using joda's `Duration`. 

**Describe alternatives you've considered**
N/A 

**Additional context**
N/A