### PR TITLE
Changing blocklist policy for Sequence stages

### DIFF
--- a/core/src/main/scala/com/salesforce/op/OpWorkflow.scala
+++ b/core/src/main/scala/com/salesforce/op/OpWorkflow.scala
@@ -152,7 +152,7 @@ class OpWorkflow(val uid: String = UID[OpWorkflow]) extends OpWorkflowCore {
         val oldOutput = stg.getOutput()
         Try(stg match {
           // For Sequence stages, we still want to keep them and remove the blocklisted inputs
-          case s @ (_ : SequenceEstimator[_, _] | _ : SequenceTransformer[_, _]) if !inputsChanged.isEmpty => {
+          case s @ (_ : SequenceEstimator[_, _] | _ : SequenceTransformer[_, _]) if inputsChanged.nonEmpty => {
             s.set(s.inputFeatures, inputsChanged.map(TransientFeature(_))).setOutputFeatureName(oldOutput.name)
             // Resetting Metadata
             s.setMetadata(new MetadataBuilder().build())

--- a/core/src/main/scala/com/salesforce/op/OpWorkflow.scala
+++ b/core/src/main/scala/com/salesforce/op/OpWorkflow.scala
@@ -151,13 +151,8 @@ class OpWorkflow(val uid: String = UID[OpWorkflow]) extends OpWorkflowCore {
         val inputsChanged = blocklistRemoved.map{ f => allUpdated.find(u => u.sameOrigin(f)).getOrElse(f) }
         val oldOutput = stg.getOutput()
         Try(stg match {
-          case s: SequenceEstimator[_, _] if (inputsChanged.size > 0) => {
-            s.set(s.inputFeatures, inputsChanged.map(TransientFeature(_))).setOutputFeatureName(oldOutput.name)
-            // Resetting Metadata
-            s.setMetadata(new MetadataBuilder().build())
-            s.getOutput()
-          }
-          case s: SequenceTransformer[_, _] if (inputsChanged.size > 0) => {
+          // For Sequence stages, we still want to keep them and remove the blocklisted inputs
+          case s @ (_ : SequenceEstimator[_, _] | _ : SequenceTransformer[_, _]) if !inputsChanged.isEmpty => {
             s.set(s.inputFeatures, inputsChanged.map(TransientFeature(_))).setOutputFeatureName(oldOutput.name)
             // Resetting Metadata
             s.setMetadata(new MetadataBuilder().build())


### PR DESCRIPTION
**Related issues**
Example : If a SequenceEstimator/Transformer with input features `Seq(f1, f2, f3)` has a `f1` as a blocklist, then, because `Seq(f2, f3)` and `Seq(f1, f2, f3)` don't have the same size, the SequenceEstimator/Transformer will be removed when updating the DAG. 
However those sequence stages should ignore if one or more original inputs are missing.  

**Describe the proposed solution**
When updating the DAG, sequence stages with updated inputs with length different than 0 will be kept.

**Describe alternatives you've considered**
A clear and concise description of any alternative solutions or features you've considered.

**Additional context**
This problem was addressed when we witnessed a result feature being part of the blocklist after updating the DAG. We acknowledge the possibility to change the policy in RawFeatureFilter.