### PR TITLE
Replace empty XGBoost feature importance with a vector of zeros

### DIFF
--- a/core/src/main/scala/com/salesforce/op/ModelInsights.scala
+++ b/core/src/main/scala/com/salesforce/op/ModelInsights.scala
@@ -802,12 +802,18 @@ case object ModelInsights {
       case m: XGBoostRegressionModel =>
         Try(Seq(m.nativeBooster.getFeatureScoreVector(featureVectorSize).toArray.toSeq)) match {
           case Success(contrib) => contrib
-          case _ => Seq.empty
+          case _ => featureVectorSize match {
+            case Some(n) => Seq(Seq.fill(n)(0.0))
+            case _ => Seq(Seq.empty)
+          }
         }
       case m: XGBoostClassificationModel =>
         Try(Seq(m.nativeBooster.getFeatureScoreVector(featureVectorSize).toArray.toSeq)) match {
           case Success(contrib) => contrib
-          case _ => Seq.empty
+          case _ => featureVectorSize match {
+            case Some(n) => Seq(Seq.fill(n)(0.0))
+            case _ => Seq(Seq.empty)
+          }
         }
     }
     contributions.getOrElse(Seq.empty)

--- a/core/src/main/scala/com/salesforce/op/ModelInsights.scala
+++ b/core/src/main/scala/com/salesforce/op/ModelInsights.scala
@@ -803,7 +803,7 @@ case object ModelInsights {
         Try(Seq(m.nativeBooster.getFeatureScoreVector(featureVectorSize).toArray.toSeq)) match {
           case Success(contrib) => contrib
           case _ => featureVectorSize match {
-            case Some(n) => Seq(Seq.fill(n)(0.0))
+            case Some(n) => Seq(Array.ofDim[Double](n).toIndexedSeq)
             case _ => Seq(Seq.empty)
           }
         }
@@ -811,7 +811,7 @@ case object ModelInsights {
         Try(Seq(m.nativeBooster.getFeatureScoreVector(featureVectorSize).toArray.toSeq)) match {
           case Success(contrib) => contrib
           case _ => featureVectorSize match {
-            case Some(n) => Seq(Seq.fill(n)(0.0))
+            case Some(n) => Seq(Array.ofDim[Double](n).toIndexedSeq)
             case _ => Seq(Seq.empty)
           }
         }

--- a/core/src/main/scala/com/salesforce/op/ModelInsights.scala
+++ b/core/src/main/scala/com/salesforce/op/ModelInsights.scala
@@ -59,7 +59,7 @@ import org.json4s.jackson.Serialization._
 import org.slf4j.LoggerFactory
 
 import scala.collection.mutable.ArrayBuffer
-import scala.util.Try
+import scala.util.{Success, Try}
 
 /**
  * Summary of all model insights
@@ -799,8 +799,16 @@ case object ModelInsights {
       case m: RandomForestRegressionModel => Seq(m.featureImportances.toArray.toSeq)
       case m: GBTRegressionModel => Seq(m.featureImportances.toArray.toSeq)
       case m: GeneralizedLinearRegressionModel => Seq(m.coefficients.toArray.toSeq)
-      case m: XGBoostRegressionModel => Seq(m.nativeBooster.getFeatureScoreVector(featureVectorSize).toArray.toSeq)
-      case m: XGBoostClassificationModel => Seq(m.nativeBooster.getFeatureScoreVector(featureVectorSize).toArray.toSeq)
+      case m: XGBoostRegressionModel =>
+        Try(Seq(m.nativeBooster.getFeatureScoreVector(featureVectorSize).toArray.toSeq)) match {
+          case Success(contrib) => contrib
+          case _ => Seq.empty
+        }
+      case m: XGBoostClassificationModel =>
+        Try(Seq(m.nativeBooster.getFeatureScoreVector(featureVectorSize).toArray.toSeq)) match {
+          case Success(contrib) => contrib
+          case _ => Seq.empty
+        }
     }
     contributions.getOrElse(Seq.empty)
   }


### PR DESCRIPTION
**Related issues**
A successfully trained XGBoost model could return an empty feature importance vector when the features have zero signal w.r.t the label. This behavior will fail `getModelContributions` via [this line](https://github.com/salesforce/TransmogrifAI/blob/master/core/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostParams.scala#L94). 

```
require(featureScore.nonEmpty, "Feature score map is empty")
```
**Describe the proposed solution**
In this case, we will return a feature contribution vector of 0's so that it matches the behavior of other models. 