### PR TITLE
Lift upperBound on # of hash features

### DIFF
--- a/core/src/main/scala/com/salesforce/op/stages/impl/feature/OPCollectionHashingVectorizer.scala
+++ b/core/src/main/scala/com/salesforce/op/stages/impl/feature/OPCollectionHashingVectorizer.scala
@@ -102,7 +102,7 @@ private[op] trait HashingVectorizerParams extends Params {
     parent = this, name = "numFeatures",
     doc = s"number of features (hashes) to generate (default: ${TransmogrifierDefaults.DefaultNumOfFeatures})",
     isValid = ParamValidators.inRange(
-      lowerBound = 0, upperBound = TransmogrifierDefaults.MaxNumOfFeatures,
+      lowerBound = 0, upperBound = 1E7,
       lowerInclusive = false, upperInclusive = true
     )
   )

--- a/core/src/main/scala/com/salesforce/op/stages/impl/feature/OPMapVectorizer.scala
+++ b/core/src/main/scala/com/salesforce/op/stages/impl/feature/OPMapVectorizer.scala
@@ -186,7 +186,7 @@ class TextMapHashingVectorizer[T <: OPMap[String]]
     parent = this, name = "numFeatures",
     doc = s"number of features (hashes) to generate (default: ${TransmogrifierDefaults.DefaultNumOfFeatures})",
     isValid = ParamValidators.inRange(
-      lowerBound = 0, upperBound = TransmogrifierDefaults.MaxNumOfFeatures,
+      lowerBound = 0, upperBound = 1E7,
       lowerInclusive = false, upperInclusive = true
     )
   )


### PR DESCRIPTION
**Related issues**
Some use cases require a much larger hash space when hashing text features. We are relaxing this limit in `HashingVectorizerParams` and `TextMapHashingVectorizer`
