### PR TITLE
Refactor flaky local scoring tests

### DIFF
--- a/local/src/test/scala/com/salesforce/op/local/OpWorkflowModelLocalTest.scala
+++ b/local/src/test/scala/com/salesforce/op/local/OpWorkflowModelLocalTest.scala
@@ -78,7 +78,6 @@ class OpWorkflowModelLocalTest extends FlatSpec with TestSparkContext with TempD
 
   // Construct a label with a strong signal so we make sure there's something for the algorithms to learn
   val labelSynth = new PickListLabelizer().setInput(rawPickList).getOutput().asInstanceOf[Feature[RealNN]]
-    .copy(isResponse = true)
 
   val genFeatureVector = Seq(rawCity, rawCountry, rawPickList, rawCurrency).transmogrify()
   val indexed = rawCountry.indexed(handleInvalid = StringIndexerHandleInvalid.Keep)


### PR DESCRIPTION
**Related issues**
N/A

**Describe the proposed solution**
The current local scoring tests are flaky when xgboost models are included because the dataset used is a tiny 8-row hardcoded dataset. This can cause the train/validation splits to often contain all of a single class which causes xgboost models to throw an error.

This PR makes the dataset used a synthetic dataset of adjustable size (now 100 rows) to fix this problem.

**Describe alternatives you've considered**
We could also have used the full hardcoded Titanic dataset, but this was much easier for me.

**Additional context**
N/A
