### PR TITLE
ignoring cardinality in modelinsights serialization

### DIFF
--- a/core/src/main/scala/com/salesforce/op/ModelInsights.scala
+++ b/core/src/main/scala/com/salesforce/op/ModelInsights.scala
@@ -408,11 +408,15 @@ case object ModelInsights {
         { case x: EvalMetric => JString(x.entryName) }
       )
     )
+    val featureDistributionSerializer = FieldSerializer[FeatureDistribution](
+      FieldSerializer.ignore("cardEstimate")
+    )
     Serialization.formats(typeHints) +
       EnumEntrySerializer.json4s[ValidationType](ValidationType) +
       EnumEntrySerializer.json4s[ProblemType](ProblemType) +
       new SpecialDoubleSerializer +
-      evalMetricsSerializer
+      evalMetricsSerializer +
+      featureDistributionSerializer
   }
 
   /**

--- a/core/src/test/scala/com/salesforce/op/ModelInsightsTest.scala
+++ b/core/src/test/scala/com/salesforce/op/ModelInsightsTest.scala
@@ -970,5 +970,4 @@ class ModelInsightsTest extends FlatSpec with PassengerSparkFixtureTest with Dou
     )
   }
 
-  it should ""
 }

--- a/core/src/test/scala/com/salesforce/op/ModelInsightsTest.scala
+++ b/core/src/test/scala/com/salesforce/op/ModelInsightsTest.scala
@@ -456,6 +456,7 @@ class ModelInsightsTest extends FlatSpec with PassengerSparkFixtureTest with Dou
             i.featureName shouldEqual o.featureName
             i.featureType shouldEqual o.featureType
             i.derivedFeatures.zip(o.derivedFeatures).foreach { case (ii, io) => ii.corr shouldEqual io.corr }
+            i.distributions.foreach { i => i.cardEstimate should not be None}
             o.distributions.foreach { o => o.cardEstimate shouldEqual None}
             RawFeatureFilterResultsComparison.compareSeqMetrics(i.metrics, o.metrics)
             RawFeatureFilterResultsComparison.compareSeqDistributions(i.distributions, o.distributions)

--- a/core/src/test/scala/com/salesforce/op/ModelInsightsTest.scala
+++ b/core/src/test/scala/com/salesforce/op/ModelInsightsTest.scala
@@ -456,6 +456,7 @@ class ModelInsightsTest extends FlatSpec with PassengerSparkFixtureTest with Dou
             i.featureName shouldEqual o.featureName
             i.featureType shouldEqual o.featureType
             i.derivedFeatures.zip(o.derivedFeatures).foreach { case (ii, io) => ii.corr shouldEqual io.corr }
+            o.distributions.foreach { o => o.cardEstimate shouldEqual None}
             RawFeatureFilterResultsComparison.compareSeqMetrics(i.metrics, o.metrics)
             RawFeatureFilterResultsComparison.compareSeqDistributions(i.distributions, o.distributions)
             RawFeatureFilterResultsComparison.compareSeqExclusionReasons(i.exclusionReasons, o.exclusionReasons)
@@ -968,4 +969,6 @@ class ModelInsightsTest extends FlatSpec with PassengerSparkFixtureTest with Dou
       "second" -> classOf[SingleMetric]
     )
   }
+
+  it should ""
 }


### PR DESCRIPTION
Related issues
Tokens of text field are printing out while internal usage.

Describe the proposed solution
Ignore cardinality field in modelInsights serialization, addition to featureDistribution

Additional context
Previous PR #420 & #438 & #447