### PR TITLE
[WIP] use codecov orb instead of bash uploader

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,9 @@ machine-config: &machine-config
     TERM: dumb
     GRADLE_OPTS: -Xmx256m
 
+orbs:
+  codecov: codecov/codecov@4.6.0
+
 shared-steps:
   open-jdk: &open-jdk
     run:
@@ -84,9 +87,8 @@ jobs:
           path: ~/junit.xml/
       - store_artifacts:
           path: ~/junit/
-      - run:
-          name: Report scoverage resuts to Codecov
-          command: bash <(curl -s https://codecov.io/bash)
+      - codecov/upload:
+          upload_name: Report scoverage resuts to Codecov
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ machine-config: &machine-config
     GRADLE_OPTS: -Xmx256m
 
 orbs:
-  codecov: codecov/codecov@4.6.0
+  codecov: codecov/codecov@1.1.4
 
 shared-steps:
   open-jdk: &open-jdk


### PR DESCRIPTION
**Related issues**
Refer to issue(s) addressed in this pull request from [Issues](https://github.com/salesforce/TransmogrifAI/issues) page.

As the result of the recent CodeCov [security breach](https://about.codecov.io/security-update/), it would be preferred to use a fixed version rather than automatically upgrade to another potentially insecure version.

**Describe the proposed solution**
A clear and concise description of what the changes are.

Use CodeCov orb and specify version instead of bash uploader

**Describe alternatives you've considered**
A clear and concise description of any alternative solutions or features you've considered.

**Additional context**
Add any other context about the changes here.
