### PR TITLE
Fix writing of model in the local file system

### DIFF
--- a/core/src/test/scala/com/salesforce/op/OpWorkflowRunnerTest.scala
+++ b/core/src/test/scala/com/salesforce/op/OpWorkflowRunnerTest.scala
@@ -232,7 +232,13 @@ class OpWorkflowRunnerTest extends AsyncFlatSpec with PassengerSparkFixtureTest 
       dirFile.isDirectory shouldBe true
       // TODO: maybe do a thorough files inspection here
       val files = FileUtils.listFiles(dirFile, null, true)
-      files.asScala.map(_.toString).exists(_.contains("_SUCCESS")) shouldBe true
+      val fileNames = files.asScala.map(_.getName)
+      if (outFile.getAbsolutePath.endsWith("/model")) {
+        fileNames should contain ("op-model.json")
+      }
+      else {
+        fileNames should contain ("_SUCCESS")
+      }
       files.size > 1
     }
     res shouldBe a[R]


### PR DESCRIPTION
**Related issues**
The model loading in a cluster was failing with error - *op-model.json/part-00000 did not exist.*

**Additional context**
In #516 we made the changes to save model locally and convert to zip before moving to remote path. So the path passed to 
the below method `saveImpl` is of a local file system, hence when we are trying to save it as a HadoopFile, *op-model.json/part-00000* is not being written out.
```
override protected def saveImpl(path: String): Unit = {
    JobGroupUtil.withJobGroup(OpStep.ModelIO) {
      sc.parallelize(Seq(toJsonString(path)), 1)
        .saveAsTextFile(OpWorkflowModelReadWriteShared.jsonPath(path), classOf[GzipCodec])
    }(this.sparkSession)
  }
```
