### PR TITLE
Let user specify feature importance type for XGBoost

### DIFF
--- a/core/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostParams.scala
+++ b/core/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostParams.scala
@@ -88,8 +88,8 @@ case object OpXGBoost {
     /**
      * Converts feature score map into a vector
      *
-     * @param featureVectorSize   size of feature vectors the xgboost model is trained on
-     * @param importanceType      type of feature importance to calculate ["gain, "cover", "total_gain", "total_cover"]
+     * @param featureVectorSize size of feature vectors the xgboost model is trained on
+     * @param importanceType    type of feature importance to calculate ["gain, "cover", "total_gain", "total_cover"]
      * @return vector containing feature scores
      */
     def getFeatureScoreVector(

--- a/core/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostParams.scala
+++ b/core/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostParams.scala
@@ -87,6 +87,7 @@ case object OpXGBoost {
      * Converts feature score map into a vector
      *
      * @param featureVectorSize   size of feature vectors the xgboost model is trained on
+     * @param importanceType      type of feature importance to calculate ["gain, "cover", "total_gain", "total_cover"]
      * @return vector containing feature scores
      */
     def getFeatureScoreVector(

--- a/core/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostParams.scala
+++ b/core/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostParams.scala
@@ -30,15 +30,12 @@
 
 package ml.dmlc.xgboost4j.scala.spark
 
-import com.salesforce.op.stages.impl.preparators.CorrelationLevel.findValues
 import enumeratum.{Enum, EnumEntry}
 import ml.dmlc.xgboost4j.LabeledPoint
 import ml.dmlc.xgboost4j.scala.Booster
 import ml.dmlc.xgboost4j.scala.spark.params.GeneralParams
 import org.apache.log4j.{Level, Logger}
 import org.apache.spark.ml.linalg.{DenseVector, SparseVector, Vector, Vectors}
-
-import scala.collection.mutable.ArrayBuffer
 
 /**
  * Hack to access [[XGBoostClassifierParams]]

--- a/core/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostParams.scala
+++ b/core/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostParams.scala
@@ -89,8 +89,10 @@ case object OpXGBoost {
      * @param featureVectorSize   size of feature vectors the xgboost model is trained on
      * @return vector containing feature scores
      */
-    def getFeatureScoreVector(featureVectorSize: Option[Int] = None): Vector = {
-      val featureScore = booster.getFeatureScore()
+    def getFeatureScoreVector(
+      featureVectorSize: Option[Int] = None, importanceType: String = "gain"
+    ): Vector = {
+      val featureScore = booster.getScore(featureMap = null, importanceType = importanceType)
       require(featureScore.nonEmpty, "Feature score map is empty")
       val indexScore = featureScore.map { case (fid, score) =>
         val index = fid.tail.toInt

--- a/core/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostParams.scala
+++ b/core/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostParams.scala
@@ -89,7 +89,7 @@ case object OpXGBoost {
      * Converts feature score map into a vector
      *
      * @param featureVectorSize size of feature vectors the xgboost model is trained on
-     * @param importanceType    type of feature importance to calculate ["gain, "cover", "total_gain", "total_cover"]
+     * @param importanceType    type of feature importance to calculate [Gain, Cover, TotalGain, TotalCover]
      * @return vector containing feature scores
      */
     def getFeatureScoreVector(


### PR DESCRIPTION
XGBoost default feature importance is now `gain` instead of `weight`. Switching to `gain` will make XGBoost feature importance more consistent with [Spark's Random Forest](https://github.com/apache/spark/blob/master/mllib/src/main/scala/org/apache/spark/ml/tree/treeModels.scala#L168-L197), which uses average of single tree importances across all trees in the ensemble.

Description of the available options for `importanceType`

```
‘gain’: the average gain across all splits the feature is used in.

‘cover’: the average coverage across all splits the feature is used in.

‘total_gain’: the total gain across all splits the feature is used in.

‘total_cover’: the total coverage across all splits the feature is used in.
```