### PR TITLE
Expose derived feature value in model insights

### DIFF
--- a/core/src/main/scala/com/salesforce/op/ModelInsights.scala
+++ b/core/src/main/scala/com/salesforce/op/ModelInsights.scala
@@ -636,7 +636,10 @@ case object ModelInsights {
               derivedFeatureName = h.columnName,
               stagesApplied = h.parentFeatureStages,
               derivedFeatureGroup = h.grouping,
-              derivedFeatureValue = h.indicatorValue,
+              derivedFeatureValue = (h.indicatorValue, h.descriptorValue) match {
+                case (None, _) => h.descriptorValue
+                case (_, None) => h.indicatorValue
+              },
               excluded = Option(s.dropped.contains(h.columnName)),
               corr = getCorr(s.correlations, h.columnName),
               cramersV = catGroupIndex.map(i => s.categoricalStats(i).cramersV),

--- a/core/src/main/scala/com/salesforce/op/ModelInsights.scala
+++ b/core/src/main/scala/com/salesforce/op/ModelInsights.scala
@@ -636,9 +636,9 @@ case object ModelInsights {
               derivedFeatureName = h.columnName,
               stagesApplied = h.parentFeatureStages,
               derivedFeatureGroup = h.grouping,
-              derivedFeatureValue = (h.indicatorValue, h.descriptorValue) match {
-                case (None, _) => h.descriptorValue
-                case (_, None) => h.indicatorValue
+              derivedFeatureValue = h.indicatorValue match {
+                case Some(_) => h.indicatorValue
+                case _ => h.descriptorValue
               },
               excluded = Option(s.dropped.contains(h.columnName)),
               corr = getCorr(s.correlations, h.columnName),

--- a/core/src/main/scala/com/salesforce/op/stages/impl/feature/OPMapVectorizer.scala
+++ b/core/src/main/scala/com/salesforce/op/stages/impl/feature/OPMapVectorizer.scala
@@ -291,7 +291,8 @@ trait MapVectorizerFuns[A, T <: OPMap[A]] extends VectorizerDefaults with MapPiv
       parentFeatureName = col.parentFeatureName,
       parentFeatureType = col.parentFeatureType,
       grouping = Option(key),
-      indicatorValue = None
+      indicatorValue = None,
+      descriptorValue = col.descriptorValue
     )
     meta.withColumns(cols.toArray)
   }

--- a/core/src/test/scala/com/salesforce/op/ModelInsightsTest.scala
+++ b/core/src/test/scala/com/salesforce/op/ModelInsightsTest.scala
@@ -525,6 +525,29 @@ class ModelInsightsTest extends FlatSpec with PassengerSparkFixtureTest with Dou
     droppedMapDerivedIn.head.derivedFeatureGroup shouldBe Some("Female")
   }
 
+  it should "have derived feature value for map feature insights" in {
+    val insights = modelWithRFF.modelInsights(predWithMaps)
+    val mapDerivedIn = insights.features.find(_.featureName == numericMap.name).get.derivedFeatures
+    mapDerivedIn.size shouldBe 3
+    val f1InDer = mapDerivedIn.head
+    println(f1InDer)
+    f1InDer.derivedFeatureName shouldBe "f1_0"
+    f1InDer.stagesApplied shouldBe Seq.empty
+    f1InDer.derivedFeatureGroup shouldBe None
+    f1InDer.derivedFeatureValue shouldBe None
+    f1InDer.excluded shouldBe Option(true)
+    f1InDer.corr.map(_.toString) shouldBe Some("NaN")
+    f1InDer.cramersV shouldBe None
+    f1InDer.mutualInformation shouldBe None
+    f1InDer.pointwiseMutualInformation shouldBe Map.empty
+    f1InDer.countMatrix shouldBe Map.empty
+    f1InDer.contribution shouldBe Seq.empty
+    f1InDer.min shouldBe Some(1.1)
+    f1InDer.max shouldBe Some(0.1)
+    f1InDer.mean shouldBe Some(2.1)
+    f1InDer.variance shouldBe Some(3.1)
+  }
+
   val labelName = "l"
 
   val summary = SanityCheckerSummary(

--- a/core/src/test/scala/com/salesforce/op/stages/impl/feature/OPMapVectorizerTest.scala
+++ b/core/src/test/scala/com/salesforce/op/stages/impl/feature/OPMapVectorizerTest.scala
@@ -463,18 +463,19 @@ object OPMapVectorizerTestHelper extends Matchers with AttributeAsserts {
 
     // Assert metadata for descriptorValue & indicatorValue
     val baseMetaDataValue: Array[String] = baseColMetaArray
-      .map(f => (f.parentFeatureName.head, f.indicatorValue, f.descriptorValue) match {
-        case (pfName, Some(iv), None) => pfName + iv
-        case (pfName, None, None) => pfName
-        case (pfName, None, Some(dv)) => pfName + dv
-        case (_, Some(_), Some(_)) => throw new RuntimeException("this metadata config should not exist")
+      .map(f => (f.indicatorValue, f.descriptorValue) match {
+        case (Some(iv), None) => iv
+        case (None, None) => ""
+        case (None, Some(dv)) => dv
+        case (Some(_), Some(_)) => throw new RuntimeException("this metadata config should not exist")
       }).sorted
 
     val mapMetaDataValue: Array[String] = mapColMetaArray
-      .map(f => (f.parentFeatureName.head, f.indicatorValue, f.descriptorValue) match {
-        case (pfName, Some(iv), None) => pfName + iv
-        case (pfName, None, None) => pfName
-        case (pfName, None, Some(dv)) => pfName + dv
+      .map(f => (f.indicatorValue, f.descriptorValue) match {
+        case (Some(iv), None) => iv
+        case (None, None) => ""
+        case (None, Some(dv)) => dv
+        case (Some(_), Some(_)) => throw new RuntimeException("this metadata config should not exist")
       }).sorted
 
     baseMetaDataValue should contain theSameElementsInOrderAs mapMetaDataValue

--- a/core/src/test/scala/com/salesforce/op/stages/impl/feature/OPMapVectorizerTest.scala
+++ b/core/src/test/scala/com/salesforce/op/stages/impl/feature/OPMapVectorizerTest.scala
@@ -462,26 +462,18 @@ object OPMapVectorizerTestHelper extends Matchers with AttributeAsserts {
     }
 
     // Assert metadata for descriptorValue & indicatorValue
-    val baseMetaDataValue: Array[String] = baseColMetaArray
-      .map(f => (f.indicatorValue, f.descriptorValue) match {
-        case (Some(iv), None) => iv
-        case (None, None) => ""
-        case (None, Some(dv)) => dv
-        case (Some(_), Some(_)) => throw new RuntimeException("this metadata config should not exist")
-      }).sorted
-
-    val mapMetaDataValue: Array[String] = mapColMetaArray
-      .map(f => (f.indicatorValue, f.descriptorValue) match {
-        case (Some(iv), None) => iv
-        case (None, None) => ""
-        case (None, Some(dv)) => dv
-        case (Some(_), Some(_)) => throw new RuntimeException("this metadata config should not exist")
-      }).sorted
-
-    baseMetaDataValue should contain theSameElementsInOrderAs mapMetaDataValue
+    extractIndiDescripValues(baseColMetaArray) should contain theSameElementsInOrderAs
+      extractIndiDescripValues(mapColMetaArray)
   }
 
-
+  def extractIndiDescripValues(metadata: Array[OpVectorColumnMetadata]): Array[String] = {
+    metadata.map(f => (f.indicatorValue, f.descriptorValue) match {
+      case (Some(iv), None) => iv
+      case (None, None) => ""
+      case (None, Some(dv)) => dv
+      case (Some(_), Some(_)) => throw new RuntimeException("this metadata config should not exist")
+    }).sorted
+  }
 
   /**
    * Construct Mapify transformer for raw features

--- a/core/src/test/scala/com/salesforce/op/stages/impl/feature/OPMapVectorizerTest.scala
+++ b/core/src/test/scala/com/salesforce/op/stages/impl/feature/OPMapVectorizerTest.scala
@@ -35,7 +35,7 @@ import java.util.{Date => JDate}
 import com.salesforce.op.{OpWorkflow, UID}
 import com.salesforce.op.features.types.{OPMap, _}
 import com.salesforce.op.features.{Feature, FeatureLike}
-import com.salesforce.op.stages.base.ternary.{TernaryLambdaTransformer, TernaryTransformer}
+import com.salesforce.op.stages.base.ternary.{TernaryTransformer}
 import com.salesforce.op.test.{TestFeatureBuilder, TestSparkContext}
 import com.salesforce.op.testkit._
 import com.salesforce.op.utils.spark.RichDataset._
@@ -461,7 +461,23 @@ object OPMapVectorizerTestHelper extends Matchers with AttributeAsserts {
         isTheSame shouldBe true
     }
 
-    // TODO assert metadata
+    // Assert metadata for descriptorValue & indicatorValue
+    val baseMetaDataValue: Array[String] = baseColMetaArray
+      .map(f => (f.parentFeatureName.head, f.indicatorValue, f.descriptorValue) match {
+        case (pfName, Some(iv), None) => pfName + iv
+        case (pfName, None, None) => pfName
+        case (pfName, None, Some(dv)) => pfName + dv
+        case (_, Some(_), Some(_)) => throw new RuntimeException("this metadata config should not exist")
+      }).sorted
+
+    val mapMetaDataValue: Array[String] = mapColMetaArray
+      .map(f => (f.parentFeatureName.head, f.indicatorValue, f.descriptorValue) match {
+        case (pfName, Some(iv), None) => pfName + iv
+        case (pfName, None, None) => pfName
+        case (pfName, None, Some(dv)) => pfName + dv
+      }).sorted
+
+    baseMetaDataValue should contain theSameElementsInOrderAs mapMetaDataValue
   }
 
 


### PR DESCRIPTION
Some of the derived features (or engineered features) have human-readable values that could be exposed inside modelInsights for downstream consumption. 