### PR TITLE
Add categorical detection to be coverage based in addition to unique count based

### DIFF
--- a/core/src/main/scala/com/salesforce/op/stages/impl/feature/SmartTextMapVectorizer.scala
+++ b/core/src/main/scala/com/salesforce/op/stages/impl/feature/SmartTextMapVectorizer.scala
@@ -156,8 +156,8 @@ class SmartTextMapVectorizer[T <: OPMap[String]]
           //
           //  - Cardinality must be greater than maxCard (already mentioned above).
           //  - Cardinality must also be greater than topK.
-          //  - Finally, the computed coverage of the topK with minimum support must be > 0.  
-          case _ if textStats.valueCounts.size > maxCard && textStats.valueCounts.size > topKValue && coverage > 0 &&
+          //  - Finally, the computed coverage of the topK with minimum support must be > 0.
+          case _ if textStats.valueCounts.size > maxCard && textStats.valueCounts.size > topKValue &&
             coverage >= $(coveragePct) => TextVectorizationMethod.Pivot
           case _ if textStats.valueCounts.size <= maxCard => TextVectorizationMethod.Pivot
           case _ if textStats.lengthStdDev < minLenStdDev => TextVectorizationMethod.Ignore

--- a/core/src/main/scala/com/salesforce/op/stages/impl/feature/SmartTextMapVectorizer.scala
+++ b/core/src/main/scala/com/salesforce/op/stages/impl/feature/SmartTextMapVectorizer.scala
@@ -150,9 +150,7 @@ class SmartTextMapVectorizer[T <: OPMap[String]]
         val coverage = cumSum.lift(math.min(topKValue, cumSum.length - 1)).getOrElse(0L) * 1.0 / totalCount
         val vecMethod: TextVectorizationMethod = textStats match {
           case _ if textStats.valueCounts.size > maxCard && textStats.valueCounts.size > topKValue && coverage > 0 &&
-            coverage >= $(coveragePct) =>
-            println(s"Pivot ${textStats.valueCounts}")
-            TextVectorizationMethod.Pivot
+            coverage >= $(coveragePct) => TextVectorizationMethod.Pivot
           case _ if textStats.valueCounts.size <= maxCard => TextVectorizationMethod.Pivot
           case _ if textStats.lengthStdDev < minLenStdDev => TextVectorizationMethod.Ignore
           case _ => TextVectorizationMethod.Hash

--- a/core/src/main/scala/com/salesforce/op/stages/impl/feature/SmartTextMapVectorizer.scala
+++ b/core/src/main/scala/com/salesforce/op/stages/impl/feature/SmartTextMapVectorizer.scala
@@ -151,7 +151,12 @@ class SmartTextMapVectorizer[T <: OPMap[String]]
           .getOrElse(Seq.empty)
         val coverage = cumCount.lift(math.min(topKValue, cumCount.length) - 1).getOrElse(0L) * 1.0 / totalCount
         val vecMethod: TextVectorizationMethod = textStats match {
-          // If cardinality not respect, but coverage is, then pivot the feature
+          // If cardinality not respected, but coverage is, then pivot the feature
+          // Extra checks need to be passed :
+          //
+          //  - Cardinality must be greater than maxCard (already mentioned above).
+          //  - Cardinality must also be greater than topK.
+          //  - Finally, the computed coverage of the topK with minimum support must be > 0.  
           case _ if textStats.valueCounts.size > maxCard && textStats.valueCounts.size > topKValue && coverage > 0 &&
             coverage >= $(coveragePct) => TextVectorizationMethod.Pivot
           case _ if textStats.valueCounts.size <= maxCard => TextVectorizationMethod.Pivot

--- a/core/src/main/scala/com/salesforce/op/stages/impl/feature/SmartTextMapVectorizer.scala
+++ b/core/src/main/scala/com/salesforce/op/stages/impl/feature/SmartTextMapVectorizer.scala
@@ -140,8 +140,12 @@ class SmartTextMapVectorizer[T <: OPMap[String]]
 
     val allFeatureInfo = aggregatedStats.toSeq.map { textMapStats =>
       textMapStats.keyValueCounts.toSeq.map { case (k, textStats) =>
+        val totalCount = textStats.valueCounts.values.sum
+        val top100 = textStats.valueCounts.toSeq.sortBy(- _._2).take(100).toMap
+
         val vecMethod: TextVectorizationMethod = textStats match {
-          case _ if textStats.valueCounts.size <= maxCard => TextVectorizationMethod.Pivot
+          case _ if top100.size < 100 && textStats.valueCounts.size <= maxCard => TextVectorizationMethod.Pivot
+          case _ if top100.size >= 100 && top100.values.sum * 1.0 / totalCount >= 0.9 => TextVectorizationMethod.Pivot
           case _ if textStats.lengthStdDev < minLenStdDev => TextVectorizationMethod.Ignore
           case _ => TextVectorizationMethod.Hash
         }

--- a/core/src/main/scala/com/salesforce/op/stages/impl/feature/SmartTextMapVectorizer.scala
+++ b/core/src/main/scala/com/salesforce/op/stages/impl/feature/SmartTextMapVectorizer.scala
@@ -147,7 +147,7 @@ class SmartTextMapVectorizer[T <: OPMap[String]]
         val sortedValues = sorted.map(_._2)
         val cumSum = sortedValues.headOption.map(_ => sortedValues.tail.scanLeft(sortedValues.head)(_ + _))
           .getOrElse(Seq.empty)
-        val coverage = cumSum.lift(math.min(topKValue, cumSum.length - 1)).getOrElse(0L) * 1.0 / totalCount
+        val coverage = cumSum.lift(math.min(topKValue, cumSum.length) - 1).getOrElse(0L) * 1.0 / totalCount
         val vecMethod: TextVectorizationMethod = textStats match {
           case _ if textStats.valueCounts.size > maxCard && textStats.valueCounts.size > topKValue && coverage > 0 &&
             coverage >= $(coveragePct) => TextVectorizationMethod.Pivot

--- a/core/src/main/scala/com/salesforce/op/stages/impl/feature/SmartTextVectorizer.scala
+++ b/core/src/main/scala/com/salesforce/op/stages/impl/feature/SmartTextVectorizer.scala
@@ -98,7 +98,7 @@ class SmartTextVectorizer[T <: Text](uid: String = UID[SmartTextVectorizer[T]])(
       val sortedValues = sorted.map(_._2)
       val cumSum = sortedValues.headOption.map(_ => sortedValues.tail.scanLeft(sortedValues.head)(_ + _))
         .getOrElse(Seq.empty)
-      val coverage = cumSum.lift(math.min(topKValue, cumSum.length - 1)).getOrElse(0L) * 1.0 / totalCount
+      val coverage = cumSum.lift(math.min(topKValue, cumSum.length) - 1).getOrElse(0L) * 1.0 / totalCount
       val vecMethod: TextVectorizationMethod = stats match {
         case _ if stats.valueCounts.size > maxCard && stats.valueCounts.size > topKValue && coverage > 0 &&
           coverage >= $(coveragePct) => TextVectorizationMethod.Pivot

--- a/core/src/main/scala/com/salesforce/op/stages/impl/feature/SmartTextVectorizer.scala
+++ b/core/src/main/scala/com/salesforce/op/stages/impl/feature/SmartTextVectorizer.scala
@@ -109,8 +109,8 @@ class SmartTextVectorizer[T <: Text](uid: String = UID[SmartTextVectorizer[T]])(
         //  - Cardinality must be greater than maxCard (already mentioned above).
         //  - Cardinality must also be greater than topK.
         //  - Finally, the computed coverage of the topK with minimum support must be > 0.
-        case _ if stats.valueCounts.size > maxCard && stats.valueCounts.size > topKValue && coverage > 0 &&
-          coverage >= $(coveragePct) => TextVectorizationMethod.Pivot
+        case _ if stats.valueCounts.size > maxCard && stats.valueCounts.size > topKValue && coverage >= $(coveragePct)
+        => TextVectorizationMethod.Pivot
         case _ if stats.valueCounts.size <= maxCard => TextVectorizationMethod.Pivot
         case _ if stats.lengthStdDev < minLenStdDev => TextVectorizationMethod.Ignore
         case _ => TextVectorizationMethod.Hash
@@ -388,7 +388,7 @@ trait MaxCardinalityParams extends Params {
     parent = this, name = "coveragePct",
     doc = "Threshold of percentage of the entries. If the topK entries make up for more than this pecentage," +
       " the feature is treated as a categorical",
-    isValid = ParamValidators.inRange(lowerBound = 0, upperBound = 1)
+    isValid = ParamValidators.inRange(lowerBound = 0, upperBound = 1, lowerInclusive = false, upperInclusive = true)
   )
   final def setCoveragePct(v: Double): this.type = set(coveragePct, v)
   final def getCoveragePct: Double = $(coveragePct)

--- a/core/src/main/scala/com/salesforce/op/stages/impl/feature/SmartTextVectorizer.scala
+++ b/core/src/main/scala/com/salesforce/op/stages/impl/feature/SmartTextVectorizer.scala
@@ -103,7 +103,12 @@ class SmartTextVectorizer[T <: Text](uid: String = UID[SmartTextVectorizer[T]])(
         .getOrElse(Seq.empty)
       val coverage = cumCount.lift(math.min(topKValue, cumCount.length) - 1).getOrElse(0L) * 1.0 / totalCount
       val vecMethod: TextVectorizationMethod = stats match {
-        // If cardinality not respect, but coverage is, then pivot the feature
+        // If cardinality not respected, but coverage is, then pivot the feature
+        // Extra checks need to be passed :
+        //
+        //  - Cardinality must be greater than maxCard (already mentioned above).
+        //  - Cardinality must also be greater than topK.
+        //  - Finally, the computed coverage of the topK with minimum support must be > 0.
         case _ if stats.valueCounts.size > maxCard && stats.valueCounts.size > topKValue && coverage > 0 &&
           coverage >= $(coveragePct) => TextVectorizationMethod.Pivot
         case _ if stats.valueCounts.size <= maxCard => TextVectorizationMethod.Pivot

--- a/core/src/main/scala/com/salesforce/op/stages/impl/feature/SmartTextVectorizer.scala
+++ b/core/src/main/scala/com/salesforce/op/stages/impl/feature/SmartTextVectorizer.scala
@@ -32,11 +32,10 @@ package com.salesforce.op.stages.impl.feature
 
 import com.salesforce.op.UID
 import com.salesforce.op.features.TransientFeature
-import com.salesforce.op.features.types.{OPVector, Text, TextList, VectorConversions, SeqDoubleConversions}
+import com.salesforce.op.features.types._
 import com.salesforce.op.stages.base.sequence.{SequenceEstimator, SequenceModel}
 import com.salesforce.op.stages.impl.feature.VectorizerUtils._
 import com.salesforce.op.utils.json.JsonLike
-import com.salesforce.op.utils.spark.RichDataset._
 import com.salesforce.op.utils.spark.{OpVectorColumnMetadata, OpVectorMetadata}
 import com.twitter.algebird.Monoid
 import com.twitter.algebird.Monoid._
@@ -91,20 +90,31 @@ class SmartTextVectorizer[T <: Text](uid: String = UID[SmartTextVectorizer[T]])(
     )
     val aggregatedStats: Array[TextStats] = valueStats.reduce(_ + _)
 
+    val topKValue = $(topK)
     val (vectorizationMethods, topValues) = aggregatedStats.map { stats =>
       val totalCount = stats.valueCounts.values.sum
-      val top100 = stats.valueCounts.toSeq.sortBy(- _._2).take(100).toMap
+      val filteredStats = stats.valueCounts.filter { case (_, count) => count >= $(minSupport) }
+      val sorted = filteredStats.toSeq.sortBy(- _._2)
+      val sortedValues = sorted.map(_._2)
+      val cumSum = sortedValues.headOption.map(_ => sortedValues.tail.scanLeft(sortedValues.head)(_ + _))
+        .getOrElse(Seq.empty)
+      val coverage = cumSum.lift(math.min(topKValue, cumSum.length - 1)).getOrElse(0L) * 1.0 / totalCount
+      println(sorted)
+      println(sorted.map(_._1).zip(cumSum))
+      println(coverage)
 
       val vecMethod: TextVectorizationMethod = stats match {
-        case _ if top100.size < 100 && stats.valueCounts.size <= maxCard => TextVectorizationMethod.Pivot
-        case _ if top100.size >= 100 && top100.values.sum * 1.0 / totalCount >= 0.9 => TextVectorizationMethod.Pivot
+        case _ if stats.valueCounts.size > maxCard && stats.valueCounts.size > topKValue && coverage > 0 &&
+          coverage >= $(coveragePct) =>
+          println(s"Pivot ${stats.valueCounts}")
+          TextVectorizationMethod.Pivot
+        case _ if stats.valueCounts.size <= maxCard => TextVectorizationMethod.Pivot
         case _ if stats.lengthStdDev < minLenStdDev => TextVectorizationMethod.Ignore
         case _ => TextVectorizationMethod.Hash
       }
-      val topValues = stats.valueCounts
-        .filter { case (_, count) => count >= $(minSupport) }
+      val topValues = filteredStats
         .toSeq.sortBy(v => -v._2 -> v._1)
-        .take($(topK)).map(_._1)
+        .take(topKValue).map(_._1)
       (vecMethod, topValues)
     }.unzip
 
@@ -173,9 +183,10 @@ class SmartTextVectorizer[T <: Text](uid: String = UID[SmartTextVectorizer[T]])(
 }
 
 object SmartTextVectorizer {
-  val MaxCardinality: Int = 200
+  val MaxCardinality: Int = 1000
   val MinTextLengthStdDev: Double = 0
   val LengthType: TextLengthType = TextLengthType.FullEntry
+  val CoveragePct: Double = 0.90
 
   private[op] def partition[T: ClassTag](input: Array[T], condition: Array[Boolean]): (Array[T], Array[T]) = {
     val all = input.zip(condition)
@@ -369,6 +380,16 @@ trait MaxCardinalityParams extends Params {
   final def setMaxCardinality(v: Int): this.type = set(maxCardinality, v)
   final def getMaxCardinality: Int = $(maxCardinality)
   setDefault(maxCardinality -> SmartTextVectorizer.MaxCardinality)
+
+  final val coveragePct = new DoubleParam(
+    parent = this, name = "coveragePct",
+    doc = "Threshold of percentage of the entries. If the topK entries make up for more than this pecentage," +
+      " the feature is treated as a categorical",
+    isValid = ParamValidators.inRange(lowerBound = 0, upperBound = 1)
+  )
+  final def setCoveragePct(v: Double): this.type = set(coveragePct, v)
+  final def getCoveragePct: Double = $(coveragePct)
+  setDefault(coveragePct -> SmartTextVectorizer.CoveragePct)
 }
 
 trait MinLengthStdDevParams extends Params {

--- a/core/src/main/scala/com/salesforce/op/stages/impl/feature/SmartTextVectorizer.scala
+++ b/core/src/main/scala/com/salesforce/op/stages/impl/feature/SmartTextVectorizer.scala
@@ -99,15 +99,9 @@ class SmartTextVectorizer[T <: Text](uid: String = UID[SmartTextVectorizer[T]])(
       val cumSum = sortedValues.headOption.map(_ => sortedValues.tail.scanLeft(sortedValues.head)(_ + _))
         .getOrElse(Seq.empty)
       val coverage = cumSum.lift(math.min(topKValue, cumSum.length - 1)).getOrElse(0L) * 1.0 / totalCount
-      println(sorted)
-      println(sorted.map(_._1).zip(cumSum))
-      println(coverage)
-
       val vecMethod: TextVectorizationMethod = stats match {
         case _ if stats.valueCounts.size > maxCard && stats.valueCounts.size > topKValue && coverage > 0 &&
-          coverage >= $(coveragePct) =>
-          println(s"Pivot ${stats.valueCounts}")
-          TextVectorizationMethod.Pivot
+          coverage >= $(coveragePct) => TextVectorizationMethod.Pivot
         case _ if stats.valueCounts.size <= maxCard => TextVectorizationMethod.Pivot
         case _ if stats.lengthStdDev < minLenStdDev => TextVectorizationMethod.Ignore
         case _ => TextVectorizationMethod.Hash

--- a/core/src/test/scala/com/salesforce/op/stages/impl/feature/SmartTextMapVectorizerTest.scala
+++ b/core/src/test/scala/com/salesforce/op/stages/impl/feature/SmartTextMapVectorizerTest.scala
@@ -44,7 +44,6 @@ import com.salesforce.op.stages.impl.feature.TextVectorizationMethod.{Hash, Pivo
 import com.salesforce.op.testkit.RandomText
 import org.apache.spark.sql.{DataFrame, Encoder, Encoders}
 import org.scalatest.Assertion
-
 import scala.util.Random
 
 @RunWith(classOf[JUnitRunner])

--- a/core/src/test/scala/com/salesforce/op/stages/impl/feature/SmartTextMapVectorizerTest.scala
+++ b/core/src/test/scala/com/salesforce/op/stages/impl/feature/SmartTextMapVectorizerTest.scala
@@ -129,7 +129,6 @@ class SmartTextMapVectorizerTest
   val categoricalCountryData = Random.shuffle(oneCountryData ++ countryData)
   val countryMapData = categoricalCountryData.map { case country => mapifyText(Seq(country)) }
   val (countryMapDF, rawCatCountryMap) = TestFeatureBuilder("rawCatCountryMap", countryMapData)
-  countryMapDF.show()
 
   /**
    * Estimator instance to be tested
@@ -690,8 +689,6 @@ class SmartTextMapVectorizerTest
       .setMaxCardinality(maxCard).setTopK(topK).setMinSupport(1).setCoveragePct(0.5).setCleanText(false)
       .setTrackTextLen(true).setNumFeatures(numHashes).setInput(rawTextMap1).getOutput()
     val transformed = new OpWorkflow().setResultFeatures(coverageHashed).transform(rawDFSeparateMaps)
-    println(categoricalTextData.toSet.toSeq.length)
-    println(categoricalTextData.toSet.toSeq)
     val expectedLength = numHashes + 2 + categoricalTextData.toSet.filter(!_.isEmpty).toSeq.length + 2
     assertVectorLength(transformed, coverageHashed, expectedLength , Hash)
   }
@@ -781,9 +778,8 @@ class SmartTextMapVectorizerTest
     val firstRes = result.head
     val metaColumns = OpVectorMetadata(df.schema(output.name)).columns
 
-    metaColumns.foreach(println(_))
-    metaColumns.length shouldBe expectedLength
     firstRes.v.size shouldBe expectedLength
+    metaColumns.length shouldBe expectedLength
 
     textVectorizationMethod match {
       case Pivot => assert(metaColumns(expectedLength - 2).indicatorValue.contains(OpVectorColumnMetadata.OtherString))

--- a/core/src/test/scala/com/salesforce/op/stages/impl/feature/SmartTextMapVectorizerTest.scala
+++ b/core/src/test/scala/com/salesforce/op/stages/impl/feature/SmartTextMapVectorizerTest.scala
@@ -599,17 +599,18 @@ class SmartTextMapVectorizerTest
     meta.columns.slice(18, 21).forall(_.indicatorValue.contains(OpVectorColumnMetadata.NullString))
   }
 
-  it should "treat the edge case of coverage being 0" in {
+  it should "treat the edge case of coverage being near 0" in {
     val maxCard = 100
-    val vectorizer = new SmartTextMapVectorizer().setCoveragePct(0.0).setMaxCardinality(maxCard).setMinSupport(1)
+    val vectorizer = new SmartTextMapVectorizer().setCoveragePct(1e-10).setMaxCardinality(maxCard).setMinSupport(1)
       .setTrackTextLen(true).setInput(rawCatCountryMap)
     val output = vectorizer.getOutput()
     val transformed = new OpWorkflow().setResultFeatures(output).transform(countryMapDF)
     assertVectorLength(transformed, output, TransmogrifierDefaults.TopK + 2, Pivot)
   }
-  it should "treat the edge case of coverage being 1" in {
+  it should "treat the edge case of coverage being near 1" in {
     val maxCard = 100
-    val vectorizer = new SmartTextMapVectorizer().setCoveragePct(1.0).setMaxCardinality(maxCard).setMinSupport(1)
+    val vectorizer = new SmartTextMapVectorizer().setCoveragePct(1.0 - 1e-10).setMaxCardinality(maxCard)
+      .setMinSupport(1)
       .setTrackTextLen(true).setInput(rawCatCountryMap)
     val output = vectorizer.getOutput()
     val transformed = new OpWorkflow().setResultFeatures(output).transform(countryMapDF)

--- a/core/src/test/scala/com/salesforce/op/stages/impl/feature/SmartTextVectorizerTest.scala
+++ b/core/src/test/scala/com/salesforce/op/stages/impl/feature/SmartTextVectorizerTest.scala
@@ -280,17 +280,17 @@ class SmartTextVectorizerTest
     meta.columns.slice(18, 21).forall(_.indicatorValue.contains(OpVectorColumnMetadata.NullString))
   }
 
-  it should "treat the edge case of coverage being 0" in {
+  it should "treat the edge case of coverage being near 0" in {
     val maxCard = 100
-    val vectorizer = new SmartTextVectorizer().setCoveragePct(0.0).setMaxCardinality(maxCard).setMinSupport(1)
+    val vectorizer = new SmartTextVectorizer().setCoveragePct(1e-10).setMaxCardinality(maxCard).setMinSupport(1)
       .setTrackTextLen(true).setInput(rawCatCountry)
     val output = vectorizer.getOutput()
     val transformed = new OpWorkflow().setResultFeatures(output).transform(countryDF)
     assertVectorLength(transformed, output, TransmogrifierDefaults.TopK + 2, Pivot)
   }
-  it should "treat the edge case of coverage being 1" in {
+  it should "treat the edge case of coverage being near 1" in {
     val maxCard = 100
-    val vectorizer = new SmartTextVectorizer().setCoveragePct(1.0).setMaxCardinality(maxCard).setMinSupport(1)
+    val vectorizer = new SmartTextVectorizer().setCoveragePct(1.0 - 1e-10).setMaxCardinality(maxCard).setMinSupport(1)
       .setTrackTextLen(true).setInput(rawCatCountry)
     val output = vectorizer.getOutput()
     val transformed = new OpWorkflow().setResultFeatures(output).transform(countryDF)

--- a/core/src/test/scala/com/salesforce/op/stages/impl/feature/SmartTextVectorizerTest.scala
+++ b/core/src/test/scala/com/salesforce/op/stages/impl/feature/SmartTextVectorizerTest.scala
@@ -31,16 +31,21 @@
 package com.salesforce.op.stages.impl.feature
 
 import com.salesforce.op._
+import com.salesforce.op.features.FeatureLike
 import com.salesforce.op.features.types._
 import com.salesforce.op.stages.base.sequence.SequenceModel
+import com.salesforce.op.stages.impl.feature.TextVectorizationMethod.{Hash, Pivot}
 import com.salesforce.op.test.{OpEstimatorSpec, TestFeatureBuilder}
 import com.salesforce.op.testkit.RandomText
 import com.salesforce.op.utils.spark.RichDataset._
 import com.salesforce.op.utils.spark.{OpVectorColumnMetadata, OpVectorMetadata}
 import org.apache.spark.ml.linalg.Vectors
+import org.apache.spark.sql.DataFrame
 import org.junit.runner.RunWith
 import org.scalatest.Assertion
 import org.scalatest.junit.JUnitRunner
+
+import scala.util.Random
 
 
 @RunWith(classOf[JUnitRunner])
@@ -97,6 +102,10 @@ class SmartTextVectorizerTest
   val stringData: String = "I have got a LovEly buncH of cOcOnuts. " +
     "Here they are ALL standing in a row."
   val tol = 1e-12 // Tolerance for comparing real numbers
+
+  val oneCountryData: Seq[Text] = Seq.fill(1000)(Text("United States"))
+  val categoricalCountryData = Random.shuffle(oneCountryData ++ countryData)
+  val (countryDF, rawCatCountry) = TestFeatureBuilder("rawCatCountry", categoricalCountryData)
 
   it should "detect one categorical and one non-categorical text feature" in {
     val smartVectorized = new SmartTextVectorizer()
@@ -233,6 +242,98 @@ class SmartTextVectorizerTest
     meta.columns.slice(10, 15).forall(_.grouping.contains("text"))
     meta.columns.slice(15, 18).forall(_.descriptorValue.contains(OpVectorColumnMetadata.TextLenString))
     meta.columns.slice(18, 21).forall(_.indicatorValue.contains(OpVectorColumnMetadata.NullString))
+  }
+
+  it should "treat the edge case of coverage being 0" in {
+    val maxCard = 100
+    val vectorizer = new SmartTextVectorizer().setCoveragePct(0.0).setMaxCardinality(maxCard).setMinSupport(1)
+      .setTrackTextLen(true).setInput(rawCatCountry)
+    val output = vectorizer.getOutput()
+    val transformed = new OpWorkflow().setResultFeatures(output).transform(countryDF)
+    assertVectorLength(transformed, output, TransmogrifierDefaults.TopK + 2, Pivot)
+  }
+  it should "treat the edge case of coverage being 1" in {
+    val maxCard = 100
+    val vectorizer = new SmartTextVectorizer().setCoveragePct(1.0).setMaxCardinality(maxCard).setMinSupport(1)
+      .setTrackTextLen(true).setInput(rawCatCountry)
+    val output = vectorizer.getOutput()
+    val transformed = new OpWorkflow().setResultFeatures(output).transform(countryDF)
+    assertVectorLength(transformed, output, TransmogrifierDefaults.DefaultNumOfFeatures + 2, Hash)
+  }
+
+  it should "detect one categorical with high cardinality using the coverage" in {
+    val maxCard = 100
+    val topK = 10
+    val cardinality = countryDF.select(rawCatCountry).distinct().count().toInt
+    cardinality should be > maxCard
+    cardinality should be > topK
+    val vectorizer = new SmartTextVectorizer()
+      .setMaxCardinality(maxCard).setTopK(topK).setMinSupport(1).setCoveragePct(0.5).setCleanText(false)
+      .setInput(rawCatCountry)
+    val output = vectorizer.getOutput()
+    val transformed = new OpWorkflow().setResultFeatures(output).transform(countryDF)
+    assertVectorLength(transformed, output, topK + 2, Pivot)
+  }
+
+  it should "not pivot using the coverage because of a high minimum support" in {
+    val maxCard = 100
+    val topK = 10
+    val minSupport = 99999
+    val numHashes = 5
+    val cardinality = countryDF.select(rawCatCountry).distinct().count().toInt
+    cardinality should be > maxCard
+    cardinality should be > topK
+    val vectorizer = new SmartTextVectorizer()
+      .setMaxCardinality(maxCard).setTopK(topK).setMinSupport(minSupport).setNumFeatures(numHashes).setCoveragePct(0.5)
+      .setTrackTextLen(true).setCleanText(false).setInput(rawCatCountry)
+    val output = vectorizer.getOutput()
+    val transformed = new OpWorkflow().setResultFeatures(output).transform(countryDF)
+    assertVectorLength(transformed, output, numHashes + 2, Hash)
+  }
+
+  it should "still pivot using the coverage despite a high minimum support" in {
+    val maxCard = 100
+    val topK = 10
+    val minSupport = 100
+    val numHashes = 5
+    val cardinality = countryDF.select(rawCatCountry).distinct().count().toInt
+    cardinality should be > maxCard
+    cardinality should be > topK
+    val vectorizer = new SmartTextVectorizer()
+      .setMaxCardinality(maxCard).setTopK(topK).setMinSupport(minSupport).setNumFeatures(numHashes).setCoveragePct(0.5)
+      .setTrackTextLen(true).setCleanText(false).setInput(rawCatCountry)
+    val output = vectorizer.getOutput()
+    val transformed = new OpWorkflow().setResultFeatures(output).transform(countryDF)
+    assertVectorLength(transformed, output, 3, Pivot)
+  }
+
+  it should "not pivot using the coverage because top K is too high" in {
+    val maxCard = 100
+    val topK = 1000000
+    val numHashes = 5
+    val cardinality = countryDF.select(rawCatCountry).distinct().count().toInt
+    cardinality should be > maxCard
+    cardinality should be <= topK
+    val vectorizer = new SmartTextVectorizer()
+      .setMaxCardinality(maxCard).setTopK(topK).setNumFeatures(numHashes).setCoveragePct(0.5)
+      .setTrackTextLen(true).setCleanText(false).setInput(rawCatCountry)
+    val output = vectorizer.getOutput()
+    val transformed = new OpWorkflow().setResultFeatures(output).transform(countryDF)
+    assertVectorLength(transformed, output, numHashes + 2, Hash)
+  }
+
+  it should "still transform country into text, despite the coverage" in {
+    val maxCard = 100
+    val topK = 10
+    val numHashes = 5
+    val cardinality = rawDF.select(rawCountry).distinct().count().toInt
+    cardinality should be > maxCard
+    cardinality should be > topK
+    val coverageHashed = new SmartTextVectorizer()
+      .setMaxCardinality(maxCard).setTopK(topK).setMinSupport(1).setCoveragePct(0.5).setCleanText(false)
+      .setTrackTextLen(true).setNumFeatures(numHashes).setInput(rawCountry).getOutput()
+    val transformed = new OpWorkflow().setResultFeatures(coverageHashed).transform(rawDF)
+    assertVectorLength(transformed, coverageHashed, numHashes + 2, Hash)
   }
 
   it should "detect and ignore fields that looks like machine-generated IDs by having a low value length variance" in {
@@ -543,6 +644,23 @@ class SmartTextVectorizerTest
 
     checkDerivedQuantities(res, Seq(58).map(_.toLong))
   }
+
+  private[op] def assertVectorLength(df: DataFrame, output: FeatureLike[OPVector],
+    expectedLength: Int, textVectorizationMethod: TextVectorizationMethod): Unit = {
+    val result = df.collect(output)
+    val firstRes = result.head
+    firstRes.v.size shouldBe expectedLength
+    val metaColumns = OpVectorMetadata(df.schema(output.name)).columns
+    metaColumns.length shouldBe expectedLength
+    textVectorizationMethod match {
+      case Pivot => assert(metaColumns(expectedLength - 2).indicatorValue.contains(OpVectorColumnMetadata.OtherString))
+      case Hash => assert(metaColumns(expectedLength - 2).descriptorValue
+        .contains(OpVectorColumnMetadata.TextLenString))
+      case other => throw new Error(s"Only Pivoting or Hashing possible, got ${other} instead")
+    }
+    assert(metaColumns(expectedLength - 1).indicatorValue.contains(OpVectorColumnMetadata.NullString))
+  }
+
 
   /**
    * Set of tests to check that the derived quantities calculated on the length distribution in TextStats

--- a/core/src/test/scala/com/salesforce/op/stages/impl/preparators/SanityCheckerTest.scala
+++ b/core/src/test/scala/com/salesforce/op/stages/impl/preparators/SanityCheckerTest.scala
@@ -357,6 +357,7 @@ class SanityCheckerTest extends OpEstimatorSpec[OPVector, BinaryModel[RealNN, OP
   it should "remove individual text hash features independently" in {
     val smartMapVectorized = new SmartTextMapVectorizer[TextMap]()
       .setMaxCardinality(2).setNumFeatures(8).setMinSupport(1).setTopK(2).setPrependFeatureName(true)
+      .setCoveragePct(1.0)
       .setHashSpaceStrategy(HashSpaceStrategy.Shared)
       .setInput(textMap).getOutput()
 

--- a/core/src/test/scala/com/salesforce/op/stages/impl/preparators/SanityCheckerTest.scala
+++ b/core/src/test/scala/com/salesforce/op/stages/impl/preparators/SanityCheckerTest.scala
@@ -392,6 +392,7 @@ class SanityCheckerTest extends OpEstimatorSpec[OPVector, BinaryModel[RealNN, OP
     val smartMapVectorized = new SmartTextMapVectorizer[TextMap]()
       .setMaxCardinality(2).setNumFeatures(4).setMinSupport(1).setTopK(2).setPrependFeatureName(true)
       .setHashSpaceStrategy(HashSpaceStrategy.Separate)
+      .setCoveragePct(1.0)
       .setInput(textMap).getOutput()
 
     val checkedFeatures = new SanityChecker()
@@ -433,6 +434,7 @@ class SanityCheckerTest extends OpEstimatorSpec[OPVector, BinaryModel[RealNN, OP
     val smartMapVectorized = new SmartTextMapVectorizer[TextMap]()
       .setMaxCardinality(2).setNumFeatures(8).setMinSupport(1).setTopK(2).setPrependFeatureName(true)
       .setHashSpaceStrategy(HashSpaceStrategy.Shared)
+      .setCoveragePct(1.0)
       .setInput(textMap).getOutput()
 
     val checkedFeatures = new SanityChecker()
@@ -503,6 +505,7 @@ class SanityCheckerTest extends OpEstimatorSpec[OPVector, BinaryModel[RealNN, OP
     val smartMapVectorized = new SmartTextMapVectorizer[TextMap]()
       .setMaxCardinality(2).setNumFeatures(8).setMinSupport(1).setTopK(2).setPrependFeatureName(true)
       .setHashSpaceStrategy(HashSpaceStrategy.Shared)
+      .setCoveragePct(1.0)
       .setInput(textMap).getOutput()
 
     val checkedFeatures = new SanityChecker()


### PR DESCRIPTION
**Related issues**
Currently SmartTextVectorizer and SmartTextMapVectorizer will count the number of unique entries in a text field (up to a threshold, currently 50) and treat the feature as categorical if it has < 50 unique entries.
You can still run into features that are effectively categorical, but may have a long tail of low-frequency entries. We would get better signal extraction if we treated these as categorical instead of hashing them.


**Describe the proposed solution**
Adding an extra check for Text(Map) features in order to become categoricals. This only applies to features that have a cardinality higher than the threshold and therefore would be hashed.

A better approach to detecting text features that are really categorical would be to use a coverage criteria. For example, the topK entries with minimum support cover at least 90% of the entries, then this would be a good feature to pivot by entry instead of hash by token. The value of 90% can be tuned by the user thanks to a param.

Extra checks need to be passed : 
- Cardinality must be greater than maxCard (already mentioned above).
- Cardinality must also be greater than topK. 
- Finally, the computed coverage of the topK with minimum support must be > 0.

If there is m < TopK elements with the required minimum support, then we are looking at the coverage of these m elements.


**Describe alternatives you've considered**
I've considered using Algebird Count Min Sketch in order to compute the current `TextStats`. 
However I ran into multiple issue : 
- Lack of transparency: `TopNCMS` only returns the "HeavyHitters" however you need much more than that(e.g. cardinality)  in order to use the coverage method.
- Serialization issues when writing to JSON

A branch still exists : [mw/coverage](https://github.com/salesforce/TransmogrifAI/tree/mw/coverage), but it is in shambles.


**Additional context**
Some criticism regarding `TextStats`. It seems not to be a semi group as it is not associative. Was it intended?