### PR TITLE
load workflows without spark context directly into MLeap transformers

### DIFF
--- a/core/src/main/scala/com/salesforce/op/OpWorkflow.scala
+++ b/core/src/main/scala/com/salesforce/op/OpWorkflow.scala
@@ -347,19 +347,12 @@ class OpWorkflow(val uid: String = UID[OpWorkflow]) extends OpWorkflowCore {
   def train(persistEveryKStages: Int = OpWorkflowModel.PersistEveryKStages)
     (implicit spark: SparkSession): OpWorkflowModel = {
 
-    val (fittedStages, newResultFeatures) =
-      if (stages.exists(_.isInstanceOf[Estimator[_]])) {
-        val rawData = generateRawData()
-        // Update features with fitted stages
-        val fittedStgs = fitStages(data = rawData, stagesToFit = stages, persistEveryKStages)
-        val newResultFtrs = resultFeatures.map(_.copyWithNewStages(fittedStgs))
-        fittedStgs -> newResultFtrs
-      } else if (rawFeatureFilter.nonEmpty) {
-        generateRawData()
-        stages -> resultFeatures
-      } else {
-        stages -> resultFeatures
-      }
+    val rawData = generateRawData()
+    // Update features with fitted stages
+    val fittedStgs = fitStages(data = rawData, stagesToFit = stages, persistEveryKStages)
+    val newResultFtrs = resultFeatures.map(_.copyWithNewStages(fittedStgs))
+    val (fittedStages, newResultFeatures) = fittedStgs -> newResultFtrs
+
 
     val model =
       new OpWorkflowModel(uid, getParameters())
@@ -397,10 +390,6 @@ class OpWorkflow(val uid: String = UID[OpWorkflow]) extends OpWorkflowCore {
       .map(_.filter(s => stagesToFit.contains(s._1)))
       .filter(_.nonEmpty)
 
-    // Search for the last estimator
-    val indexOfLastEstimator: Option[Int] =
-      dag.collect { case seq if seq.exists(_._1.isInstanceOf[Estimator[_]]) => seq.head._2 }.lastOption
-
     // doing regular workflow fit without workflow level CV
     if (!isWorkflowCV) {
       // The cross-validation job group is handled in the appropriate Estimator
@@ -410,7 +399,6 @@ class OpWorkflow(val uid: String = UID[OpWorkflow]) extends OpWorkflowCore {
           train = train,
           test = test,
           hasTest = hasTest,
-          indexOfLastEstimator = indexOfLastEstimator,
           persistEveryKStages = persistEveryKStages
         ).transformers
       }
@@ -427,7 +415,6 @@ class OpWorkflow(val uid: String = UID[OpWorkflow]) extends OpWorkflowCore {
             train = train,
             test = test,
             hasTest = hasTest,
-            indexOfLastEstimator = indexOfLastEstimator,
             persistEveryKStages = persistEveryKStages
           )
         }
@@ -458,7 +445,6 @@ class OpWorkflow(val uid: String = UID[OpWorkflow]) extends OpWorkflowCore {
               train = trainFixed,
               test = testFixed,
               hasTest = hasTest,
-              indexOfLastEstimator = indexOfLastEstimator,
               persistEveryKStages = persistEveryKStages,
               fittedTransformers = beforeTransformers
             ).transformers

--- a/core/src/main/scala/com/salesforce/op/OpWorkflow.scala
+++ b/core/src/main/scala/com/salesforce/op/OpWorkflow.scala
@@ -349,10 +349,8 @@ class OpWorkflow(val uid: String = UID[OpWorkflow]) extends OpWorkflowCore {
 
     val rawData = generateRawData()
     // Update features with fitted stages
-    val fittedStgs = fitStages(data = rawData, stagesToFit = stages, persistEveryKStages)
-    val newResultFtrs = resultFeatures.map(_.copyWithNewStages(fittedStgs))
-    val (fittedStages, newResultFeatures) = fittedStgs -> newResultFtrs
-
+    val fittedStages = fitStages(data = rawData, stagesToFit = stages, persistEveryKStages)
+    val newResultFeatures = resultFeatures.map(_.copyWithNewStages(fittedStages)
 
     val model =
       new OpWorkflowModel(uid, getParameters())

--- a/core/src/main/scala/com/salesforce/op/OpWorkflowModel.scala
+++ b/core/src/main/scala/com/salesforce/op/OpWorkflowModel.scala
@@ -464,7 +464,7 @@ case object OpWorkflowModel {
    * Load a previously trained workflow model from path
    *
    * @param path to the trained workflow model
-   * @param asSpark if true will load as spark models if false will load as Mlleap stages for spark wrapped stages
+   * @param asSpark if true will load as spark models if false will load as Mleap stages for spark wrapped stages
    * @return workflow model
    */
   def load(path: String, asSpark: Boolean = true): OpWorkflowModel =

--- a/core/src/main/scala/com/salesforce/op/OpWorkflowModel.scala
+++ b/core/src/main/scala/com/salesforce/op/OpWorkflowModel.scala
@@ -466,6 +466,7 @@ case object OpWorkflowModel {
    * @param path to the trained workflow model
    * @return workflow model
    */
-  def load(path: String): OpWorkflowModel = new OpWorkflowModelReader(None).load(path)
+  def load(path: String, asSpark: Boolean = true): OpWorkflowModel =
+    new OpWorkflowModelReader(None, asSpark).load(path)
 
 }

--- a/core/src/main/scala/com/salesforce/op/OpWorkflowModel.scala
+++ b/core/src/main/scala/com/salesforce/op/OpWorkflowModel.scala
@@ -464,6 +464,7 @@ case object OpWorkflowModel {
    * Load a previously trained workflow model from path
    *
    * @param path to the trained workflow model
+   * @param asSpark if true will load as spark models if false will load as Mlleap stages for spark wrapped stages
    * @return workflow model
    */
   def load(path: String, asSpark: Boolean = true): OpWorkflowModel =

--- a/core/src/main/scala/com/salesforce/op/OpWorkflowModelReader.scala
+++ b/core/src/main/scala/com/salesforce/op/OpWorkflowModelReader.scala
@@ -67,11 +67,11 @@ class OpWorkflowModelReader(val workflowOpt: Option[OpWorkflow], val asSpark: Bo
    */
   final def load(path: String): OpWorkflowModel = {
     implicit val conf = new org.apache.hadoop.conf.Configuration()
-    FileReader.loadFile(OpWorkflowModelReadWriteShared.jsonPath(path))
     Try(FileReader.loadFile(OpWorkflowModelReadWriteShared.jsonPath(path)))
       .flatMap(loadJson(_, path = path)) match {
       case Failure(error) => throw new RuntimeException(s"Failed to load Workflow from path '$path'", error)
       case Success(wf) => wf
+
     }
   }
 

--- a/core/src/main/scala/com/salesforce/op/OpWorkflowModelReader.scala
+++ b/core/src/main/scala/com/salesforce/op/OpWorkflowModelReader.scala
@@ -30,6 +30,7 @@
 
 package com.salesforce.op
 
+
 import com.salesforce.op.OpWorkflowModelReadWriteShared.{FieldNames => FN}
 import com.salesforce.op.OpWorkflowModelReadWriteShared.FieldNames._
 import com.salesforce.op.OpWorkflowModelReadWriteShared.DeprecatedFieldNames._
@@ -37,12 +38,15 @@ import com.salesforce.op.features.{FeatureJsonHelper, OPFeature, TransientFeatur
 import com.salesforce.op.filters.{FeatureDistribution, RawFeatureFilterResults}
 import com.salesforce.op.stages.OpPipelineStageReaderWriter._
 import com.salesforce.op.stages._
-import com.salesforce.op.utils.spark.{JobGroupUtil, OpStep}
-import org.apache.spark.ml.util.MLReader
+import org.apache.commons.io.IOUtils
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.Path
+import org.apache.hadoop.io.compress.CompressionCodecFactory
 import org.json4s.JsonAST.{JArray, JNothing, JValue}
 import org.json4s.jackson.JsonMethods.parse
 
 import scala.collection.mutable.ArrayBuffer
+import scala.io.Source
 import scala.util.{Failure, Success, Try}
 
 /**
@@ -52,7 +56,7 @@ import scala.util.{Failure, Success, Try}
  *
  * @param workflowOpt optional workflow that produced the trained model
  */
-class OpWorkflowModelReader(val workflowOpt: Option[OpWorkflow]) extends MLReader[OpWorkflowModel] {
+class OpWorkflowModelReader(val workflowOpt: Option[OpWorkflow]) {
 
   /**
    * Load a previously trained workflow model from path
@@ -60,14 +64,14 @@ class OpWorkflowModelReader(val workflowOpt: Option[OpWorkflow]) extends MLReade
    * @param path to the trained workflow model
    * @return workflow model
    */
-  final override def load(path: String): OpWorkflowModel = {
-    JobGroupUtil.withJobGroup(OpStep.ModelIO) {
-      Try(sc.textFile(OpWorkflowModelReadWriteShared.jsonPath(path), 1).collect().mkString)
-        .flatMap(loadJson(_, path = path)) match {
-        case Failure(error) => throw new RuntimeException(s"Failed to load Workflow from path '$path'", error)
-        case Success(wf) => wf
-      }
-    }(this.sparkSession)
+  final def load(path: String): OpWorkflowModel = {
+    implicit val conf = new org.apache.hadoop.conf.Configuration()
+    FileReader.loadFile(OpWorkflowModelReadWriteShared.jsonPath(path))
+    Try(FileReader.loadFile(OpWorkflowModelReadWriteShared.jsonPath(path)))
+      .flatMap(loadJson(_, path = path)) match {
+      case Failure(error) => throw new RuntimeException(s"Failed to load Workflow from path '$path'", error)
+      case Success(wf) => wf
+    }
   }
 
   /**
@@ -224,3 +228,30 @@ class OpWorkflowModelReader(val workflowOpt: Option[OpWorkflow]) extends MLReade
   }
 
 }
+
+private object FileReader {
+
+  def loadFile(pathString: String)(implicit conf: Configuration): String = {
+    val path = new Path(pathString)
+    val fs = path.getFileSystem(conf)
+    val allFiles = fs.listFiles(path, false)
+    var partPath: Option[Path] = None
+    while (allFiles.hasNext) {
+      val p = allFiles.next().getPath
+      if (p.getName.startsWith("part")) {
+        partPath = Option(p)
+      }
+    }
+    val finalPath = partPath.getOrElse(path)
+    val codecFactory = new CompressionCodecFactory(conf)
+    val codec = Option(codecFactory.getCodec(finalPath))
+    val in = fs.open(finalPath)
+    val read = codec.map( c => Source.fromInputStream(c.createInputStream(in)).mkString )
+      .getOrElse( IOUtils.toString(in, "UTF-8") )
+    in.close()
+    read
+  }
+}
+
+
+

--- a/core/src/main/scala/com/salesforce/op/OpWorkflowModelReader.scala
+++ b/core/src/main/scala/com/salesforce/op/OpWorkflowModelReader.scala
@@ -55,7 +55,7 @@ import scala.util.{Failure, Success, Try}
  * NOTE: The FeatureGeneratorStages will not be recovered into the Model object, because they are part of each feature.
  *
  * @param workflowOpt optional workflow that produced the trained model
- * @param asSpark if true will load as spark models if false will load as Mlleap stages for spark wrapped stages
+ * @param asSpark if true will load as spark models if false will load as Mleap stages for spark wrapped stages
  */
 class OpWorkflowModelReader(val workflowOpt: Option[OpWorkflow], val asSpark: Boolean = true) {
 
@@ -67,7 +67,7 @@ class OpWorkflowModelReader(val workflowOpt: Option[OpWorkflow], val asSpark: Bo
    */
   final def load(path: String): OpWorkflowModel = {
     implicit val conf = new org.apache.hadoop.conf.Configuration()
-    Try(FileReader.loadFile(OpWorkflowModelReadWriteShared.jsonPath(path)))
+    Try(WorkflowFileReader.loadFile(OpWorkflowModelReadWriteShared.jsonPath(path)))
       .flatMap(loadJson(_, path = path)) match {
       case Failure(error) => throw new RuntimeException(s"Failed to load Workflow from path '$path'", error)
       case Success(wf) => wf
@@ -231,7 +231,7 @@ class OpWorkflowModelReader(val workflowOpt: Option[OpWorkflow], val asSpark: Bo
 
 }
 
-private object FileReader {
+private object WorkflowFileReader {
 
   def loadFile(pathString: String)(implicit conf: Configuration): String = {
     val path = new Path(pathString)

--- a/core/src/main/scala/com/salesforce/op/stages/impl/classification/OpDecisionTreeClassifier.scala
+++ b/core/src/main/scala/com/salesforce/op/stages/impl/classification/OpDecisionTreeClassifier.scala
@@ -113,8 +113,8 @@ class OpDecisionTreeClassificationModel
 ) extends OpProbabilisticClassifierModel[DecisionTreeClassificationModel](
   sparkModel = sparkModel, uid = uid, operationName = operationName
 ) {
-  @transient lazy val predictRawMirror = reflectMethod(getSparkMlStage().get, "predictRaw")
-  @transient lazy val raw2probabilityMirror = reflectMethod(getSparkMlStage().get, "raw2probability")
-  @transient lazy val probability2predictionMirror =
-    reflectMethod(getSparkMlStage().get, "probability2prediction")
+  @transient lazy val predictRawMirror = getSparkOrLocalMethod("predictRaw", "predictRaw")
+  @transient lazy val raw2probabilityMirror = getSparkOrLocalMethod("raw2probability", "rawToProbability")
+  @transient lazy val probability2predictionMirror = getSparkOrLocalMethod("probability2prediction",
+    "probabilityToPrediction")
 }

--- a/core/src/main/scala/com/salesforce/op/stages/impl/classification/OpGBTClassifier.scala
+++ b/core/src/main/scala/com/salesforce/op/stages/impl/classification/OpGBTClassifier.scala
@@ -139,9 +139,9 @@ class OpGBTClassificationModel
 ) extends OpProbabilisticClassifierModel[GBTClassificationModel](
   sparkModel = sparkModel, uid = uid, operationName = operationName
 ) {
-  @transient lazy val predictRawMirror = reflectMethod(getSparkMlStage().get, "predictRaw")
-  @transient lazy val raw2probabilityMirror = reflectMethod(getSparkMlStage().get, "raw2probability")
-  @transient lazy val probability2predictionMirror =
-    reflectMethod(getSparkMlStage().get, "probability2prediction")
+  @transient lazy val predictRawMirror = getSparkOrLocalMethod("predictRaw", "predictRaw")
+  @transient lazy val raw2probabilityMirror = getSparkOrLocalMethod("raw2probability", "rawToProbability")
+  @transient lazy val probability2predictionMirror = getSparkOrLocalMethod("probability2prediction",
+    "probabilityToPrediction")
 }
 

--- a/core/src/main/scala/com/salesforce/op/stages/impl/classification/OpLinearSVC.scala
+++ b/core/src/main/scala/com/salesforce/op/stages/impl/classification/OpLinearSVC.scala
@@ -34,7 +34,7 @@ import com.salesforce.op.UID
 import com.salesforce.op.features.types.{OPVector, Prediction, RealNN}
 import com.salesforce.op.stages.impl.CheckIsResponseValues
 import com.salesforce.op.stages.sparkwrappers.specific.{OpPredictorWrapper, OpPredictorWrapperModel}
-import com.salesforce.op.utils.reflection.ReflectionUtils.reflectMethod
+import ml.combust.mleap.core.classification.{LinearSVCModel => MleapLinearSVCModel}
 import org.apache.spark.ml.classification.{LinearSVC, LinearSVCModel, OpLinearSVCParams}
 import org.apache.spark.ml.linalg.Vector
 
@@ -151,13 +151,16 @@ class OpLinearSVCModel
   ttov: TypeTag[Prediction#Value]
 ) extends OpPredictorWrapperModel[LinearSVCModel](uid = uid, operationName = operationName, sparkModel = sparkModel) {
 
-  @transient lazy private val predictRaw = reflectMethod(getSparkMlStage().get, "predictRaw")
-  @transient lazy private val predict: Vector => Double = getSparkMlStage().get.predict(_)
+  @transient lazy private val predictRaw = getSparkOrLocalMethod("predictRaw", "predictRaw")
+  @transient lazy private val predict: Vector => Double =
+    getSparkMlStage().map(s => s.predict(_))
+      .orElse( getLocalMlStage().map(s => s.model.asInstanceOf[MleapLinearSVCModel].predict(_) )
+      ).getOrElse( throw new RuntimeException("Failed to find wrapped stage for LinearSVC") )
 
   /**
    * Function used to convert input to output
    */
-  override def transformFn: (RealNN, OPVector) => Prediction = (label, features) => {
+  override def transformFn: (RealNN, OPVector) => Prediction = (_, features) => {
     val raw = predictRaw(features.value).asInstanceOf[Vector]
     val pred = predict(features.value)
 

--- a/core/src/main/scala/com/salesforce/op/stages/impl/classification/OpLogisticRegression.scala
+++ b/core/src/main/scala/com/salesforce/op/stages/impl/classification/OpLogisticRegression.scala
@@ -205,8 +205,8 @@ class OpLogisticRegressionModel
 ) extends OpProbabilisticClassifierModel[LogisticRegressionModel](
   sparkModel = sparkModel, uid = uid, operationName = operationName
 ) {
-  @transient lazy val predictRawMirror = reflectMethod(getSparkMlStage().get, "predictRaw")
-  @transient lazy val raw2probabilityMirror = reflectMethod(getSparkMlStage().get, "raw2probability")
-  @transient lazy val probability2predictionMirror =
-    reflectMethod(getSparkMlStage().get, "probability2prediction")
+  @transient lazy val predictRawMirror = getSparkOrLocalMethod("predictRaw", "predictRaw")
+  @transient lazy val raw2probabilityMirror = getSparkOrLocalMethod("raw2probability", "rawToProbability")
+  @transient lazy val probability2predictionMirror = getSparkOrLocalMethod("probability2prediction",
+    "probabilityToPrediction")
 }

--- a/core/src/main/scala/com/salesforce/op/stages/impl/classification/OpMultilayerPerceptronClassifier.scala
+++ b/core/src/main/scala/com/salesforce/op/stages/impl/classification/OpMultilayerPerceptronClassifier.scala
@@ -141,9 +141,9 @@ class OpMultilayerPerceptronClassificationModel
 ) extends OpProbabilisticClassifierModel[MultilayerPerceptronClassificationModel](
   sparkModel = sparkModel, uid = uid, operationName = operationName
 ) {
-  @transient lazy val predictRawMirror = reflectMethod(getSparkMlStage().get, "predictRaw")
-  @transient lazy val raw2probabilityMirror = reflectMethod(getSparkMlStage().get, "raw2probability")
-  @transient lazy val probability2predictionMirror =
-    reflectMethod(getSparkMlStage().get, "probability2prediction")
+  @transient lazy val predictRawMirror = getSparkOrLocalMethod("predictRaw", "predictRaw")
+  @transient lazy val raw2probabilityMirror = getSparkOrLocalMethod("raw2probability", "rawToProbability")
+  @transient lazy val probability2predictionMirror = getSparkOrLocalMethod("probability2prediction",
+    "probabilityToPrediction")
 }
 

--- a/core/src/main/scala/com/salesforce/op/stages/impl/classification/OpNaiveBayes.scala
+++ b/core/src/main/scala/com/salesforce/op/stages/impl/classification/OpNaiveBayes.scala
@@ -103,10 +103,10 @@ class OpNaiveBayesModel
 ) extends OpProbabilisticClassifierModel[NaiveBayesModel](
   sparkModel = sparkModel, uid = uid, operationName = operationName
 ) {
-  @transient lazy val predictRawMirror = reflectMethod(getSparkMlStage().get, "predictRaw")
-  @transient lazy val raw2probabilityMirror = reflectMethod(getSparkMlStage().get, "raw2probability")
-  @transient lazy val probability2predictionMirror =
-    reflectMethod(getSparkMlStage().get, "probability2prediction")
+  @transient lazy val predictRawMirror = getSparkOrLocalMethod("predictRaw", "predictRaw")
+  @transient lazy val raw2probabilityMirror = getSparkOrLocalMethod("raw2probability", "rawToProbability")
+  @transient lazy val probability2predictionMirror = getSparkOrLocalMethod("probability2prediction",
+    "probabilityToPrediction")
 }
 
 

--- a/core/src/main/scala/com/salesforce/op/stages/impl/classification/OpRandomForestClassifier.scala
+++ b/core/src/main/scala/com/salesforce/op/stages/impl/classification/OpRandomForestClassifier.scala
@@ -150,10 +150,10 @@ class OpRandomForestClassificationModel
 ) extends OpProbabilisticClassifierModel[RandomForestClassificationModel](
   sparkModel = sparkModel, uid = uid, operationName = operationName
 ) {
-  @transient lazy val predictRawMirror = reflectMethod(getSparkMlStage().get, "predictRaw")
-  @transient lazy val raw2probabilityMirror = reflectMethod(getSparkMlStage().get, "raw2probability")
-  @transient lazy val probability2predictionMirror =
-    reflectMethod(getSparkMlStage().get, "probability2prediction")
+  @transient lazy val predictRawMirror = getSparkOrLocalMethod("predictRaw", "predictRaw")
+  @transient lazy val raw2probabilityMirror = getSparkOrLocalMethod("raw2probability", "rawToProbability")
+  @transient lazy val probability2predictionMirror = getSparkOrLocalMethod("probability2prediction",
+    "probabilityToPrediction")
 }
 
 

--- a/core/src/main/scala/com/salesforce/op/stages/impl/insights/RecordInsightsLOCO.scala
+++ b/core/src/main/scala/com/salesforce/op/stages/impl/insights/RecordInsightsLOCO.scala
@@ -107,7 +107,7 @@ class RecordInsightsLOCO[T <: Model[T]]
   private val modelApply = model match {
     case m: SelectedModel => m.transformFn
     case m: OpPredictorWrapperModel[_] => m.transformFn
-    case m => toOPUnchecked(m).transformFn
+    case m => toOPUnchecked(m, m.uid).transformFn
   }
   private val labelDummy = RealNN(0.0)
   private lazy val histories = OpVectorMetadata(getInputSchema()(in1.name)).getColumnHistory()

--- a/core/src/main/scala/com/salesforce/op/stages/impl/regression/OpGeneralizedLinearRegression.scala
+++ b/core/src/main/scala/com/salesforce/op/stages/impl/regression/OpGeneralizedLinearRegression.scala
@@ -34,8 +34,10 @@ import com.salesforce.op.UID
 import com.salesforce.op.features.types.{OPVector, Prediction, RealNN}
 import com.salesforce.op.stages.impl.CheckIsResponseValues
 import com.salesforce.op.stages.sparkwrappers.specific.{OpPredictorWrapper, OpPredictorWrapperModel}
+import ml.combust.mleap.core.regression.{GeneralizedLinearRegressionModel => MleapGeneralizedLinearRegressionModel}
 import com.salesforce.op.utils.reflection.ReflectionUtils.reflectMethod
 import org.apache.spark.ml.regression.{GeneralizedLinearRegression, GeneralizedLinearRegressionModel, OpGeneralizedLinearRegressionParams}
+import org.apache.spark.ml.linalg.Vector
 
 import scala.reflect.runtime.universe.TypeTag
 
@@ -183,16 +185,22 @@ class OpGeneralizedLinearRegressionModel
 ) extends OpPredictorWrapperModel[GeneralizedLinearRegressionModel](uid = uid, operationName = operationName,
   sparkModel = sparkModel) {
 
-  @transient lazy private val predictLink = reflectMethod(getSparkMlStage().get, "predictLink")
-  @transient lazy private val predict = reflectMethod(getSparkMlStage().get, "predict", argsCount = Some(2))
+  @transient lazy private val predictLinkSpark = getSparkMlStage()
+    .map(s => reflectMethod(s, "predictLink", argsCount = Option(2)))
+  @transient lazy private val predictLinkLocal = getLocalMlStage()
+    .map(s => s.model.asInstanceOf[MleapGeneralizedLinearRegressionModel].predictLink(_))
+  @transient lazy protected val predict: Vector => Double = getSparkMlStage().map( m => m.predict(_) )
+    .orElse{ getLocalMlStage().map(s => s.model.asInstanceOf[MleapGeneralizedLinearRegressionModel].predict(_)) }
+    .getOrElse( throw new RuntimeException("Failed to find predict function in local or spark models") )
 
   /**
    * Function used to convert input to output
    */
-  override def transformFn: (RealNN, OPVector) => Prediction = (label, features) => {
-    val offset = 0.0
-    val raw = predictLink(features.value, offset).asInstanceOf[Double]
-    val pred = predict(features.value, offset).asInstanceOf[Double]
+  override def transformFn: (RealNN, OPVector) => Prediction = (_, features) => {
+    val raw: Double = predictLinkSpark.map( p => p(features.value, 0.0).asInstanceOf[Double] )
+      .orElse( predictLinkLocal.map(p => p(features.value)) )
+      .getOrElse(throw new RuntimeException("Failed to find link function in local or spark models"))
+    val pred: Double = predict(features.value)
     Prediction(prediction = pred, rawPrediction = raw)
   }
 }

--- a/core/src/main/scala/com/salesforce/op/stages/impl/regression/OpLinearRegression.scala
+++ b/core/src/main/scala/com/salesforce/op/stages/impl/regression/OpLinearRegression.scala
@@ -34,7 +34,9 @@ import com.salesforce.op._
 import com.salesforce.op.features.types.{OPVector, Prediction, RealNN}
 import com.salesforce.op.stages.impl.CheckIsResponseValues
 import com.salesforce.op.stages.sparkwrappers.specific.{OpPredictionModel, OpPredictorWrapper}
+import org.apache.spark.ml.linalg.Vector
 import org.apache.spark.ml.regression.{LinearRegression, LinearRegressionModel, OpLinearRegressionParams}
+import ml.combust.mleap.core.regression.{LinearRegressionModel => MleapLinearRegressionModel}
 
 import scala.reflect.runtime.universe.TypeTag
 
@@ -204,4 +206,8 @@ class OpLinearRegressionModel
   ttov: TypeTag[Prediction#Value]
 ) extends OpPredictionModel[LinearRegressionModel](
   sparkModel = sparkModel, uid = uid, operationName = operationName
-)
+) {
+  @transient lazy protected val predict: Vector => Double = getSparkMlStage().map(s => s.predict(_))
+    .orElse( getLocalMlStage().map(s => s.model.asInstanceOf[MleapLinearRegressionModel].predict(_)) )
+    .getOrElse( throw new RuntimeException(s"Could not find the wrapped Spark stage.") )
+}

--- a/core/src/main/scala/com/salesforce/op/stages/impl/regression/OpRandomForestRegressor.scala
+++ b/core/src/main/scala/com/salesforce/op/stages/impl/regression/OpRandomForestRegressor.scala
@@ -34,7 +34,9 @@ import com.salesforce.op.UID
 import com.salesforce.op.features.types.{OPVector, Prediction, RealNN}
 import com.salesforce.op.stages.impl.CheckIsResponseValues
 import com.salesforce.op.stages.sparkwrappers.specific.{OpPredictionModel, OpPredictorWrapper}
+import org.apache.spark.ml.linalg.Vector
 import org.apache.spark.ml.regression.{OpRandomForestRegressorParams, RandomForestRegressionModel, RandomForestRegressor}
+import ml.combust.mleap.core.regression.{RandomForestRegressionModel => MleapRandomForestRegressionModel}
 
 import scala.reflect.runtime.universe.TypeTag
 
@@ -125,4 +127,9 @@ class OpRandomForestRegressionModel
   ttov: TypeTag[Prediction#Value]
 ) extends OpPredictionModel[RandomForestRegressionModel](
   sparkModel = sparkModel, uid = uid, operationName = operationName
-)
+){
+  @transient lazy protected val predict: Vector => Double = getSparkMlStage().map(s => s.predict(_))
+    .orElse( getLocalMlStage().map(s => s.model.asInstanceOf[MleapRandomForestRegressionModel].predict(_)) )
+    .getOrElse( throw new RuntimeException(s"Could not find the wrapped Spark stage.") )
+}
+

--- a/core/src/main/scala/com/salesforce/op/stages/impl/selector/ModelSelector.scala
+++ b/core/src/main/scala/com/salesforce/op/stages/impl/selector/ModelSelector.scala
@@ -47,6 +47,7 @@ import com.salesforce.op.utils.stages.FitStagesUtil._
 import org.apache.spark.ml.param._
 import org.apache.spark.ml.{Estimator, Model, PredictionModel}
 import org.apache.spark.sql.{DataFrame, Dataset, SparkSession}
+import ml.combust.mleap.runtime.frame.{Transformer => MLeapTransformer}
 
 import scala.reflect.runtime.universe._
 
@@ -239,9 +240,11 @@ final class SelectedModel private[op]
     case m => setDefault(sparkMlStage, Option(m))
   }
 
-  @transient private lazy val recoveredStage: ModelType = getSparkMlStage() match {
-    case Some(m: PredictionModel[_, _]) => SparkModelConverter.toOPUnchecked(m).asInstanceOf[ModelType]
-    case Some(m: ModelType@unchecked) => m
+  @transient private lazy val recoveredStage: ModelType = (getSparkMlStage(), getLocalMlStage()) match {
+    case (Some(m: PredictionModel[_, _]), _) => SparkModelConverter.toOPUnchecked(m).asInstanceOf[ModelType]
+    case (Some(m: ModelType@unchecked), _) => m
+//    case (None, Some(m: MLeapTransformer)) => SparkModelConverter.toOPUnchecked(m).asInstanceOf[ModelType]
+//    // TODO make this work
     case m => throw new IllegalArgumentException(s"SparkMlStage in SelectedModel ($m) is of unsupported" +
       s" type ${m.getClass.getName}")
   }

--- a/core/src/main/scala/com/salesforce/op/stages/impl/selector/ModelSelector.scala
+++ b/core/src/main/scala/com/salesforce/op/stages/impl/selector/ModelSelector.scala
@@ -241,10 +241,9 @@ final class SelectedModel private[op]
   }
 
   @transient private lazy val recoveredStage: ModelType = (getSparkMlStage(), getLocalMlStage()) match {
-    case (Some(m: PredictionModel[_, _]), _) => SparkModelConverter.toOPUnchecked(m).asInstanceOf[ModelType]
+    case (Some(m: PredictionModel[_, _]), _) => SparkModelConverter.toOPUnchecked(m, m.uid).asInstanceOf[ModelType]
     case (Some(m: ModelType@unchecked), _) => m
-//    case (None, Some(m: MLeapTransformer)) => SparkModelConverter.toOPUnchecked(m).asInstanceOf[ModelType]
-//    // TODO make this work
+    case (None, Some(m: MLeapTransformer)) => SparkModelConverter.toOPUnchecked(m, m.uid).asInstanceOf[ModelType]
     case m => throw new IllegalArgumentException(s"SparkMlStage in SelectedModel ($m) is of unsupported" +
       s" type ${m.getClass.getName}")
   }

--- a/core/src/main/scala/com/salesforce/op/stages/impl/selector/ModelSelector.scala
+++ b/core/src/main/scala/com/salesforce/op/stages/impl/selector/ModelSelector.scala
@@ -196,6 +196,12 @@ E <: Estimator[_] with OpPipelineStage2[RealNN, OPVector, Prediction]]
       .setMetadata(getMetadata())
       .setOutputFeatureName(getOutputFeatureName)
       .setEvaluators(evaluators)
+
+    bestModel match {
+      case m: SparkWrapperParams[_] => m.getOutputDF.foreach(selectedModel.setOutputDF)
+      case _ =>
+    }
+
     // Reset the job group to feature engineering.
     JobGroupUtil.setJobGroup(OpStep.FeatureEngineering)
     selectedModel

--- a/core/src/main/scala/com/salesforce/op/stages/impl/tuning/OpValidator.scala
+++ b/core/src/main/scala/com/salesforce/op/stages/impl/tuning/OpValidator.scala
@@ -260,8 +260,7 @@ private[op] trait OpValidator[M <: Model[_], E <: Estimator[_]] extends Serializ
       dag = dag,
       train = training,
       test = validation,
-      hasTest = true,
-      indexOfLastEstimator = Option(-1)
+      hasTest = true
     )
     val selectTrain = newTrain.select(label, features)
     val selectTest = newTest.select(label, features)

--- a/core/src/main/scala/com/salesforce/op/stages/sparkwrappers/specific/OpPredictionModel.scala
+++ b/core/src/main/scala/com/salesforce/op/stages/sparkwrappers/specific/OpPredictionModel.scala
@@ -34,6 +34,7 @@ import com.salesforce.op.features.types.{OPVector, Prediction, RealNN}
 import org.apache.spark.ml.PredictionModel
 import org.apache.spark.ml.linalg.Vector
 
+import scala.reflect.ClassTag
 import scala.reflect.runtime.universe._
 
 /**
@@ -45,7 +46,7 @@ import scala.reflect.runtime.universe._
  * @param operationName unique name of the operation this stage performs
  * @tparam T type of the model to wrap
  */
-abstract class OpPredictionModel[T <: PredictionModel[Vector, T]]
+abstract class OpPredictionModel[T <: PredictionModel[Vector, T] : ClassTag]
 (
   sparkModel: T,
   uid: String,
@@ -55,14 +56,12 @@ abstract class OpPredictionModel[T <: PredictionModel[Vector, T]]
   /**
    * Predict label for the given features
    */
-  @transient protected lazy val predict: Vector => Double = getSparkMlStage().getOrElse(
-    throw new RuntimeException(s"Could not find the wrapped Spark stage.")
-  ).predict(_)
+  @transient protected def predict: Vector => Double
 
   /**
    * Function used to convert input to output
    */
-  override def transformFn: (RealNN, OPVector) => Prediction = (label, features) =>
+  override def transformFn: (RealNN, OPVector) => Prediction = (_, features) =>
     Prediction(prediction = predict(features.value))
 
 }

--- a/core/src/main/scala/com/salesforce/op/stages/sparkwrappers/specific/OpProbabilisticClassifierModel.scala
+++ b/core/src/main/scala/com/salesforce/op/stages/sparkwrappers/specific/OpProbabilisticClassifierModel.scala
@@ -34,6 +34,7 @@ import com.salesforce.op.features.types._
 import org.apache.spark.ml.classification.ProbabilisticClassificationModel
 import org.apache.spark.ml.linalg.Vector
 
+import scala.reflect.ClassTag
 import scala.reflect.runtime.universe._
 
 /**
@@ -45,7 +46,7 @@ import scala.reflect.runtime.universe._
  * @param operationName unique name of the operation this stage performs
  * @tparam T type of the model to wrap
  */
-abstract class OpProbabilisticClassifierModel[T <: ProbabilisticClassificationModel[Vector, T]]
+abstract class OpProbabilisticClassifierModel[T <: ProbabilisticClassificationModel[Vector, T] : ClassTag]
 (
   sparkModel: T,
   uid: String,

--- a/core/src/main/scala/com/salesforce/op/stages/sparkwrappers/specific/SparkModelConverter.scala
+++ b/core/src/main/scala/com/salesforce/op/stages/sparkwrappers/specific/SparkModelConverter.scala
@@ -39,6 +39,7 @@ import org.apache.spark.ml.classification._
 import org.apache.spark.ml.linalg.Vector
 import org.apache.spark.ml.regression._
 import org.apache.spark.ml.{Model, PredictionModel}
+import ml.combust.mleap.runtime.frame.{Transformer => MLeapTransformer}
 
 /**
  * Allows conversion from spark models to models that follow the OP convention of having a
@@ -74,10 +75,8 @@ object SparkModelConverter {
    * Converts supported spark model of type PredictionModel[Vector, T] to an OP model
    * @param model model to convert
    * @param uid uid to give converted model
-   * @tparam T type of model to convert
    * @return Op Binary Model which will produce the same values put into a Prediction return feature
    */
-  // TODO remove when loco and model selector are updated
   def toOPUnchecked(
     model: Model[_],
     uid: String
@@ -100,5 +99,31 @@ object SparkModelConverter {
       case m => throw new RuntimeException(s"model conversion not implemented for model $m")
     }
   }
+
+  /**
+   * Converts supported mleap loaded spark model of type PredictionModel[Vector, T] to an OP model
+   * @param model model to convert
+   * @return Op Binary Model which will produce the same values put into a Prediction return feature
+   */
+//  def toOPUnchecked(
+//    model: MLeapTransformer
+//  ): OpTransformer2[RealNN, OPVector, Prediction] =
+//    model match {
+//      case m: LogisticRegressionModel => new OpLogisticRegressionModel(m, uid = uid)
+//      case m: RandomForestClassificationModel => new OpRandomForestClassificationModel(m, uid = uid)
+//      case m: NaiveBayesModel => new OpNaiveBayesModel(m, uid)
+//      case m: DecisionTreeClassificationModel => new OpDecisionTreeClassificationModel(m, uid = uid)
+//      case m: GBTClassificationModel => new OpGBTClassificationModel(m, uid = uid)
+//      case m: LinearSVCModel => new OpLinearSVCModel(m, uid = uid)
+//      case m: MultilayerPerceptronClassificationModel => new OpMultilayerPerceptronClassificationModel(m, uid = uid)
+//      case m: LinearRegressionModel => new OpLinearRegressionModel(m, uid = uid)
+//      case m: RandomForestRegressionModel => new OpRandomForestRegressionModel(m, uid = uid)
+//      case m: GBTRegressionModel => new OpGBTRegressionModel(m, uid = uid)
+//      case m: DecisionTreeRegressionModel => new OpDecisionTreeRegressionModel(m, uid = uid)
+//      case m: GeneralizedLinearRegressionModel => new OpGeneralizedLinearRegressionModel(m, uid = uid)
+//      case m: XGBoostClassificationModel => new OpXGBoostClassificationModel(m, uid = uid)
+//      case m: XGBoostRegressionModel => new OpXGBoostRegressionModel(m, uid = uid)
+//      case m => throw new RuntimeException(s"model conversion not implemented for model $m")
+//    }
 
 }

--- a/core/src/main/scala/com/salesforce/op/utils/stages/FitStagesUtil.scala
+++ b/core/src/main/scala/com/salesforce/op/utils/stages/FitStagesUtil.scala
@@ -204,7 +204,6 @@ private[op] case object FitStagesUtil {
    * @param train                training dataset
    * @param test                 test dataset
    * @param hasTest              whether the test dataset is empty or not
-   * @param indexOfLastEstimator Optional index of the last estimator
    * @param persistEveryKStages  frequency of persisting stages
    * @param fittedTransformers   list of already fitted transformers
    * @param spark                Spark session
@@ -215,7 +214,6 @@ private[op] case object FitStagesUtil {
     train: Dataset[Row],
     test: Dataset[Row],
     hasTest: Boolean,
-    indexOfLastEstimator: Option[Int],
     persistEveryKStages: Int = OpWorkflowModel.PersistEveryKStages,
     fittedTransformers: Seq[OPStage] = Seq.empty
   )(implicit spark: SparkSession): FittedDAG = {
@@ -228,7 +226,7 @@ private[op] case object FitStagesUtil {
           train = currTrain,
           test = currTest,
           hasTest = hasTest,
-          transformData = indexOfLastEstimator.exists(_ < index), // only need to update for fit before last estimator
+          transformData = true, // even transformers need to be fit because may need metadata from training
           persistEveryKStages = persistEveryKStages
         )
         alreadyFitted ++= justFitted

--- a/core/src/test/scala/com/salesforce/op/stages/OpPipelineStageReaderWriterTest.scala
+++ b/core/src/test/scala/com/salesforce/op/stages/OpPipelineStageReaderWriterTest.scala
@@ -106,7 +106,21 @@ private[stages] abstract class OpPipelineStageReaderWriterTest
   }
   it should "load stage correctly" in {
     val reader = new OpPipelineStageReader(stage)
-    val stageLoaded = reader.loadFromJsonString(stageJsonString, path = savePath)
+    val stageLoaded = reader.loadFromJsonString(stageJsonString, path = savePath, asSpark = true)
+    stageLoaded shouldBe a[OpPipelineStageBase]
+    stageLoaded shouldBe a[Transformer]
+    stageLoaded.getOutput() shouldBe a[FeatureLike[_]]
+    val _ = stage.asInstanceOf[Transformer].transform(passengersDataSet)
+    val transformed = stageLoaded.asInstanceOf[Transformer].transform(passengersDataSet)
+    transformed.collect(stageLoaded.getOutput().asInstanceOf[FeatureLike[Real]]) shouldBe expected
+    stageLoaded.uid shouldBe stage.uid
+    stageLoaded.operationName shouldBe stage.operationName
+    stageLoaded.getInputFeatures() shouldBe stage.getInputFeatures()
+    stageLoaded.getInputSchema() shouldBe stage.getInputSchema()
+  }
+  it should "load stage correctly with spark as false" in {
+    val reader = new OpPipelineStageReader(stage)
+    val stageLoaded = reader.loadFromJsonString(stageJsonString, path = savePath, asSpark = false)
     stageLoaded shouldBe a[OpPipelineStageBase]
     stageLoaded shouldBe a[Transformer]
     stageLoaded.getOutput() shouldBe a[FeatureLike[_]]

--- a/core/src/test/scala/com/salesforce/op/stages/OpPipelineStageReaderWriterTest.scala
+++ b/core/src/test/scala/com/salesforce/op/stages/OpPipelineStageReaderWriterTest.scala
@@ -60,7 +60,6 @@ private[stages] abstract class OpPipelineStageReaderWriterTest
   private lazy val writer = new OpPipelineStageWriter(stage)
   private lazy val stageJsonString: String = writer.writeToJsonString(savePath)
   private lazy val stageJson: JValue = parse(stageJsonString)
-  private lazy val isModel = stage.isInstanceOf[Model[_]]
   private val FN = FieldNames
 
   Spec(this.getClass) should "write stage uid" in {
@@ -82,7 +81,7 @@ private[stages] abstract class OpPipelineStageReaderWriterTest
   }
   it should "write outputMetadata" in {
     val params = extractParams(stageJson)
-    val metadataStr = compact(render(extractParams(stageJson) \ "outputMetadata"))
+    val metadataStr = compact(render(params \ "outputMetadata"))
     val metadata = Metadata.fromJson(metadataStr)
     metadata shouldBe stage.getMetadata()
   }

--- a/core/src/test/scala/com/salesforce/op/stages/OpPipelineStagesTest.scala
+++ b/core/src/test/scala/com/salesforce/op/stages/OpPipelineStagesTest.scala
@@ -143,7 +143,8 @@ class OpPipelineStagesTest
     testOp.setInput(weight)
     val reader = new OpPipelineStageReader(testOp)
     val stageJson = writer.writeToJsonString(savePath)
-    val stage = reader.loadFromJsonString(stageJson, savePath).asInstanceOf[UnaryLambdaTransformer[Real, Real]]
+    val stage = reader.loadFromJsonString(stageJson, savePath, asSpark = true)
+      .asInstanceOf[UnaryLambdaTransformer[Real, Real]]
 
     val features = stage.get(stage.inputFeatures).get
     features should have length 1

--- a/features/build.gradle
+++ b/features/build.gradle
@@ -22,4 +22,6 @@ dependencies {
     compile "ml.combust.mleap:mleap-spark_$scalaVersion:$mleapVersion"
     compile "ml.combust.mleap:mleap-runtime_$scalaVersion:$mleapVersion"
     compile "ml.combust.mleap:mleap-xgboost-spark_$scalaVersion:$mleapVersion"
+    compile "ml.combust.mleap:mleap-xgboost-runtime_$scalaVersion:$mleapVersion"
+    compile "com.jsuereth:scala-arm_$scalaVersion:$mleapVersion"
 }

--- a/features/src/main/scala/com/salesforce/op/stages/OpPipelineStageReader.scala
+++ b/features/src/main/scala/com/salesforce/op/stages/OpPipelineStageReader.scala
@@ -34,9 +34,7 @@ import com.salesforce.op.features.OPFeature
 import com.salesforce.op.stages.OpPipelineStageReaderWriter._
 import com.salesforce.op.stages.sparkwrappers.generic.SparkWrapperParams
 import com.salesforce.op.utils.reflection.ReflectionUtils
-import org.apache.hadoop.fs.Path
 import org.apache.spark.ml.SparkDefaultParamsReadWrite
-import org.apache.spark.ml.util.MLReader
 import org.json4s.JsonAST.JValue
 import org.json4s._
 import org.json4s.jackson.JsonMethods.{compact, render}
@@ -53,7 +51,7 @@ final class OpPipelineStageReader private
 (
   val originalStage: Option[OpPipelineStageBase],
   val features: Seq[OPFeature]
-) extends MLReader[OpPipelineStageBase] {
+) {
 
   /**
    * Legacy ctor which requires origin stage to be preset when loading stages
@@ -62,17 +60,6 @@ final class OpPipelineStageReader private
     this(Option(origStage), origStage.getInputFeatures().flatMap(_.allFeatures))
 
   def this(feats: Seq[OPFeature]) = this(None, feats)
-
-  /**
-   * Load from disk. File should contain data serialized in json format
-   *
-   * @param path to the stored output
-   * @return OpPipelineStageBase
-   */
-  override def load(path: String): OpPipelineStageBase = {
-    val metadataPath = new Path(path, "metadata").toString
-    loadFromJsonString(sc.textFile(metadataPath, 1).first(), path)
-  }
 
   /**
    * Loads from the json serialized data

--- a/features/src/main/scala/com/salesforce/op/stages/OpPipelineStageReader.scala
+++ b/features/src/main/scala/com/salesforce/op/stages/OpPipelineStageReader.scala
@@ -68,8 +68,8 @@ final class OpPipelineStageReader private
    * @param path to the stored output
    * @return OpPipelineStageBase
    */
-  def loadFromJson(json: JValue, path: String): OpPipelineStageBase =
-    loadFromJsonString(jsonStr = compact(render(json)), path = path)
+  def loadFromJson(json: JValue, path: String, asSpark: Boolean): OpPipelineStageBase =
+    loadFromJsonString(jsonStr = compact(render(json)), path = path, asSpark = asSpark)
 
   /**
    * Loads from the json serialized data
@@ -78,7 +78,7 @@ final class OpPipelineStageReader private
    * @param path    to the stored output
    * @return OpPipelineStageBase
    */
-  def loadFromJsonString(jsonStr: String, path: String): OpPipelineStageBase = {
+  def loadFromJsonString(jsonStr: String, path: String, asSpark: Boolean): OpPipelineStageBase = {
     // Load stage json with it's params
     val metadata = SparkDefaultParamsReadWrite.parseMetadata(jsonStr)
     val (className, metadataJson) = metadata.className -> metadata.metadata
@@ -110,8 +110,8 @@ final class OpPipelineStageReader private
     // Update [[SparkWrapperParams]] with path so we can load the [[SparkStageParam]] instance
     val updatedMetadata = stage match {
       case _: SparkWrapperParams[_] => metadata.copy(
-        params = SparkStageParam.updateParamsMetadataWithPath(metadata.params, path),
-        defaultParams = SparkStageParam.updateParamsMetadataWithPath(metadata.defaultParams, path)
+        params = SparkStageParam.updateParamsMetadataWithPath(metadata.params, path, asSpark),
+        defaultParams = SparkStageParam.updateParamsMetadataWithPath(metadata.defaultParams, path, asSpark)
       )
       case _ => metadata
     }

--- a/features/src/main/scala/com/salesforce/op/stages/SparkStageParam.scala
+++ b/features/src/main/scala/com/salesforce/op/stages/SparkStageParam.scala
@@ -127,7 +127,7 @@ class SparkStageParam[S <: PipelineStage with Params]
     }.orElse { // for backwards compatibility
       getPathUid(jsonStr) match {
         case (_, Some(NoUID), _) => None
-        case (Some(p), Some(stageUid), _) =>
+        case (Some(p), Some(stageUid), Some(true)) =>
           val stagePath = new Path(p, stageUid).toString
           val json = parse(jsonStr)
           val className = (json \ "className").extract[String]

--- a/features/src/main/scala/com/salesforce/op/stages/SparkStageParam.scala
+++ b/features/src/main/scala/com/salesforce/op/stages/SparkStageParam.scala
@@ -159,9 +159,8 @@ class SparkStageParam[S <: PipelineStage with Params]
         None
       case (Some(p), Some(stageUid), asSpark) =>
         savePath = Option(p)
-        println(asSpark)
         val loaded = for {bundle <- managed(BundleFile(s"file:$p/$stageUid"))} yield {
-          if (asSpark.getOrElse(false)) Left(loadError(bundle.loadSparkBundle()).root.asInstanceOf[S])
+          if (asSpark.getOrElse(true)) Left(loadError(bundle.loadSparkBundle()).root.asInstanceOf[S])
           else Right(loadError(bundle.loadMleapBundle()).root.asInstanceOf[MLeapTransformer])
         }
         loaded.opt

--- a/features/src/main/scala/com/salesforce/op/stages/sparkwrappers/generic/SparkWrapperParams.scala
+++ b/features/src/main/scala/com/salesforce/op/stages/sparkwrappers/generic/SparkWrapperParams.scala
@@ -88,6 +88,8 @@ trait SparkWrapperParams[S <: PipelineStage with Params] extends Params {
     sparkMlStage.sbc = Option(SparkBundleContext().withDataset(df))
   }
 
+  private[op] def getOutputDF(): Option[DataFrame] = outputDF
+
   /**
    * Sets a save path for wrapped spark stage
    *

--- a/features/src/main/scala/com/salesforce/op/stages/sparkwrappers/generic/SparkWrapperParams.scala
+++ b/features/src/main/scala/com/salesforce/op/stages/sparkwrappers/generic/SparkWrapperParams.scala
@@ -86,6 +86,14 @@ trait SparkWrapperParams[S <: PipelineStage with Params] extends Params {
    */
   def getLocalMlStage(): Option[MLeapTransformer] = sparkMlStage.localTransformer
 
+  /**
+   * method to set local stage for recovered wrapped stages after loading
+   * @param stage
+   */
+  private[op] def setLocalMlStage(stage: MLeapTransformer): this.type = {
+    sparkMlStage.localTransformer = Option(stage)
+    this
+  }
 
   /**
    * XGBoost model save requires a non-empty dataframe to save correctly with Mleap

--- a/features/src/main/scala/com/salesforce/op/stages/sparkwrappers/generic/SparkWrapperParams.scala
+++ b/features/src/main/scala/com/salesforce/op/stages/sparkwrappers/generic/SparkWrapperParams.scala
@@ -37,6 +37,7 @@ import org.apache.spark.ml.param.{Params, StringArrayParam}
 import org.apache.spark.ml.{PipelineStage, Transformer}
 import org.apache.spark.sql.catalyst.encoders.RowEncoder
 import org.apache.spark.sql.{DataFrame, Row, SparkSession}
+import ml.combust.mleap.runtime.frame.{Transformer => MLeapTransformer}
 
 
 /**
@@ -77,6 +78,14 @@ trait SparkWrapperParams[S <: PipelineStage with Params] extends Params {
    * @return Option of spark ml stage
    */
   def getSparkMlStage(): Option[S] = $(sparkMlStage)
+
+  /**
+   * Method to access the local version of stage being wrapped
+   *
+   * @return Option of ml leap runtime version of the spark stage after reloading as local
+   */
+  def getLocalMlStage(): Option[MLeapTransformer] = sparkMlStage.localTransformer
+
 
   /**
    * XGBoost model save requires a non-empty dataframe to save correctly with Mleap

--- a/features/src/main/scala/com/salesforce/op/test/OpPipelineStageSpec.scala
+++ b/features/src/main/scala/com/salesforce/op/test/OpPipelineStageSpec.scala
@@ -151,6 +151,7 @@ trait OpPipelineStageAsserts extends AppendedClues {
       stage.getInputFeatures() should contain theSameElementsAs expected.getInputFeatures()
     }
     clue("Input schemas don't match:") {
+      stage.getInputSchema().fields.size shouldEqual expected.getInputSchema().fields.size
       stage.getInputSchema().fields.zip(expected.getInputSchema().fields).foreach{
         case (sf, ef) =>
           sf.name shouldBe ef.name

--- a/features/src/main/scala/com/salesforce/op/test/OpTransformerSpec.scala
+++ b/features/src/main/scala/com/salesforce/op/test/OpTransformerSpec.scala
@@ -80,6 +80,13 @@ TransformerType <: OpPipelineStage[O] with Transformer with OpTransformer]
     val res: Seq[O] = transformed.collect(output)(convert, classTag[O]).toSeq
     res shouldEqual expectedResult
   }
+  it should "transform data after being loaded without spark" in {
+    val loaded = writeAndRead(stage, asSpark = false)
+    val transformed = loaded.asInstanceOf[TransformerType].transform(inputData)
+    val output = loaded.getOutput().asInstanceOf[FeatureLike[O]]
+    val res: Seq[O] = transformed.collect(output)(convert, classTag[O]).toSeq
+    res shouldEqual expectedResult
+  }
 }
 
 /**
@@ -127,6 +134,7 @@ private[test] trait TransformerSpecCommon[O <: FeatureType, TransformerType <: O
         val sparkWrapped = l.asInstanceOf[SparkWrapperParams[_]]
         sparkWrapped.getLocalMlStage().isDefined shouldBe true
         sparkWrapped.getSparkMlStage().isEmpty shouldBe true
+      case _ =>
     }
     assert(loaded, transformer)
   }

--- a/features/src/main/scala/com/salesforce/op/test/OpTransformerSpec.scala
+++ b/features/src/main/scala/com/salesforce/op/test/OpTransformerSpec.scala
@@ -152,7 +152,7 @@ private[test] trait TransformerSpecCommon[O <: FeatureType, TransformerType <: O
   protected def writeAndRead(stage: TransformerType, savePath: String = stageSavePath): OpPipelineStageBase = {
     val json = new OpPipelineStageWriter(stage).overwrite().writeToJsonString(savePath)
     val features = stage.getInputFeatures().flatMap(_.allFeatures)
-    new OpPipelineStageReader(features).loadFromJsonString(json, savePath)
+    new OpPipelineStageReader(features).loadFromJsonString(json, savePath, true) // TODO add test for false
   }
 
   /**

--- a/features/src/test/scala/com/salesforce/op/stages/FeatureGeneratorStageTest.scala
+++ b/features/src/test/scala/com/salesforce/op/stages/FeatureGeneratorStageTest.scala
@@ -74,7 +74,7 @@ class FeatureGeneratorStageTest extends FlatSpec with TestSparkContext {
     val recovered: FeaturesAndGenerators =
       for {(feature, featureGenerator) <- featuresAndGenerators} yield {
         val featureGenJson = featureGenerator.write.asInstanceOf[OpPipelineStageWriter].writeToJsonString("")
-        val recoveredStage = new OpPipelineStageReader(Seq.empty).loadFromJsonString(featureGenJson, "")
+        val recoveredStage = new OpPipelineStageReader(Seq.empty).loadFromJsonString(featureGenJson, "", true)
         recoveredStage shouldBe a[FeatureGeneratorStage[_, _]]
         feature -> recoveredStage.asInstanceOf[FeatureGeneratorStage[Row, _ <: FeatureType]]
       }
@@ -87,7 +87,7 @@ class FeatureGeneratorStageTest extends FlatSpec with TestSparkContext {
     val multiplied = FeatureBuilder.Integral[Int].extract(new IntMultiplyExtractor(multiplier)).asPredictor
     val featureGenerator = multiplied.originStage
     val featureGenJson = featureGenerator.write.asInstanceOf[OpPipelineStageWriter].writeToJsonString("")
-    val recoveredStage = new OpPipelineStageReader(Seq.empty).loadFromJsonString(featureGenJson, "")
+    val recoveredStage = new OpPipelineStageReader(Seq.empty).loadFromJsonString(featureGenJson, "", true)
     recoveredStage shouldBe a[FeatureGeneratorStage[_, _]]
     val extractFn = recoveredStage.asInstanceOf[FeatureGeneratorStage[Int, Integral]].extractFn
     extractFn shouldBe a[IntMultiplyExtractor]

--- a/features/src/test/scala/org/apache/spark/ml/SparkStageParamTest.scala
+++ b/features/src/test/scala/org/apache/spark/ml/SparkStageParamTest.scala
@@ -73,12 +73,13 @@ class SparkStageParamTest extends FlatSpec with TestSparkContext with BeforeAndA
     param.sbc = Option(SparkBundleContext().withDataset(dataset))
     val jsonOut = param.jsonEncode(Option(stage))
     val parsed = parse(jsonOut).asInstanceOf[JObject]
-    val updated = parsed ~ ("path" -> savePath) // inject path for decoding
+    val updated = parsed ~ ("path" -> savePath) ~ ("asSpark" -> true) // inject path for decoding
 
     updated shouldBe JObject(
       "className" -> JString(stage.getClass.getName),
       "uid" -> JString(stage.uid),
-      "path" -> JString(savePath)
+      "path" -> JString(savePath),
+      "asSpark" -> JBool(true)
     )
     val updatedJson = compact(updated)
 

--- a/local/src/main/scala/com/salesforce/op/local/MLeapModelConverter.scala
+++ b/local/src/main/scala/com/salesforce/op/local/MLeapModelConverter.scala
@@ -30,7 +30,7 @@
 
 package com.salesforce.op.local
 
-import ml.combust.mleap.core.feature._
+import ml.combust.mleap.runtime.transformer.feature._
 import org.apache.spark.ml.linalg.Vector
 
 /**
@@ -40,52 +40,51 @@ case object MLeapModelConverter {
 
   /**
    * Convert MLeap model instance to a model apply function
-   *
+   * TODO look into using mleap transform function instead of model apply
    * @param model MLeap model
    * @throws RuntimeException if model type is not supported
    * @return runnable model apply function
    */
   def modelToFunction(model: Any): Array[Any] => Any = model match {
-    case m: BinarizerModel => x => m.apply(x(0).asInstanceOf[Number].doubleValue())
-    case m: BucketedRandomProjectionLSHModel => x => m.apply(x(0).asInstanceOf[Vector])
-    case m: BucketizerModel => x => m.apply(x(0).asInstanceOf[Number].doubleValue())
-    case m: ChiSqSelectorModel => x => m.apply(x(0).asInstanceOf[Vector])
-    case m: CoalesceModel => x => m.apply(x: _*)
-    case m: CountVectorizerModel => x => m.apply(x(0).asInstanceOf[Seq[String]])
-    case m: DCTModel => x => m.apply(x(0).asInstanceOf[Vector])
-    case m: ElementwiseProductModel => x => m.apply(x(0).asInstanceOf[Vector])
-    case m: FeatureHasherModel => x => m.apply(x(0).asInstanceOf[Seq[Any]])
-    case m: HashingTermFrequencyModel => x => m.apply(x(0).asInstanceOf[Seq[Any]])
-    case m: IDFModel => x => m.apply(x(0).asInstanceOf[Vector])
-    case m: ImputerModel => x => m.apply(x(0).asInstanceOf[Number].doubleValue())
-    case m: InteractionModel => x => m.apply(x(0).asInstanceOf[Seq[Any]])
-    case m: MathBinaryModel => x =>
-      m.apply(
+    case m: Binarizer => x => m.model.apply(x(0).asInstanceOf[Number].doubleValue())
+    case m: BucketedRandomProjectionLSH => x => m.model.apply(x(0).asInstanceOf[Vector])
+    case m: Bucketizer => x => m.model.apply(x(0).asInstanceOf[Number].doubleValue())
+    case m: ChiSqSelector => x => m.model.apply(x(0).asInstanceOf[Vector])
+    case m: Coalesce => x => m.model.apply(x: _*)
+    case m: CountVectorizer => x => m.model.apply(x(0).asInstanceOf[Seq[String]])
+    case m: DCT => x => m.model.apply(x(0).asInstanceOf[Vector])
+    case m: ElementwiseProduct => x => m.model.apply(x(0).asInstanceOf[Vector])
+    case m: FeatureHasher => x => m.model.apply(x(0).asInstanceOf[Seq[Any]])
+    case m: HashingTermFrequency => x => m.model.apply(x(0).asInstanceOf[Seq[Any]])
+    case m: IDF => x => m.model.apply(x(0).asInstanceOf[Vector])
+    case m: Imputer => x => m.model.apply(x(0).asInstanceOf[Number].doubleValue())
+    case m: Interaction => x => m.model.apply(x(0).asInstanceOf[Seq[Any]])
+    case m: MathBinary => x => m.model.apply(
         x.headOption.map(_.asInstanceOf[Number].doubleValue()),
         x.lastOption.map(_.asInstanceOf[Number].doubleValue())
       )
-    case m: MathUnaryModel => x => m.apply(x(0).asInstanceOf[Number].doubleValue())
-    case m: MaxAbsScalerModel => x => m.apply(x(0).asInstanceOf[Vector])
-    case m: MinHashLSHModel => x => m.apply(x(0).asInstanceOf[Vector])
-    case m: MinMaxScalerModel => x => m.apply(x(0).asInstanceOf[Vector])
-    case m: NGramModel => x => m.apply(x(0).asInstanceOf[Seq[String]])
-    case m: NormalizerModel => x => m.apply(x(0).asInstanceOf[Vector])
-    case m: OneHotEncoderModel => x => m.apply(x(0).asInstanceOf[Vector].toArray)
-    case m: PcaModel => x => m.apply(x(0).asInstanceOf[Vector])
-    case m: PolynomialExpansionModel => x => m.apply(x(0).asInstanceOf[Vector])
-    case m: RegexIndexerModel => x => m.apply(x(0).toString)
-    case m: RegexTokenizerModel => x => m.apply(x(0).toString)
-    case m: ReverseStringIndexerModel => x => m.apply(x(0).asInstanceOf[Number].intValue())
-    case m: StandardScalerModel => x => m.apply(x(0).asInstanceOf[Vector])
-    case m: StopWordsRemoverModel => x => m.apply(x(0).asInstanceOf[Seq[String]])
-    case m: StringIndexerModel => x => m.apply(x(0))
-    case m: StringMapModel => x => m.apply(x(0).toString)
-    case m: TokenizerModel => x => m.apply(x(0).toString)
-    case m: VectorAssemblerModel => x => m.apply(x(0).asInstanceOf[Seq[Any]])
-    case m: VectorIndexerModel => x => m.apply(x(0).asInstanceOf[Vector])
-    case m: VectorSlicerModel => x => m.apply(x(0).asInstanceOf[Vector])
-    case m: WordLengthFilterModel => x => m.apply(x(0).asInstanceOf[Seq[String]])
-    case m: WordToVectorModel => x => m.apply(x(0).asInstanceOf[Seq[String]])
+    case m: MathUnary => x => m.model.apply(x(0).asInstanceOf[Number].doubleValue())
+    case m: MaxAbsScaler => x => m.model.apply(x(0).asInstanceOf[Vector])
+    case m: MinHashLSH => x => m.model.apply(x(0).asInstanceOf[Vector])
+    case m: MinMaxScaler => x => m.model.apply(x(0).asInstanceOf[Vector])
+    case m: NGram => x => m.model.apply(x(0).asInstanceOf[Seq[String]])
+    case m: Normalizer => x => m.model.apply(x(0).asInstanceOf[Vector])
+    case m: OneHotEncoder => x => m.model.apply(x(0).asInstanceOf[Vector].toArray)
+    case m: Pca => x => m.model.apply(x(0).asInstanceOf[Vector])
+    case m: PolynomialExpansion => x => m.model.apply(x(0).asInstanceOf[Vector])
+    case m: RegexIndexer => x => m.model.apply(x(0).toString)
+    case m: RegexTokenizer => x => m.model.apply(x(0).toString)
+    case m: ReverseStringIndexer => x => m.model.apply(x(0).asInstanceOf[Number].intValue())
+    case m: StandardScaler => x => m.model.apply(x(0).asInstanceOf[Vector])
+    case m: StopWordsRemover => x => m.model.apply(x(0).asInstanceOf[Seq[String]])
+    case m: StringIndexer => x => m.model.apply(x(0))
+    case m: StringMap => x => m.model.apply(x(0).toString)
+    case m: Tokenizer => x => m.model.apply(x(0).toString)
+    case m: VectorAssembler => x => m.model.apply(x(0).asInstanceOf[Seq[Any]])
+    case m: VectorIndexer => x => m.model.apply(x(0).asInstanceOf[Vector])
+    case m: VectorSlicer => x => m.model.apply(x(0).asInstanceOf[Vector])
+    case m: WordLengthFilter => x => m.model.apply(x(0).asInstanceOf[Seq[String]])
+    case m: WordToVector => x => m.model.apply(x(0).asInstanceOf[Seq[String]])
     case m => throw new RuntimeException(s"Unsupported MLeap model: ${m.getClass.getName}")
   }
 

--- a/local/src/main/scala/com/salesforce/op/local/MLeapModelConverter.scala
+++ b/local/src/main/scala/com/salesforce/op/local/MLeapModelConverter.scala
@@ -31,6 +31,7 @@
 package com.salesforce.op.local
 
 import ml.combust.mleap.runtime.transformer.feature._
+import ml.combust.mleap.core.feature._
 import org.apache.spark.ml.linalg.Vector
 
 /**
@@ -40,12 +41,12 @@ case object MLeapModelConverter {
 
   /**
    * Convert MLeap model instance to a model apply function
-   * TODO look into using mleap transform function instead of model apply
    * @param model MLeap model
    * @throws RuntimeException if model type is not supported
    * @return runnable model apply function
    */
   def modelToFunction(model: Any): Array[Any] => Any = model match {
+    // model wrapped in transformer // TODO look into applying transform directly
     case m: Binarizer => x => m.model.apply(x(0).asInstanceOf[Number].doubleValue())
     case m: BucketedRandomProjectionLSH => x => m.model.apply(x(0).asInstanceOf[Vector])
     case m: Bucketizer => x => m.model.apply(x(0).asInstanceOf[Number].doubleValue())
@@ -85,6 +86,48 @@ case object MLeapModelConverter {
     case m: VectorSlicer => x => m.model.apply(x(0).asInstanceOf[Vector])
     case m: WordLengthFilter => x => m.model.apply(x(0).asInstanceOf[Seq[String]])
     case m: WordToVector => x => m.model.apply(x(0).asInstanceOf[Seq[String]])
+
+    // just the underlying model
+    case m: BinarizerModel => x => m.apply(x(0).asInstanceOf[Number].doubleValue())
+    case m: BucketedRandomProjectionLSHModel => x => m.apply(x(0).asInstanceOf[Vector])
+    case m: BucketizerModel => x => m.apply(x(0).asInstanceOf[Number].doubleValue())
+    case m: ChiSqSelectorModel => x => m.apply(x(0).asInstanceOf[Vector])
+    case m: CoalesceModel => x => m.apply(x: _*)
+    case m: CountVectorizerModel => x => m.apply(x(0).asInstanceOf[Seq[String]])
+    case m: DCTModel => x => m.apply(x(0).asInstanceOf[Vector])
+    case m: ElementwiseProductModel => x => m.apply(x(0).asInstanceOf[Vector])
+    case m: FeatureHasherModel => x => m.apply(x(0).asInstanceOf[Seq[Any]])
+    case m: HashingTermFrequencyModel => x => m.apply(x(0).asInstanceOf[Seq[Any]])
+    case m: IDFModel => x => m.apply(x(0).asInstanceOf[Vector])
+    case m: ImputerModel => x => m.apply(x(0).asInstanceOf[Number].doubleValue())
+    case m: InteractionModel => x => m.apply(x(0).asInstanceOf[Seq[Any]])
+    case m: MathBinaryModel => x =>
+      m.apply(
+        x.headOption.map(_.asInstanceOf[Number].doubleValue()),
+        x.lastOption.map(_.asInstanceOf[Number].doubleValue())
+      )
+    case m: MathUnaryModel => x => m.apply(x(0).asInstanceOf[Number].doubleValue())
+    case m: MaxAbsScalerModel => x => m.apply(x(0).asInstanceOf[Vector])
+    case m: MinHashLSHModel => x => m.apply(x(0).asInstanceOf[Vector])
+    case m: MinMaxScalerModel => x => m.apply(x(0).asInstanceOf[Vector])
+    case m: NGramModel => x => m.apply(x(0).asInstanceOf[Seq[String]])
+    case m: NormalizerModel => x => m.apply(x(0).asInstanceOf[Vector])
+    case m: OneHotEncoderModel => x => m.apply(x(0).asInstanceOf[Vector].toArray)
+    case m: PcaModel => x => m.apply(x(0).asInstanceOf[Vector])
+    case m: PolynomialExpansionModel => x => m.apply(x(0).asInstanceOf[Vector])
+    case m: RegexIndexerModel => x => m.apply(x(0).toString)
+    case m: RegexTokenizerModel => x => m.apply(x(0).toString)
+    case m: ReverseStringIndexerModel => x => m.apply(x(0).asInstanceOf[Number].intValue())
+    case m: StandardScalerModel => x => m.apply(x(0).asInstanceOf[Vector])
+    case m: StopWordsRemoverModel => x => m.apply(x(0).asInstanceOf[Seq[String]])
+    case m: StringIndexerModel => x => m.apply(x(0))
+    case m: StringMapModel => x => m.apply(x(0).toString)
+    case m: TokenizerModel => x => m.apply(x(0).toString)
+    case m: VectorAssemblerModel => x => m.apply(x(0).asInstanceOf[Seq[Any]])
+    case m: VectorIndexerModel => x => m.apply(x(0).asInstanceOf[Vector])
+    case m: VectorSlicerModel => x => m.apply(x(0).asInstanceOf[Vector])
+    case m: WordLengthFilterModel => x => m.apply(x(0).asInstanceOf[Seq[String]])
+    case m: WordToVectorModel => x => m.apply(x(0).asInstanceOf[Seq[String]])
     case m => throw new RuntimeException(s"Unsupported MLeap model: ${m.getClass.getName}")
   }
 

--- a/local/src/main/scala/com/salesforce/op/local/MLeapModelConverter.scala
+++ b/local/src/main/scala/com/salesforce/op/local/MLeapModelConverter.scala
@@ -46,48 +46,7 @@ case object MLeapModelConverter {
    * @return runnable model apply function
    */
   def modelToFunction(model: Any): Array[Any] => Any = model match {
-    // model wrapped in transformer // TODO look into applying transform directly
-    case m: Binarizer => x => m.model.apply(x(0).asInstanceOf[Number].doubleValue())
-    case m: BucketedRandomProjectionLSH => x => m.model.apply(x(0).asInstanceOf[Vector])
-    case m: Bucketizer => x => m.model.apply(x(0).asInstanceOf[Number].doubleValue())
-    case m: ChiSqSelector => x => m.model.apply(x(0).asInstanceOf[Vector])
-    case m: Coalesce => x => m.model.apply(x: _*)
-    case m: CountVectorizer => x => m.model.apply(x(0).asInstanceOf[Seq[String]])
-    case m: DCT => x => m.model.apply(x(0).asInstanceOf[Vector])
-    case m: ElementwiseProduct => x => m.model.apply(x(0).asInstanceOf[Vector])
-    case m: FeatureHasher => x => m.model.apply(x(0).asInstanceOf[Seq[Any]])
-    case m: HashingTermFrequency => x => m.model.apply(x(0).asInstanceOf[Seq[Any]])
-    case m: IDF => x => m.model.apply(x(0).asInstanceOf[Vector])
-    case m: Imputer => x => m.model.apply(x(0).asInstanceOf[Number].doubleValue())
-    case m: Interaction => x => m.model.apply(x(0).asInstanceOf[Seq[Any]])
-    case m: MathBinary => x => m.model.apply(
-        x.headOption.map(_.asInstanceOf[Number].doubleValue()),
-        x.lastOption.map(_.asInstanceOf[Number].doubleValue())
-      )
-    case m: MathUnary => x => m.model.apply(x(0).asInstanceOf[Number].doubleValue())
-    case m: MaxAbsScaler => x => m.model.apply(x(0).asInstanceOf[Vector])
-    case m: MinHashLSH => x => m.model.apply(x(0).asInstanceOf[Vector])
-    case m: MinMaxScaler => x => m.model.apply(x(0).asInstanceOf[Vector])
-    case m: NGram => x => m.model.apply(x(0).asInstanceOf[Seq[String]])
-    case m: Normalizer => x => m.model.apply(x(0).asInstanceOf[Vector])
-    case m: OneHotEncoder => x => m.model.apply(x(0).asInstanceOf[Vector].toArray)
-    case m: Pca => x => m.model.apply(x(0).asInstanceOf[Vector])
-    case m: PolynomialExpansion => x => m.model.apply(x(0).asInstanceOf[Vector])
-    case m: RegexIndexer => x => m.model.apply(x(0).toString)
-    case m: RegexTokenizer => x => m.model.apply(x(0).toString)
-    case m: ReverseStringIndexer => x => m.model.apply(x(0).asInstanceOf[Number].intValue())
-    case m: StandardScaler => x => m.model.apply(x(0).asInstanceOf[Vector])
-    case m: StopWordsRemover => x => m.model.apply(x(0).asInstanceOf[Seq[String]])
-    case m: StringIndexer => x => m.model.apply(x(0))
-    case m: StringMap => x => m.model.apply(x(0).toString)
-    case m: Tokenizer => x => m.model.apply(x(0).toString)
-    case m: VectorAssembler => x => m.model.apply(x(0).asInstanceOf[Seq[Any]])
-    case m: VectorIndexer => x => m.model.apply(x(0).asInstanceOf[Vector])
-    case m: VectorSlicer => x => m.model.apply(x(0).asInstanceOf[Vector])
-    case m: WordLengthFilter => x => m.model.apply(x(0).asInstanceOf[Seq[String]])
-    case m: WordToVector => x => m.model.apply(x(0).asInstanceOf[Seq[String]])
-
-    // just the underlying model
+    // TODO look into applying transform directly rather than using the model apply
     case m: BinarizerModel => x => m.apply(x(0).asInstanceOf[Number].doubleValue())
     case m: BucketedRandomProjectionLSHModel => x => m.apply(x(0).asInstanceOf[Vector])
     case m: BucketizerModel => x => m.apply(x(0).asInstanceOf[Number].doubleValue())

--- a/local/src/main/scala/com/salesforce/op/local/OpWorkflowModelLocal.scala
+++ b/local/src/main/scala/com/salesforce/op/local/OpWorkflowModelLocal.scala
@@ -31,20 +31,10 @@
 package com.salesforce.op.local
 
 
-import java.nio.file.Paths
-
-import com.github.marschall.memoryfilesystem.MemoryFileSystemBuilder
 import com.salesforce.op.OpWorkflowModel
-import com.salesforce.op.features.FeatureSparkTypes
 import com.salesforce.op.stages.sparkwrappers.generic.SparkWrapperParams
 import com.salesforce.op.stages.{OPStage, OpTransformer}
-import ml.combust.bundle.serializer.SerializationFormat
-import ml.combust.bundle.{BundleContext, BundleRegistry}
-import ml.combust.mleap.runtime.MleapContext
-import org.apache.spark.ml.Transformer
-import org.apache.spark.ml.bundle.SparkBundleContext
-import org.apache.spark.sql.catalyst.encoders.RowEncoder
-import org.apache.spark.sql.{DataFrame, Row, SparkSession}
+import org.apache.spark.sql.SparkSession
 
 import scala.collection.mutable
 
@@ -95,19 +85,21 @@ trait OpWorkflowModelLocal extends Serializable {
       val stagesWithIndex = model.getStages().zipWithIndex
 
       // Prepare an empty DataFrame with transformed schema & metadata (needed for loading MLeap models)
-      val transformedData = makeTransformedDataFrame(model)
+      // val transformedData = makeTransformedDataFrame(model)
 
       // Collect all OP stages
       val opStages = stagesWithIndex.collect { case (s: OpTransformer, i) => OPModel(s.getOutputFeatureName, s) -> i }
 
       // Collect all Spark wrapped stages
-      val sparkStages = stagesWithIndex.filterNot(_._1.isInstanceOf[OpTransformer]).collect {
-        case (opStage: OPStage with SparkWrapperParams[_], i) if opStage.getSparkMlStage().isDefined =>
-          val sparkStage = opStage.getSparkMlStage().get.asInstanceOf[Transformer]
-          (opStage, sparkStage, i)
+      val mleapStages = stagesWithIndex.collect { // TODO - this will likely fail on the predictors
+        case (opStage: OPStage with SparkWrapperParams[_], i) if opStage.getLocalMlStage().isDefined =>
+          val model = opStage.getLocalMlStage().get
+          MLeapModel(
+            inputs = opStage.getTransientFeatures().map(_.name),
+            output = opStage.getOutputFeatureName,
+            modelFn = MLeapModelConverter.modelToFunction(model)
+          ) -> i
       }
-      // Convert Spark wrapped stages into MLeap models
-      val mleapStages = toMLeapModels(sparkStages, transformedData)
 
       // Combine all stages and apply the original order
       val allStages = (opStages ++ mleapStages).sortBy(_._2).map(_._1)
@@ -134,68 +126,6 @@ trait OpWorkflowModelLocal extends Serializable {
         transformedRow.filterKeys(resultFeatures.contains).toMap
       }
     }
-
-    /**
-     * Prepares an empty DataFrame with transformed schema & metadata (needed for loading MLeap models)
-     */
-    private def makeTransformedDataFrame(model: OpWorkflowModel)(implicit spark: SparkSession): DataFrame = {
-      val rawSchema = FeatureSparkTypes.toStructType(model.getRawFeatures(): _*)
-      val df = spark.emptyDataset[Row](RowEncoder(rawSchema))
-      model.getStages().collect { case t: Transformer => t }.foldLeft(df) { case (d, t) => t.transform(d) }
-    }
-
-    /**
-     * Convert Spark wrapped stages into MLeap local Models
-     *
-     * @param sparkStages     stages to convert
-     * @param transformedData dataset with transformed schema & metadata (needed for loading MLeap models)
-     * @return MLeap local stages
-     */
-    private def toMLeapModels
-    (
-      sparkStages: Seq[(OPStage, Transformer, Int)],
-      transformedData: DataFrame
-    ): Seq[(MLeapModel, Int)] = {
-      // Setup a in-memory file system for MLeap model saving/loading
-      val emptyPath = Paths.get("")
-      val fs = MemoryFileSystemBuilder.newEmpty().build()
-
-      // Setup two MLeap registries - one local and one for Spark
-      val mleapRegistry = BundleRegistry("ml.combust.mleap.registry.default")
-      val sparkRegistry = BundleRegistry("ml.combust.mleap.spark.registry.default")
-
-      val sparkBundleContext = BundleContext[SparkBundleContext](
-        SparkBundleContext(Option(transformedData), sparkRegistry),
-        SerializationFormat.Json, sparkRegistry, fs, emptyPath
-      )
-      val mleapBundleContext = BundleContext[MleapContext](
-        MleapContext(mleapRegistry), SerializationFormat.Json, mleapRegistry, fs, emptyPath)
-
-      for {
-        (opStage, sparkStage, i) <- sparkStages
-      } yield try {
-        val model = {
-          // Serialize Spark model using Spark registry
-          val opModel = sparkRegistry.opForObj[SparkBundleContext, AnyRef, AnyRef](sparkStage)
-          val emptyModel = new ml.combust.bundle.dsl.Model(op = opModel.Model.opName)
-          val serializedModel = opModel.Model.store(emptyModel, sparkStage)(sparkBundleContext)
-
-          // Load MLeap model using MLeap local registry from the serialized model
-          val mleapLocalModel = mleapRegistry.model[MleapContext, AnyRef](op = serializedModel.op)
-          mleapLocalModel.load(serializedModel)(mleapBundleContext)
-        }
-        // Prepare and return MLeap model with inputs, output and model function
-        MLeapModel(
-          inputs = opStage.getTransientFeatures().map(_.name),
-          output = opStage.getOutputFeatureName,
-          modelFn = MLeapModelConverter.modelToFunction(model)
-        ) -> i
-      } catch {
-        case e: Exception =>
-          throw new RuntimeException(s"Failed to convert stage '${opStage.uid}' to MLeap stage", e)
-      }
-    }
-
 
   }
 

--- a/local/src/main/scala/com/salesforce/op/local/OpWorkflowModelLocal.scala
+++ b/local/src/main/scala/com/salesforce/op/local/OpWorkflowModelLocal.scala
@@ -91,7 +91,7 @@ trait OpWorkflowModelLocal extends Serializable {
           MLeapModel(
             inputs = opStage.getTransientFeatures().map(_.name),
             output = opStage.getOutputFeatureName,
-            modelFn = MLeapModelConverter.modelToFunction(model)
+            modelFn = MLeapModelConverter.modelToFunction(model.model)
           ) -> i
       }
 

--- a/local/src/main/scala/com/salesforce/op/local/OpWorkflowModelLocal.scala
+++ b/local/src/main/scala/com/salesforce/op/local/OpWorkflowModelLocal.scala
@@ -34,7 +34,6 @@ package com.salesforce.op.local
 import com.salesforce.op.OpWorkflowModel
 import com.salesforce.op.stages.sparkwrappers.generic.SparkWrapperParams
 import com.salesforce.op.stages.{OPStage, OpTransformer}
-import org.apache.spark.sql.SparkSession
 
 import scala.collection.mutable
 
@@ -106,7 +105,6 @@ trait OpWorkflowModelLocal extends Serializable {
         val transformedRow = allStages.foldLeft(inputMap) {
           // For OP Models we simply call transform
           case (row, OPModel(output, stage)) =>
-            println(row)
             row += output -> stage.transformKeyValue(row.apply)
 
           // For MLeap models we call the prepared local model

--- a/local/src/test/scala/com/salesforce/op/local/MLeapModelConverterTest.scala
+++ b/local/src/test/scala/com/salesforce/op/local/MLeapModelConverterTest.scala
@@ -33,6 +33,7 @@ package com.salesforce.op.local
 import com.salesforce.op.test.TestCommon
 import ml.combust.mleap.core.feature._
 import ml.combust.mleap.core.types.ScalarShape
+import ml.combust.mleap.runtime.transformer.feature._
 import org.apache.spark.ml.linalg.{DenseMatrix, Vectors}
 import org.junit.runner.RunWith
 import org.scalatest.PropSpec
@@ -42,7 +43,7 @@ import org.scalatest.prop.PropertyChecks
 @RunWith(classOf[JUnitRunner])
 class MLeapModelConverterTest extends PropSpec with PropertyChecks with TestCommon {
 
-  val mleapModels = Table("mleapModels",
+  val mleapModels = Table("mleapModels", // TODO wrap these in mleap transformers
     BinarizerModel(0.0, ScalarShape()),
     BucketedRandomProjectionLSHModel(Seq(), 0.0, 0),
     BucketizerModel(Array.empty),

--- a/local/src/test/scala/com/salesforce/op/local/OpWorkflowModelLocalTest.scala
+++ b/local/src/test/scala/com/salesforce/op/local/OpWorkflowModelLocalTest.scala
@@ -159,7 +159,7 @@ class OpWorkflowModelLocalTest extends FlatSpec with TestSparkContext with TempD
     model.save(modelLocation2)
 
     // Load and score the model
-    val scoreFn = OpWorkflowModel.load(modelLocation2).scoreFunction
+    val scoreFn = OpWorkflowModel.load(modelLocation2, asSpark = false).scoreFunction
     scoreFn shouldBe a[ScoreFunction]
     val rawData = ds.withColumn(KeyFieldName, col(id)).sort(KeyFieldName).collect().map(_.toMap)
     val scores = rawData.map(scoreFn)
@@ -194,7 +194,7 @@ class OpWorkflowModelLocalTest extends FlatSpec with TestSparkContext with TempD
     expectedScores: Array[(Prediction, RealNN, RealNN, Text)],
     prediction: FeatureLike[Prediction]
   ): Unit = {
-    val scoreFn = OpWorkflowModel.load(modelLocation).scoreFunction
+    val scoreFn = OpWorkflowModel.load(modelLocation, asSpark = false).scoreFunction
     scoreFn shouldBe a[ScoreFunction]
     val scores = rawData.map(scoreFn)
     assert(scores, expectedScores, prediction)

--- a/local/src/test/scala/com/salesforce/op/local/OpWorkflowModelLocalTest.scala
+++ b/local/src/test/scala/com/salesforce/op/local/OpWorkflowModelLocalTest.scala
@@ -53,7 +53,7 @@ import org.junit.runner.RunWith
 import org.scalatest.FlatSpec
 import org.scalatest.junit.JUnitRunner
 import org.slf4j.LoggerFactory
-
+import org.scalactic.Equality
 
 @RunWith(classOf[JUnitRunner])
 class OpWorkflowModelLocalTest extends FlatSpec with TestSparkContext with TempDirectoryTest with TestCommon {
@@ -96,8 +96,8 @@ class OpWorkflowModelLocalTest extends FlatSpec with TestSparkContext with TempD
         .build()
   }
 
-  lazy val (modelLocation, model, prediction) = buildAndSaveModel(logReg)
-  lazy val (xgbModelLocation, xgbModel, xgbPred) = buildAndSaveModel(xgb)
+  lazy val (modelLocation, model, prediction) = buildAndSaveModel(logReg, "logreg")
+  lazy val (xgbModelLocation, xgbModel, xgbPred) = buildAndSaveModel(xgb, "xgboost")
   lazy val (rawData, expectedScores) = genRawDataAndScore(model, prediction)
   lazy val (rawDataXGB, expectedXGBScores) = genRawDataAndScore(xgbModel, xgbPred)
   lazy val modelLocation2 = {
@@ -113,9 +113,7 @@ class OpWorkflowModelLocalTest extends FlatSpec with TestSparkContext with TempD
   }
 
   it should "produce scores without Spark in timely fashion" in {
-    val loadedModel = OpWorkflowModel.load(modelLocation, asSpark = false)
-    val scoreFn = loadedModel.scoreFunction
-    scoreFn shouldBe a[ScoreFunction]
+    val scoreFn = assertLoadModelAndScore(modelLocation, rawData, expectedScores, prediction)
     val numOfRuns = 1000
     var elapsed = 0L
     for {_ <- 0 until numOfRuns} {
@@ -184,7 +182,11 @@ class OpWorkflowModelLocalTest extends FlatSpec with TestSparkContext with TempD
         deindexed.name -> deindexedV.value.orNull
       )
     } withClue(s"Record index $i: ") {
-      score shouldBe expected
+      val scoresFound = score(prediction.name).asInstanceOf[Map[String, Double]]
+      val scoresExp = expected(prediction.name).asInstanceOf[Map[String, Double]]
+      val keys = scoresExp.keySet.union(scoresFound.keySet)
+      keys.foreach( k => math.abs(scoresFound(k) - scoresExp(k)) < 0.001 shouldBe true )
+      score.filterNot(_._1 == prediction.name) shouldEqual expected.filterNot(_._1 == prediction.name)
     }
   }
 
@@ -193,23 +195,23 @@ class OpWorkflowModelLocalTest extends FlatSpec with TestSparkContext with TempD
     rawData: Array[Map[String, Any]],
     expectedScores: Array[(Prediction, RealNN, RealNN, Text)],
     prediction: FeatureLike[Prediction]
-  ): Unit = {
+  ): ScoreFunction = {
     val loadedModel = OpWorkflowModel.load(modelLocation, asSpark = false)
     val scoreFn = loadedModel.scoreFunction
     scoreFn shouldBe a[ScoreFunction]
     val scores = rawData.map(scoreFn)
     assert(scores, expectedScores, prediction)
+    scoreFn
   }
 
-  private def buildAndSaveModel(modelsAndParams: Seq[(EstimatorType, Array[ParamMap])]):
+  private def buildAndSaveModel(modelsAndParams: Seq[(EstimatorType, Array[ParamMap])], pathName: String):
   (String, OpWorkflowModel, FeatureLike[Prediction]) = {
     val prediction = BinaryClassificationModelSelector.withTrainValidationSplit(
       modelsAndParameters = modelsAndParams
     ).setInput(labelSynth, genFeatureVector).getOutput()
     val workflow = new OpWorkflow().setInputDataset(rawDF).setResultFeatures(prediction, labelSynth, indexed, deindexed)
     lazy val model = workflow.train()
-    rawDF.show(10)
-    val path = Paths.get(tempDir.toString, "op-runner-local-test-model").toFile.getCanonicalFile.toString
+    val path = Paths.get(tempDir.toString, s"op-runner-local-test-model-$pathName").toFile.getCanonicalFile.toString
     model.save(path)
     (path, model, prediction)
   }


### PR DESCRIPTION
Changes model loading to not require spark context and allows for local loading of spark wrapped stages into MLleap transformers rather than spark stages that are then converted to mleap for local scoring.

The final pr will fix the spark predictor wrapped stages to work with mleap loaded models.